### PR TITLE
fix_test_performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,13 @@
 *.exe
 *.out
 *.app
+
+src/CMakeFiles
+src/cmake_install.cmake
+src/CMakeCache.txt
+src/Makefile
+
+test/module/CMakeFiles
+test/module/cmake_install.cmake
+test/module/CMakeCache.txt
+test/module/Makefile


### PR DESCRIPTION
fix LLAPI test performance by creating a matrix before inserting
edits .gitignore file to ignore cmake autogenerated file