### PR TITLE
Pinning rltest to the last release prior to redis-py 4 as a requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ pytest = "^6.2.4"
 scipy = "^1.5.4"
 h5py = "^3.6.0"
 pybind11 = {path = "deps/pybind11"}
-rltest = {git = "https://github.com/RedisLabsModules/RLTest.git", rev = "master"}
+rltest = "0.4.2"
 
 
 [build-system]


### PR DESCRIPTION
This allows a longer-tail migration to the latest version as each repository is ready, without breaking individual projects.
