### PR TITLE
Fix HNSW deletion tie bug

### DIFF
--- a/src/VecSim/algorithms/brute_force/vector_block.h
+++ b/src/VecSim/algorithms/brute_force/vector_block.h
@@ -16,7 +16,7 @@ struct VectorBlock;
 struct CompareByFirst {
     constexpr bool operator()(std::pair<float, labelType> const &a,
                               std::pair<float, labelType> const &b) const noexcept {
-        return a.first < b.first;
+        return (a.first != b.first) ? a.first < b.first : a.second < b.second;
     }
 };
 

--- a/src/VecSim/algorithms/brute_force/vector_block.h
+++ b/src/VecSim/algorithms/brute_force/vector_block.h
@@ -4,6 +4,7 @@
 #include "VecSim/utils/vecsim_stl.h"
 
 #include "VecSim/spaces/space_interface.h"
+#include "VecSim/utils/vec_utils.h"
 
 typedef size_t labelType;
 typedef size_t idType;
@@ -12,17 +13,9 @@ typedef size_t idType;
 
 struct VectorBlock;
 
-// TODO: unify this with HNSW
-struct CompareByFirst {
-    constexpr bool operator()(std::pair<float, labelType> const &a,
-                              std::pair<float, labelType> const &b) const noexcept {
-        return (a.first != b.first) ? a.first < b.first : a.second < b.second;
-    }
-};
-
-using CandidatesHeap =
-    vecsim_stl::priority_queue<std::pair<float, labelType>,
-                               vecsim_stl::vector<std::pair<float, labelType>>, CompareByFirst>;
+using CandidatesHeap = vecsim_stl::priority_queue<std::pair<float, labelType>,
+                                                  vecsim_stl::vector<std::pair<float, labelType>>,
+                                                  CompareByFirst<float>>;
 
 struct VectorBlockMember : public VecsimBaseObject {
 public:

--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -7,6 +7,7 @@
 #include "VecSim/utils/arr_cpp.h"
 #include "VecSim/memory/vecsim_malloc.h"
 #include "VecSim/utils/vecsim_stl.h"
+#include "VecSim/utils/vec_utils.h"
 
 #include <deque>
 #include <memory>
@@ -26,14 +27,6 @@ using namespace std;
 typedef size_t labeltype;
 typedef unsigned int tableint;
 typedef unsigned int linklistsizeint;
-
-template <typename dist_t>
-struct CompareByFirst {
-    constexpr bool operator()(pair<dist_t, tableint> const &a,
-                              pair<dist_t, tableint> const &b) const noexcept {
-        return (a.first != b.first) ? a.first < b.first : a.second < b.second;
-    }
-};
 
 template <typename dist_t>
 using CandidatesQueue =

--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -31,7 +31,7 @@ template <typename dist_t>
 struct CompareByFirst {
     constexpr bool operator()(pair<dist_t, tableint> const &a,
                               pair<dist_t, tableint> const &b) const noexcept {
-        return a.first < b.first;
+        return (a.first != b.first) ? a.first < b.first : a.second < b.second;
     }
 };
 
@@ -362,7 +362,7 @@ CandidatesQueue<dist_t> HierarchicalNSW<dist_t>::searchLayer(tableint ep_id, con
             char *currObj1 = (getDataByInternalId(candidate_id));
 
             dist_t dist1 = fstdistfunc_(data_point, currObj1, dist_func_param_);
-            if (top_candidates.size() < ef_construction_ || lowerBound > dist1) {
+            if (top_candidates.size() < ef || lowerBound > dist1) {
                 candidate_set.emplace(-dist1, candidate_id);
 #ifdef USE_SSE
                 _mm_prefetch(getDataByInternalId(candidate_set.top().second), _MM_HINT_T0);

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -2,6 +2,15 @@
 
 #include <stdlib.h>
 #include <VecSim/query_results.h>
+#include <utility>
+
+template <typename dist_t>
+struct CompareByFirst {
+    constexpr bool operator()(std::pair<dist_t, uint> const &a,
+                              std::pair<dist_t, uint> const &b) const noexcept {
+        return (a.first != b.first) ? a.first < b.first : a.second < b.second;
+    }
+};
 
 void float_vector_normalize(float *x, size_t dim);
 

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -573,13 +573,13 @@ TEST_F(HNSWLibTest, hnsw_override) {
     size_t ef = 300;
 
     VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
-            .hnswParams = {.type = VecSimType_FLOAT32,
-                    .dim = dim,
-                    .metric = VecSimMetric_L2,
-                    .initialCapacity = n,
-                    .M = M,
-                    .efConstruction = 20,
-                    .efRuntime = ef}};
+                           .hnswParams = {.type = VecSimType_FLOAT32,
+                                          .dim = dim,
+                                          .metric = VecSimMetric_L2,
+                                          .initialCapacity = n,
+                                          .M = M,
+                                          .efConstruction = 20,
+                                          .efRuntime = ef}};
 
     VecSimIndex *index = VecSimIndex_New(&params);
     ASSERT_TRUE(index != nullptr);
@@ -607,8 +607,8 @@ TEST_F(HNSWLibTest, hnsw_override) {
         query[j] = (float)n;
     }
     // This is testing a bug fix - before we had the seconder sorting by id in CompareByFirst,
-    // the graph got disconnected due to the deletion of some node followed by a bad repairing of one
-    // of its neighbours. Here, we ensure that we get all the nodes in the graph as results.
+    // the graph got disconnected due to the deletion of some node followed by a bad repairing of
+    // one of its neighbours. Here, we ensure that we get all the nodes in the graph as results.
     auto verify_res = [&](int id, float score, size_t index) { ASSERT_TRUE(id == n - 1 - index); };
     runTopKSearchTest(index, query, 300, verify_res);
 


### PR DESCRIPTION
Deletion of a node in HNSW index is followed by a procedure of repairing edges for other nodes that were pointing to the deleted node. In this procedure, we select neighbours to the repaired node by the heuristics, and compare these to the original set of its neighbours. We assume that these 2 "nodes queues" are sorted in a unified way - by their distance to the repaired node. However, when there is tie, the order of the nodes is undefined, and may result inconsistency when going over the two queues. In some case, we miss a node that is selected to be linked to the repaired node because of that, and it leads to the disconnection of the entire graph. 

In this PR we add a seconder sorting by the id, so that the order of the nodes in the 2 queues is well defined. This also fixes an incorrect check in `knn` function of HNSW where we use `ef_construction` instead of `ef_runtime`. 