### PR TITLE
Resolve raw params

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -2,7 +2,6 @@
 #include "brute_force.h"
 #include "VecSim/spaces/L2_space.h"
 #include "VecSim/spaces/IP_space.h"
-#include "VecSim/utils/arr_cpp.h"
 #include "VecSim/utils/vec_utils.h"
 #include "VecSim/query_result_struct.h"
 #include "VecSim/algorithms/brute_force/bf_batch_iterator.h"
@@ -154,9 +153,15 @@ int BruteForceIndex::deleteVector(size_t label) {
 
 size_t BruteForceIndex::indexSize() const { return this->count; }
 
-int BruteForceIndex::resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) {
+VecSimResolveCode BruteForceIndex::resolveParams(VecSimRawParam *rparams, int paramNum, VecSimQueryParams *qparams) {
+    if (!qparams) {
+        return VecSimErr_MissingParamStruct;
+    }
     bzero(qparams, sizeof(VecSimQueryParams));
-    return (array_len(rparams) == 0);
+    if (paramNum != 0) {
+        return VecSimErr_UnknownParam;
+    }
+    return VecSimErr_OK;
 }
 
 VecSimQueryResult_List BruteForceIndex::topKQuery(const void *queryBlob, size_t k,

--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -154,6 +154,11 @@ int BruteForceIndex::deleteVector(size_t label) {
 
 size_t BruteForceIndex::indexSize() const { return this->count; }
 
+int BruteForceIndex::resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) {
+    bzero(qparams, sizeof(VecSimQueryParams));
+    return (array_len(rparams) == 0);
+}
+
 VecSimQueryResult_List BruteForceIndex::topKQuery(const void *queryBlob, size_t k,
                                                   VecSimQueryParams *queryParams) {
 

--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -153,7 +153,8 @@ int BruteForceIndex::deleteVector(size_t label) {
 
 size_t BruteForceIndex::indexSize() const { return this->count; }
 
-VecSimResolveCode BruteForceIndex::resolveParams(VecSimRawParam *rparams, int paramNum, VecSimQueryParams *qparams) {
+VecSimResolveCode BruteForceIndex::resolveParams(VecSimRawParam *rparams, int paramNum,
+                                                 VecSimQueryParams *qparams) {
     if (!qparams) {
         return VecSimErr_MissingParamStruct;
     }

--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -155,8 +155,8 @@ size_t BruteForceIndex::indexSize() const { return this->count; }
 
 VecSimResolveCode BruteForceIndex::resolveParams(VecSimRawParam *rparams, int paramNum,
                                                  VecSimQueryParams *qparams) {
-    if (!qparams) {
-        return VecSimParamResolverErr_MissingParamStruct;
+    if (!qparams || (!rparams && (paramNum != 0))) {
+        return VecSimParamResolverErr_NullParam;
     }
     bzero(qparams, sizeof(VecSimQueryParams));
     if (paramNum != 0) {

--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -156,13 +156,13 @@ size_t BruteForceIndex::indexSize() const { return this->count; }
 VecSimResolveCode BruteForceIndex::resolveParams(VecSimRawParam *rparams, int paramNum,
                                                  VecSimQueryParams *qparams) {
     if (!qparams) {
-        return VecSimErr_MissingParamStruct;
+        return VecSimParamResolverErr_MissingParamStruct;
     }
     bzero(qparams, sizeof(VecSimQueryParams));
     if (paramNum != 0) {
-        return VecSimErr_UnknownParam;
+        return VecSimParamResolverErr_UnknownParam;
     }
-    return VecSimErr_OK;
+    return (VecSimResolveCode)VecSim_OK;
 }
 
 VecSimQueryResult_List BruteForceIndex::topKQuery(const void *queryBlob, size_t k,

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -18,6 +18,7 @@ public:
     virtual int addVector(const void *vector_data, size_t label) override;
     virtual int deleteVector(size_t id) override;
     virtual size_t indexSize() const override;
+    virtual int resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) override;
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
     virtual VecSimIndexInfo info() override;

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -18,7 +18,8 @@ public:
     virtual int addVector(const void *vector_data, size_t label) override;
     virtual int deleteVector(size_t id) override;
     virtual size_t indexSize() const override;
-    virtual VecSimResolveCode resolveParams(VecSimRawParam *rparams, int paramNum, VecSimQueryParams *qparams) override;
+    virtual VecSimResolveCode resolveParams(VecSimRawParam *rparams, int paramNum,
+                                            VecSimQueryParams *qparams) override;
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
     virtual VecSimIndexInfo info() override;

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -18,7 +18,7 @@ public:
     virtual int addVector(const void *vector_data, size_t label) override;
     virtual int deleteVector(size_t id) override;
     virtual size_t indexSize() const override;
-    virtual int resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) override;
+    virtual VecSimResolveCode resolveParams(VecSimRawParam *rparams, int paramNum, VecSimQueryParams *qparams) override;
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
     virtual VecSimIndexInfo info() override;

--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -3,7 +3,7 @@
 #include "visited_nodes_handler.h"
 #include "VecSim/spaces/L2_space.h"
 #include "VecSim/spaces/IP_space.h"
-#include "VecSim//spaces/space_interface.h"
+#include "VecSim/spaces/space_interface.h"
 #include "VecSim/utils/arr_cpp.h"
 #include "VecSim/memory/vecsim_malloc.h"
 #include "VecSim/utils/vecsim_stl.h"

--- a/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
+++ b/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
@@ -53,14 +53,16 @@ int HNSWIndex::deleteVector(size_t id) { return this->hnsw->removePoint(id); }
 int HNSWIndex::resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) {
     bzero(qparams, sizeof(VecSimQueryParams));
     for (int i = 0; i < array_len(rparams); i++) {
-        if (!strncasecmp(rparams[i].name, VecSimCommonStrings::HNSW_EF_RUNTIME_STRING, rparams[i].nameLen)) {
+        if (!strncasecmp(rparams[i].name, VecSimCommonStrings::HNSW_EF_RUNTIME_STRING,
+                         rparams[i].nameLen)) {
             if (qparams->hnswRuntimeParams.efRuntime != 0) { // Already been set.
                 return false;
             } else {
                 char *ep;
                 errno = 0;
                 long long val = strtoll(rparams[i].value, &ep, 0);
-                if (val <= 0 || val == LLONG_MAX || errno != 0 || (rparams[i].value + rparams[i].valLen) != ep) {
+                if (val <= 0 || val == LLONG_MAX || errno != 0 ||
+                    (rparams[i].value + rparams[i].valLen) != ep) {
                     return false;
                 }
                 qparams->hnswRuntimeParams.efRuntime = (size_t)val;

--- a/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
+++ b/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
@@ -52,29 +52,29 @@ int HNSWIndex::deleteVector(size_t id) { return this->hnsw->removePoint(id); }
 VecSimResolveCode HNSWIndex::resolveParams(VecSimRawParam *rparams, int paramNum,
                                            VecSimQueryParams *qparams) {
     if (!qparams) {
-        return VecSimErr_MissingParamStruct;
+        return VecSimParamResolverErr_MissingParamStruct;
     }
     bzero(qparams, sizeof(VecSimQueryParams));
     for (int i = 0; i < paramNum; i++) {
         if (!strncasecmp(rparams[i].name, VecSimCommonStrings::HNSW_EF_RUNTIME_STRING,
                          rparams[i].nameLen)) {
             if (qparams->hnswRuntimeParams.efRuntime != 0) {
-                return VecSimErr_AlreadySet;
+                return VecSimParamResolverErr_AlreadySet;
             } else {
                 char *ep; // for checking strtoll used all rparams[i].valLen chars.
                 errno = 0;
                 long long val = strtoll(rparams[i].value, &ep, 0);
                 if (val <= 0 || val == LLONG_MAX || errno != 0 ||
                     (rparams[i].value + rparams[i].valLen) != ep) {
-                    return VecSimErr_BadValue;
+                    return VecSimParamResolverErr_BadValue;
                 }
                 qparams->hnswRuntimeParams.efRuntime = (size_t)val;
             }
         } else {
-            return VecSimErr_UnknownParam;
+            return VecSimParamResolverErr_UnknownParam;
         }
     }
-    return VecSimErr_OK;
+    return (VecSimResolveCode)VecSim_OK;
 }
 
 size_t HNSWIndex::indexSize() const { return this->hnsw->getIndexSize(); }

--- a/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
+++ b/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
@@ -49,7 +49,8 @@ int HNSWIndex::addVector(const void *vector_data, size_t id) {
 
 int HNSWIndex::deleteVector(size_t id) { return this->hnsw->removePoint(id); }
 
-VecSimResolveCode HNSWIndex::resolveParams(VecSimRawParam *rparams, int paramNum, VecSimQueryParams *qparams) {
+VecSimResolveCode HNSWIndex::resolveParams(VecSimRawParam *rparams, int paramNum,
+                                           VecSimQueryParams *qparams) {
     if (!qparams) {
         return VecSimErr_MissingParamStruct;
     }

--- a/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
+++ b/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
@@ -50,6 +50,28 @@ int HNSWIndex::addVector(const void *vector_data, size_t id) {
 
 int HNSWIndex::deleteVector(size_t id) { return this->hnsw->removePoint(id); }
 
+int HNSWIndex::resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) {
+    bzero(qparams, sizeof(VecSimQueryParams));
+    for (int i = 0; i < array_len(rparams); i++) {
+        if (!strncasecmp(rparams[i].name, VecSimCommonStrings::HNSW_EF_RUNTIME_STRING, rparams[i].nameLen)) {
+            if (qparams->hnswRuntimeParams.efRuntime != 0) { // Already been set.
+                return false;
+            } else {
+                char *ep;
+                errno = 0;
+                long long val = strtoll(rparams[i].value, &ep, 0);
+                if (val <= 0 || val == LLONG_MAX || errno != 0 || (rparams[i].value + rparams[i].valLen) != ep) {
+                    return false;
+                }
+                qparams->hnswRuntimeParams.efRuntime = (size_t)val;
+            }
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
 size_t HNSWIndex::indexSize() const { return this->hnsw->getIndexSize(); }
 
 void HNSWIndex::setEf(size_t ef) { this->hnsw->setEf(ef); }

--- a/src/VecSim/algorithms/hnsw/hnswlib_c.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib_c.h
@@ -15,7 +15,8 @@ public:
     virtual int addVector(const void *vector_data, size_t label) override;
     virtual int deleteVector(size_t id) override;
     virtual size_t indexSize() const override;
-    virtual VecSimResolveCode resolveParams(VecSimRawParam *rparams, int paramNum, VecSimQueryParams *qparams) override;
+    virtual VecSimResolveCode resolveParams(VecSimRawParam *rparams, int paramNum,
+                                            VecSimQueryParams *qparams) override;
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
     virtual VecSimIndexInfo info() override;

--- a/src/VecSim/algorithms/hnsw/hnswlib_c.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib_c.h
@@ -15,7 +15,7 @@ public:
     virtual int addVector(const void *vector_data, size_t label) override;
     virtual int deleteVector(size_t id) override;
     virtual size_t indexSize() const override;
-    virtual int resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) override;
+    virtual VecSimResolveCode resolveParams(VecSimRawParam *rparams, int paramNum, VecSimQueryParams *qparams) override;
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
     virtual VecSimIndexInfo info() override;

--- a/src/VecSim/algorithms/hnsw/hnswlib_c.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib_c.h
@@ -15,6 +15,7 @@ public:
     virtual int addVector(const void *vector_data, size_t label) override;
     virtual int deleteVector(size_t id) override;
     virtual size_t indexSize() const override;
+    virtual int resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) override;
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
     virtual VecSimIndexInfo info() override;

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -45,7 +45,7 @@ extern "C" int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id) {
 extern "C" size_t VecSimIndex_IndexSize(VecSimIndex *index) { return index->indexSize(); }
 
 extern "C" VecSimResolveCode VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams,
-                                         int paramNum, VecSimQueryParams *qparams) {
+                                                       int paramNum, VecSimQueryParams *qparams) {
     return index->resolveParams(rparams, paramNum, qparams);
 }
 

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -44,9 +44,9 @@ extern "C" int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id) {
 
 extern "C" size_t VecSimIndex_IndexSize(VecSimIndex *index) { return index->indexSize(); }
 
-extern "C" int VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams,
-                                         VecSimQueryParams *qparams) {
-    return index->resolveParams(rparams, qparams);
+extern "C" VecSimResolveCode VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams,
+                                         int paramNum, VecSimQueryParams *qparams) {
+    return index->resolveParams(rparams, paramNum, qparams);
 }
 
 extern "C" VecSimQueryResult_List VecSimIndex_TopKQuery(VecSimIndex *index, const void *queryBlob,

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -44,7 +44,8 @@ extern "C" int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id) {
 
 extern "C" size_t VecSimIndex_IndexSize(VecSimIndex *index) { return index->indexSize(); }
 
-extern "C" int VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams, VecSimQueryParams *qparams) { 
+extern "C" int VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams,
+                                         VecSimQueryParams *qparams) {
     return index->resolveParams(rparams, qparams);
 }
 

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -44,6 +44,10 @@ extern "C" int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id) {
 
 extern "C" size_t VecSimIndex_IndexSize(VecSimIndex *index) { return index->indexSize(); }
 
+extern "C" int VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams, VecSimQueryParams *qparams) { 
+    return index->resolveParams(rparams, qparams);
+}
+
 extern "C" VecSimQueryResult_List VecSimIndex_TopKQuery(VecSimIndex *index, const void *queryBlob,
                                                         size_t k, VecSimQueryParams *queryParams,
                                                         VecSimQueryResult_Order order) {

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -51,6 +51,15 @@ int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id);
 size_t VecSimIndex_IndexSize(VecSimIndex *index);
 
 /**
+ * @brief Resolves VecSimRawParam array and generate VecSimQueryParams struct.
+ * @param index the index whose size is requested.
+ * @param rparams array of raw params to resolve.
+ * @param qparams pointer to VecSimQueryParams struct to set.
+ * @return true if the resolve was successful, false if not (bad raw params).
+ */
+int VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams, VecSimQueryParams *qparams);
+
+/**
  * @brief Search for the k closest vectors to a given vector in the index. The results can be
  * ordered by their score or id.
  * @param index the index to query in.

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -57,7 +57,8 @@ size_t VecSimIndex_IndexSize(VecSimIndex *index);
  * @param qparams pointer to VecSimQueryParams struct to set.
  * @return true if the resolve was successful, false if not (bad raw params).
  */
-int VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams, VecSimQueryParams *qparams);
+int VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams,
+                              VecSimQueryParams *qparams);
 
 /**
  * @brief Search for the k closest vectors to a given vector in the index. The results can be

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -57,8 +57,8 @@ size_t VecSimIndex_IndexSize(VecSimIndex *index);
  * @param qparams pointer to VecSimQueryParams struct to set.
  * @return true if the resolve was successful, false if not (bad raw params).
  */
-int VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams,
-                              VecSimQueryParams *qparams);
+VecSimResolveCode VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams,
+                              int paramNum, VecSimQueryParams *qparams);
 
 /**
  * @brief Search for the k closest vectors to a given vector in the index. The results can be

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -58,7 +58,7 @@ size_t VecSimIndex_IndexSize(VecSimIndex *index);
  * @return true if the resolve was successful, false if not (bad raw params).
  */
 VecSimResolveCode VecSimIndex_ResolveParams(VecSimIndex *index, VecSimRawParam *rparams,
-                              int paramNum, VecSimQueryParams *qparams);
+                                            int paramNum, VecSimQueryParams *qparams);
 
 /**
  * @brief Search for the k closest vectors to a given vector in the index. The results can be

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -38,12 +38,14 @@ typedef struct {
     size_t valLen;
 } VecSimRawParam;
 
+#define VecSim_OK 0
+
 typedef enum {
-    VecSimErr_OK = 0,
-    VecSimErr_MissingParamStruct,
-    VecSimErr_AlreadySet,
-    VecSimErr_UnknownParam,
-    VecSimErr_BadValue
+    VecSimParamResolver_OK = VecSim_OK, // for returning VecSim_OK as an enum value
+    VecSimParamResolverErr_MissingParamStruct,
+    VecSimParamResolverErr_AlreadySet,
+    VecSimParamResolverErr_UnknownParam,
+    VecSimParamResolverErr_BadValue
 } VecSimResolveCode;
 
 /**

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -42,7 +42,7 @@ typedef struct {
 
 typedef enum {
     VecSimParamResolver_OK = VecSim_OK, // for returning VecSim_OK as an enum value
-    VecSimParamResolverErr_MissingParamStruct,
+    VecSimParamResolverErr_NullParam,
     VecSimParamResolverErr_AlreadySet,
     VecSimParamResolverErr_UnknownParam,
     VecSimParamResolverErr_BadValue

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -27,6 +27,18 @@ typedef enum { VecSimAlgo_BF, VecSimAlgo_HNSWLIB } VecSimAlgo;
 typedef enum { VecSimMetric_L2, VecSimMetric_IP, VecSimMetric_Cosine } VecSimMetric;
 
 /**
+ * @brief Query Runtime raw parameters.
+ * Use VecSimIndex_ResolveParams to generate VecSimQueryParams from array of VecSimRawParams.
+ *
+ */
+typedef struct {
+    const char *name;
+    size_t nameLen;
+    const char *value;
+    size_t valLen;
+} VecSimRawParam;
+
+/**
  * @brief Index initialization parameters.
  *
  */

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -38,7 +38,13 @@ typedef struct {
     size_t valLen;
 } VecSimRawParam;
 
-typedef enum { VecSimErr_OK = 0, VecSimErr_MissingParamStruct, VecSimErr_AlreadySet, VecSimErr_UnknownParam, VecSimErr_BadValue } VecSimResolveCode;
+typedef enum {
+    VecSimErr_OK = 0,
+    VecSimErr_MissingParamStruct,
+    VecSimErr_AlreadySet,
+    VecSimErr_UnknownParam,
+    VecSimErr_BadValue
+} VecSimResolveCode;
 
 /**
  * @brief Index initialization parameters.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -38,6 +38,8 @@ typedef struct {
     size_t valLen;
 } VecSimRawParam;
 
+typedef enum { VecSimErr_OK = 0, VecSimErr_MissingParamStruct, VecSimErr_AlreadySet, VecSimErr_UnknownParam, VecSimErr_BadValue } VecSimResolveCode;
+
 /**
  * @brief Index initialization parameters.
  *

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -52,6 +52,7 @@ public:
      * @brief Resolves VecSimRawParam array and generate VecSimQueryParams struct.
      * @param index the index whose size is requested.
      * @param rparams array of raw params to resolve.
+     * @param paramNum number of params in rparams (or number of parames in rparams to resolve).
      * @param qparams pointer to VecSimQueryParams struct to set.
      * @return true if the resolve was successful, false if not (bad raw params).
      */

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -55,7 +55,7 @@ public:
      * @param qparams pointer to VecSimQueryParams struct to set.
      * @return true if the resolve was successful, false if not (bad raw params).
      */
-    virtual int resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) = 0;
+    virtual VecSimResolveCode resolveParams(VecSimRawParam *rparams, int paramNum, VecSimQueryParams *qparams) = 0;
 
     /**
      * @brief Search for the k closest vectors to a given vector in the index.

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -49,6 +49,15 @@ public:
     virtual size_t indexSize() const = 0;
 
     /**
+     * @brief Resolves VecSimRawParam array and generate VecSimQueryParams struct.
+     * @param index the index whose size is requested.
+     * @param rparams array of raw params to resolve.
+     * @param qparams pointer to VecSimQueryParams struct to set.
+     * @return true if the resolve was successful, false if not (bad raw params).
+     */
+    virtual int resolveParams(VecSimRawParam *rparams, VecSimQueryParams *qparams) = 0;
+
+    /**
      * @brief Search for the k closest vectors to a given vector in the index.
      *
      * @param queryBlob binary representation of the query vector. Blob size should match the index

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -55,7 +55,8 @@ public:
      * @param qparams pointer to VecSimQueryParams struct to set.
      * @return true if the resolve was successful, false if not (bad raw params).
      */
-    virtual VecSimResolveCode resolveParams(VecSimRawParam *rparams, int paramNum, VecSimQueryParams *qparams) = 0;
+    virtual VecSimResolveCode resolveParams(VecSimRawParam *rparams, int paramNum,
+                                            VecSimQueryParams *qparams) = 0;
 
     /**
      * @brief Search for the k closest vectors to a given vector in the index.

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -850,15 +850,17 @@ TEST_F(BruteForceTest, brute_force_resolve_params) {
                                         .blockSize = 5}};
     VecSimIndex *index = VecSimIndex_New(&params);
 
-    VecSimQueryParams qparams;
+    VecSimQueryParams qparams, zero;
+    bzero(&zero, sizeof(VecSimQueryParams));
 
     VecSimRawParam *rparams = array_new<VecSimRawParam>(1);
 
-    ASSERT_TRUE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_OK);
+    ASSERT_EQ(memcmp(&qparams, &zero, sizeof(VecSimQueryParams)), 0);
 
     array_append(rparams, (VecSimRawParam){
                               .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
-    ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_UnknownParam);
 
     VecSimIndex_Free(index);
     array_free(rparams);

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "VecSim/vec_sim.h"
 #include "test_utils.h"
+#include "VecSim/utils/arr_cpp.h"
 
 class BruteForceTest : public ::testing::Test {
 protected:
@@ -836,4 +837,25 @@ TEST_F(BruteForceTest, brute_force_batch_iterator_corner_cases) {
 
     VecSimBatchIterator_Free(batchIterator);
     VecSimIndex_Free(index);
+}
+
+TEST_F(BruteForceTest, brute_force_resolve_params) {
+    size_t dim = 4;
+
+    VecSimParams params = {.algo = VecSimAlgo_BF,
+                           .bfParams = {.type = VecSimType_FLOAT32,
+                                        .dim = dim,
+                                        .metric = VecSimMetric_L2,
+                                        .initialCapacity = 0,
+                                        .blockSize = 5}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    VecSimQueryParams qparams;
+
+    VecSimRawParam *rparams = array_new<VecSimRawParam>(1);
+
+    ASSERT_TRUE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+
+    array_append(rparams, (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
+    ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 }

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -855,12 +855,14 @@ TEST_F(BruteForceTest, brute_force_resolve_params) {
 
     VecSimRawParam *rparams = array_new<VecSimRawParam>(1);
 
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_OK);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimErr_OK);
     ASSERT_EQ(memcmp(&qparams, &zero, sizeof(VecSimQueryParams)), 0);
 
     array_append(rparams, (VecSimRawParam){
                               .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_UnknownParam);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimErr_UnknownParam);
 
     VecSimIndex_Free(index);
     array_free(rparams);

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -859,4 +859,7 @@ TEST_F(BruteForceTest, brute_force_resolve_params) {
     array_append(rparams, (VecSimRawParam){
                               .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
     ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+
+    VecSimIndex_Free(index);
+    array_free(rparams);
 }

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -864,7 +864,7 @@ TEST_F(BruteForceTest, brute_force_resolve_params) {
               VecSimParamResolverErr_UnknownParam);
 
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), NULL),
-              VecSimParamResolverErr_MissingParamStruct);
+              VecSimParamResolverErr_NullParam);
 
     VecSimIndex_Free(index);
     array_free(rparams);

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -864,6 +864,9 @@ TEST_F(BruteForceTest, brute_force_resolve_params) {
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
               VecSimErr_UnknownParam);
 
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), NULL),
+              VecSimErr_MissingParamStruct);
+
     VecSimIndex_Free(index);
     array_free(rparams);
 }

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -855,17 +855,16 @@ TEST_F(BruteForceTest, brute_force_resolve_params) {
 
     VecSimRawParam *rparams = array_new<VecSimRawParam>(1);
 
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-              VecSimErr_OK);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSim_OK);
     ASSERT_EQ(memcmp(&qparams, &zero, sizeof(VecSimQueryParams)), 0);
 
     array_append(rparams, (VecSimRawParam){
                               .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-              VecSimErr_UnknownParam);
+              VecSimParamResolverErr_UnknownParam);
 
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), NULL),
-              VecSimErr_MissingParamStruct);
+              VecSimParamResolverErr_MissingParamStruct);
 
     VecSimIndex_Free(index);
     array_free(rparams);

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -856,6 +856,7 @@ TEST_F(BruteForceTest, brute_force_resolve_params) {
 
     ASSERT_TRUE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 
-    array_append(rparams, (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
+    array_append(rparams, (VecSimRawParam){
+                              .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
     ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 }

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -970,7 +970,7 @@ TEST_F(HNSWLibTest, hnsw_resolve_params) {
               VecSimParamResolverErr_AlreadySet);
 
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), NULL),
-              VecSimParamResolverErr_MissingParamStruct);
+              VecSimParamResolverErr_NullParam);
 
     VecSimIndex_Free(index);
     array_free(rparams);

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -936,22 +936,26 @@ TEST_F(HNSWLibTest, hnsw_resolve_params) {
 
     ASSERT_TRUE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 
-    array_append(rparams, (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
+    array_append(rparams, (VecSimRawParam){
+                              .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
     ASSERT_TRUE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 
-    array_append(rparams, (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
+    array_append(rparams, (VecSimRawParam){
+                              .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
     ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 
     array_hdr(rparams)->len--;
     rparams[0] = (VecSimRawParam){.name = "wrong_name", .nameLen = 10, .value = "100", .valLen = 3};
     ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 
-    rparams[0] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "wrong_val", .valLen = 9};
+    rparams[0] =
+        (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "wrong_val", .valLen = 9};
     ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 
     rparams[0] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "-30", .valLen = 3};
     ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 
-    rparams[0] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "1.618", .valLen = 5};
+    rparams[0] =
+        (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "1.618", .valLen = 5};
     ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
 }

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -958,4 +958,7 @@ TEST_F(HNSWLibTest, hnsw_resolve_params) {
     rparams[0] =
         (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "1.618", .valLen = 5};
     ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+
+    VecSimIndex_Free(index);
+    array_free(rparams);
 }

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -935,44 +935,42 @@ TEST_F(HNSWLibTest, hnsw_resolve_params) {
 
     VecSimRawParam *rparams = array_new<VecSimRawParam>(2);
 
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-              VecSimErr_OK);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSim_OK);
     ASSERT_EQ(memcmp(&qparams, &zero, sizeof(VecSimQueryParams)), 0);
 
     array_append(rparams, (VecSimRawParam){
                               .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-              VecSimErr_OK);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSim_OK);
     ASSERT_EQ(qparams.hnswRuntimeParams.efRuntime, 100);
     qparams.hnswRuntimeParams.efRuntime = 0;
     ASSERT_EQ(memcmp(&qparams, &zero, sizeof(VecSimQueryParams)), 0);
 
     rparams[0] = (VecSimRawParam){.name = "wrong_name", .nameLen = 10, .value = "100", .valLen = 3};
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-              VecSimErr_UnknownParam);
+              VecSimParamResolverErr_UnknownParam);
 
     rparams[0] =
         (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "wrong_val", .valLen = 9};
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-              VecSimErr_BadValue);
+              VecSimParamResolverErr_BadValue);
 
     rparams[0] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "-30", .valLen = 3};
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-              VecSimErr_BadValue);
+              VecSimParamResolverErr_BadValue);
 
     rparams[0] =
         (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "1.618", .valLen = 5};
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-              VecSimErr_BadValue);
+              VecSimParamResolverErr_BadValue);
 
     rparams[0] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3};
     array_append(rparams, (VecSimRawParam){
                               .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-              VecSimErr_AlreadySet);
+              VecSimParamResolverErr_AlreadySet);
 
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), NULL),
-              VecSimErr_MissingParamStruct);
+              VecSimParamResolverErr_MissingParamStruct);
 
     VecSimIndex_Free(index);
     array_free(rparams);

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -935,34 +935,41 @@ TEST_F(HNSWLibTest, hnsw_resolve_params) {
 
     VecSimRawParam *rparams = array_new<VecSimRawParam>(2);
 
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_OK);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimErr_OK);
     ASSERT_EQ(memcmp(&qparams, &zero, sizeof(VecSimQueryParams)), 0);
 
     array_append(rparams, (VecSimRawParam){
                               .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_OK);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimErr_OK);
     ASSERT_EQ(qparams.hnswRuntimeParams.efRuntime, 100);
     qparams.hnswRuntimeParams.efRuntime = 0;
     ASSERT_EQ(memcmp(&qparams, &zero, sizeof(VecSimQueryParams)), 0);
 
     rparams[0] = (VecSimRawParam){.name = "wrong_name", .nameLen = 10, .value = "100", .valLen = 3};
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_UnknownParam);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimErr_UnknownParam);
 
     rparams[0] =
         (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "wrong_val", .valLen = 9};
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_BadValue);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimErr_BadValue);
 
     rparams[0] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "-30", .valLen = 3};
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_BadValue);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimErr_BadValue);
 
     rparams[0] =
         (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "1.618", .valLen = 5};
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_BadValue);
-    
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimErr_BadValue);
+
     rparams[0] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3};
     array_append(rparams, (VecSimRawParam){
                               .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
-    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_AlreadySet);
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimErr_AlreadySet);
 
     VecSimIndex_Free(index);
     array_free(rparams);

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -971,6 +971,9 @@ TEST_F(HNSWLibTest, hnsw_resolve_params) {
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
               VecSimErr_AlreadySet);
 
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), NULL),
+              VecSimErr_MissingParamStruct);
+
     VecSimIndex_Free(index);
     array_free(rparams);
 }

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -930,34 +930,39 @@ TEST_F(HNSWLibTest, hnsw_resolve_params) {
                                           .efRuntime = ef}};
     VecSimIndex *index = VecSimIndex_New(&params);
 
-    VecSimQueryParams qparams;
+    VecSimQueryParams qparams, zero;
+    bzero(&zero, sizeof(VecSimQueryParams));
 
     VecSimRawParam *rparams = array_new<VecSimRawParam>(2);
 
-    ASSERT_TRUE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_OK);
+    ASSERT_EQ(memcmp(&qparams, &zero, sizeof(VecSimQueryParams)), 0);
 
     array_append(rparams, (VecSimRawParam){
                               .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
-    ASSERT_TRUE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_OK);
+    ASSERT_EQ(qparams.hnswRuntimeParams.efRuntime, 100);
+    qparams.hnswRuntimeParams.efRuntime = 0;
+    ASSERT_EQ(memcmp(&qparams, &zero, sizeof(VecSimQueryParams)), 0);
 
-    array_append(rparams, (VecSimRawParam){
-                              .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
-    ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
-
-    array_hdr(rparams)->len--;
     rparams[0] = (VecSimRawParam){.name = "wrong_name", .nameLen = 10, .value = "100", .valLen = 3};
-    ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_UnknownParam);
 
     rparams[0] =
         (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "wrong_val", .valLen = 9};
-    ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_BadValue);
 
     rparams[0] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "-30", .valLen = 3};
-    ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_BadValue);
 
     rparams[0] =
         (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "1.618", .valLen = 5};
-    ASSERT_FALSE(VecSimIndex_ResolveParams(index, rparams, &qparams));
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_BadValue);
+    
+    rparams[0] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3};
+    array_append(rparams, (VecSimRawParam){
+                              .name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3});
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSimErr_AlreadySet);
 
     VecSimIndex_Free(index);
     array_free(rparams);


### PR DESCRIPTION
Added ResolveParams function to VecSimIndex, including the struct VecSimRawParam that holds a parameter in <string,string> key-value fashion.
Also added tests for hnsw and br indexes ResolveParams.