### PR TITLE
Fix bug in BF batch search

### DIFF
--- a/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
+++ b/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
@@ -25,6 +25,36 @@ VecSimQueryResult *BF_BatchIterator::searchByHeuristics(size_t n_res,
     return res;
 }
 
+void BF_BatchIterator::swapScores(const unordered_map<size_t, size_t> &TopCandidatesIndices,
+                                  size_t res_num) {
+    // Create a set of the indices in the scores array for every results that we return.
+    set<size_t> indices;
+    for (auto pos : TopCandidatesIndices) {
+        indices.insert(pos.second);
+    }
+    // Get the first valid position in the next iteration.
+    size_t next_scores_valid_start_pos = this->scores_valid_start_pos + res_num;
+    // Get the first index of a results in this iteration which is greater or equal to
+    // next_scores_valid_start_pos.
+    auto reuse_index_it = indices.lower_bound(next_scores_valid_start_pos);
+    auto it = indices.begin();
+    size_t ind = this->scores_valid_start_pos;
+    // Swap elements which are in the first res_num positions in the scores array, and place them
+    // in indices of results that we return now (reuse these indices).
+    while (ind < next_scores_valid_start_pos) {
+        // don't swap if there is a result in one of the heading indices which will be invalid from
+        // next iteration.
+        if (*it == ind) {
+            it++;
+        } else {
+            this->scores[*reuse_index_it] = this->scores[ind];
+            reuse_index_it++;
+        }
+        ind++;
+    }
+    this->scores_valid_start_pos = next_scores_valid_start_pos;
+}
+
 VecSimQueryResult *BF_BatchIterator::heapBasedSearch(size_t n_res) {
     float upperBound = std::numeric_limits<float>::lowest();
     vecsim_stl::max_priority_queue<pair<float, labelType>> TopCandidates(this->allocator);
@@ -49,16 +79,14 @@ VecSimQueryResult *BF_BatchIterator::heapBasedSearch(size_t n_res) {
         }
     }
 
+    // Save the top results to return.
     auto *results = array_new_len<VecSimQueryResult>(TopCandidates.size(), TopCandidates.size());
     for (int i = (int)TopCandidates.size() - 1; i >= 0; --i) {
         VecSimQueryResult_SetId(results[i], TopCandidates.top().second);
         VecSimQueryResult_SetScore(results[i], TopCandidates.top().first);
-        // Move the first valid entry in the scores array to the current vector position,
-        // and advance the scores array's head (for next iterations).
-        this->scores[TopCandidatesIndices[TopCandidates.top().second]] =
-            this->scores[this->scores_valid_start_pos++];
         TopCandidates.pop();
     }
+    swapScores(TopCandidatesIndices, array_len(results));
     return results;
 }
 

--- a/src/VecSim/algorithms/brute_force/bf_batch_iterator.h
+++ b/src/VecSim/algorithms/brute_force/bf_batch_iterator.h
@@ -17,6 +17,7 @@ private:
     VecSimQueryResult *searchByHeuristics(size_t n_res, VecSimQueryResult_Order order);
     VecSimQueryResult *selectBasedSearch(size_t n_res);
     VecSimQueryResult *heapBasedSearch(size_t n_res);
+    void swapScores(const unordered_map<size_t, size_t> &TopCandidatesIndices, size_t res_num);
 
 public:
     BF_BatchIterator(const void *query_vector, const BruteForceIndex *index,

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -1019,3 +1019,66 @@ TEST_F(BruteForceTest, preferAdHocOptimization) {
         }
     }
 }
+
+TEST_F(BruteForceTest, batchIteratorSwapIndices) {
+    size_t dim = 4;
+    size_t n = 10000;
+
+    VecSimParams params{.algo = VecSimAlgo_BF,
+                        .bfParams = BFParams{.type = VecSimType_FLOAT32,
+                                             .dim = dim,
+                                             .metric = VecSimMetric_L2,
+                                             .initialCapacity = n}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    float close_vec[] = {1.0, 1.0, 1.0, 1.0};
+    float further_vec[] = {2.0, 2.0, 2.0, 2.0};
+    VecSimIndex_AddVector(index, (const void *)further_vec, 0);
+    VecSimIndex_AddVector(index, (const void *)close_vec, 1);
+    VecSimIndex_AddVector(index, (const void *)further_vec, 2);
+    VecSimIndex_AddVector(index, (const void *)close_vec, 3);
+    VecSimIndex_AddVector(index, (const void *)close_vec, 4);
+    VecSimIndex_AddVector(index, (const void *)close_vec, 5);
+    for (size_t i = 6; i < n; i++) {
+        float f[dim];
+        f[0] = f[1] = f[2] = f[3] = (float)i;
+        VecSimIndex_AddVector(index, (const void *)f, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    // query for (1,1,1,1) vector.
+    float query[dim];
+    query[0] = query[1] = query[2] = query[3] = 1.0;
+    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query);
+
+    // Get first batch - expect to get ids 1,3,4,5.
+    VecSimQueryResult_List res = VecSimBatchIterator_Next(batchIterator, 4, BY_ID);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 4);
+    VecSimQueryResult_Iterator *iterator = VecSimQueryResult_List_GetIterator(res);
+    int res_ind = 0;
+    size_t expected_res[] = {1, 3, 4, 5};
+    while (VecSimQueryResult_IteratorHasNext(iterator)) {
+        VecSimQueryResult *item = VecSimQueryResult_IteratorNext(iterator);
+        int id = (int)VecSimQueryResult_GetId(item);
+        ASSERT_EQ(expected_res[res_ind++], id);
+    }
+    VecSimQueryResult_IteratorFree(iterator);
+    VecSimQueryResult_Free(res);
+
+    // Get another batch - expect to get ids 0,2,6,7. Make sure that ids 0,2 swapped properly.
+    res = VecSimBatchIterator_Next(batchIterator, 4, BY_ID);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 4);
+    iterator = VecSimQueryResult_List_GetIterator(res);
+    res_ind = 0;
+    size_t expected_res_2[] = {0, 2, 6, 7};
+    while (VecSimQueryResult_IteratorHasNext(iterator)) {
+        VecSimQueryResult *item = VecSimQueryResult_IteratorNext(iterator);
+        int id = (int)VecSimQueryResult_GetId(item);
+        ASSERT_EQ(expected_res_2[res_ind++], id);
+    }
+    VecSimQueryResult_IteratorFree(iterator);
+    VecSimQueryResult_Free(res);
+
+    VecSimBatchIterator_Free(batchIterator);
+    VecSimIndex_Free(index);
+}


### PR DESCRIPTION
replacing indexes in scores array after heap based search wasn't taking care of the case where results are placed in the head of the array which is going to be trimmed in the next iteration.