### PR TITLE
Add the search mode to the info fields

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -22,7 +22,8 @@ BruteForceIndex::BruteForceIndex(const BFParams *params, std::shared_ptr<VecSimA
                 ? static_cast<SpaceInterface<float> *>(new (allocator)
                                                            L2Space(params->dim, allocator))
                 : static_cast<SpaceInterface<float> *>(
-                      new (allocator) InnerProductSpace(params->dim, allocator))) {
+                      new (allocator) InnerProductSpace(params->dim, allocator))),
+      last_mode(EMPTY_MODE) {
     this->idToVectorBlockMemberMapping.resize(params->initialCapacity);
     this->dist_func = this->space->get_dist_func();
 }
@@ -183,6 +184,7 @@ VecSimResolveCode BruteForceIndex::resolveParams(VecSimRawParam *rparams, int pa
 VecSimQueryResult_List BruteForceIndex::topKQuery(const void *queryBlob, size_t k,
                                                   VecSimQueryParams *queryParams) {
 
+    this->last_mode = STANDARD_KNN;
     float normalized_blob[this->dim]; // This will be use only if metric == VecSimMetric_Cosine
     if (this->metric == VecSimMetric_Cosine) {
         // TODO: need more generic
@@ -237,13 +239,14 @@ VecSimIndexInfo BruteForceIndex::info() {
     info.bfInfo.indexSize = this->count;
     info.bfInfo.blockSize = this->vectorBlockSize;
     info.bfInfo.memory = this->allocator->getAllocationSize();
+    info.bfInfo.last_mode = this->last_mode;
     return info;
 }
 
 VecSimInfoIterator *BruteForceIndex::infoIterator() {
     VecSimIndexInfo info = this->info();
     // For readability. Update this number when needed;
-    size_t numberOfInfoFields = 7;
+    size_t numberOfInfoFields = 8;
     VecSimInfoIterator *infoIterator = new VecSimInfoIterator(numberOfInfoFields);
 
     infoIterator->addInfoField(VecSim_InfoField{.fieldName = VecSimCommonStrings::ALGORITHM_STRING,
@@ -269,6 +272,10 @@ VecSimInfoIterator *BruteForceIndex::infoIterator() {
     infoIterator->addInfoField(VecSim_InfoField{.fieldName = VecSimCommonStrings::MEMORY_STRING,
                                                 .fieldType = INFOFIELD_UINT64,
                                                 .uintegerValue = info.bfInfo.memory});
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::SEARCH_MODE_STRING,
+                         .fieldType = INFOFIELD_STRING,
+                         .stringValue = VecSimSearchMode_ToString(info.bfInfo.last_mode)});
 
     return infoIterator;
 }
@@ -281,58 +288,67 @@ bool BruteForceIndex::preferAdHocSearch(size_t subsetSize, size_t k) {
     // This heuristic is based on sklearn decision tree classifier (with 10 leaves nodes) -
     // see scripts/BF_batches_clf.py
     size_t index_size = this->indexSize();
+    if (subsetSize > index_size) {
+        throw std::runtime_error("internal error: subset size cannot be larger than index size");
+    }
     size_t d = this->dim;
-    float r = (float)(subsetSize) / (float)index_size;
-    if (index_size <= 5500)
-        return true;
-    // node 2
-    if (d <= 300) {
-        // node 3
-        if (r <= 0.15) {
-            // node 5
-            return true;
-        } else {
-            // node 6
-            if (r <= 0.35) {
-                // node 9
-                if (d <= 75) {
-                    // node 11
-                    return false;
-                } else {
-                    // node 12
-                    if (index_size <= 550000) {
-                        // node 17
-                        return true;
-                    } else {
-                        // node 18
-                        return false;
-                    }
-                }
-            } else {
-                // node 10
-                return false;
-            }
-        }
+    float r = (index_size == 0) ? 0.0f : (float)(subsetSize) / (float)index_size;
+    bool res;
+    if (index_size <= 5500) {
+        // node 1
+        res = true;
     } else {
-        // node 4
-        if (r <= 0.55) {
-            // node 7
-            return true;
-        } else {
-            // node 8
-            if (d <= 750) {
-                // node 13
-                return false;
+        // node 2
+        if (d <= 300) {
+            // node 3
+            if (r <= 0.15) {
+                // node 5
+                res = true;
             } else {
-                // node 14
-                if (r <= 0.75) {
-                    // node 15
-                    return true;
+                // node 6
+                if (r <= 0.35) {
+                    // node 9
+                    if (d <= 75) {
+                        // node 11
+                        res = false;
+                    } else {
+                        // node 12
+                        if (index_size <= 550000) {
+                            // node 17
+                            res = true;
+                        } else {
+                            // node 18
+                            res = false;
+                        }
+                    }
                 } else {
-                    // node 16
-                    return false;
+                    // node 10
+                    res = false;
+                }
+            }
+        } else {
+            // node 4
+            if (r <= 0.55) {
+                // node 7
+                res = true;
+            } else {
+                // node 8
+                if (d <= 750) {
+                    // node 13
+                    res = false;
+                } else {
+                    // node 14
+                    if (r <= 0.75) {
+                        // node 15
+                        res = true;
+                    } else {
+                        // node 16
+                        res = false;
+                    }
                 }
             }
         }
     }
+    this->last_mode = res ? HYBRID_ADHOC_BF : HYBRID_BATCHES;
+    return res;
 }

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -42,8 +42,10 @@ private:
     idType count;
     std::unique_ptr<SpaceInterface<float>> space;
     DISTFUNC<float> dist_func;
+    VecSearchMode last_mode;
 #ifdef BUILD_TESTS
-    // Allow the following test to access the index size private member.
+    // Allow the following tests to access the index size private member.
     friend class BruteForceTest_preferAdHocOptimization_Test;
+    friend class BruteForceTest_test_dynamic_bf_info_iterator_Test;
 #endif
 };

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
@@ -32,4 +32,5 @@ public:
 private:
     std::shared_ptr<SpaceInterface<float>> space;
     std::shared_ptr<hnswlib::HierarchicalNSW<float>> hnsw;
+    VecSearchMode last_mode;
 };

--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -92,6 +92,7 @@ private:
     friend class HNSWIndexSerializer;
     // Allow the following test to access the index size private member.
     friend class HNSWLibTest_preferAdHocOptimization_Test;
+    friend class HNSWLibTest_test_dynamic_hnsw_info_iterator_Test;
 #endif
 
     HierarchicalNSW() {}                                // default constructor

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -34,6 +34,7 @@ const char *VecSimCommonStrings::HNSW_MAX_LEVEL = "MAX_LEVEL";
 const char *VecSimCommonStrings::HNSW_ENTRYPOINT = "ENTRYPOINT";
 
 const char *VecSimCommonStrings::BLOCK_SIZE_STRING = "BLOCK_SIZE";
+const char *VecSimCommonStrings::SEARCH_MODE_STRING = "LAST_SEARCH_MODE";
 
 int cmpVecSimQueryResultById(const VecSimQueryResult *res1, const VecSimQueryResult *res2) {
     return (int)(VecSimQueryResult_GetId(res1) - VecSimQueryResult_GetId(res2));
@@ -103,6 +104,21 @@ const char *VecSimMetric_ToString(VecSimMetric vecsimMetric) {
         return "IP";
     case VecSimMetric_L2:
         return "L2";
+    default:
+        return NULL;
+    }
+}
+
+const char *VecSimSearchMode_ToString(VecSearchMode vecsimSearchMode) {
+    switch (vecsimSearchMode) {
+    case EMPTY_MODE:
+        return "EMPTY_MODE";
+    case STANDARD_KNN:
+        return "STANDARD_KNN";
+    case HYBRID_ADHOC_BF:
+        return "HYBRID_ADHOC_BF";
+    case HYBRID_BATCHES:
+        return "HYBRID_BATCHES";
     default:
         return NULL;
     }

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -41,6 +41,7 @@ public:
     static const char *HNSW_ENTRYPOINT;
 
     static const char *BLOCK_SIZE_STRING;
+    static const char *SEARCH_MODE_STRING;
 };
 
 void float_vector_normalize(float *x, size_t dim);
@@ -54,3 +55,5 @@ const char *VecSimAlgo_ToString(VecSimAlgo vecsimAlgo);
 const char *VecSimType_ToString(VecSimType vecsimType);
 
 const char *VecSimMetric_ToString(VecSimMetric vecsimMetric);
+
+const char *VecSimSearchMode_ToString(VecSearchMode vecsimSearchMode);

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -93,36 +93,51 @@ typedef struct {
 } VecSimQueryParams;
 
 /**
+ * @brief Query runtime information - the search mode in RediSearch (used for debug/testing).
+ *
+ */
+typedef enum {
+    EMPTY_MODE,      // Default value to initialize the "last_mode" field with.
+    STANDARD_KNN,    // Run k-nn query over the entire vector index.
+    HYBRID_ADHOC_BF, // Measure ad-hoc the distance for every result that passes the filters,
+                     // and take the top k results.
+    HYBRID_BATCHES   // Get the top vector results in batches upon demand, and keep the results that
+                     // passes the filters until we reach k results.
+} VecSearchMode;
+
+/**
  * @brief Index information. Mainly used for debug/testing.
  *
  */
 typedef struct {
     union {
         struct {
-            size_t indexSize;      // Current count of vectors.
-            size_t M;              // Number of allowed edges per node in graph.
-            size_t efConstruction; // EF parameter for HNSW graph accuracy/latency for indexing.
-            size_t efRuntime;      // EF parameter for HNSW graph accuracy/latency for search.
-            size_t max_level;      // Number of graph levels.
-            size_t entrypoint;     // Entrypoint vector label.
-            VecSimMetric metric;   // Index distance metric
-            uint64_t memory;       // Index memory consumption.
-            VecSimType type;       // Datatype the index holds.
-            size_t dim;            // Vector size (dimension).
+            size_t indexSize;        // Current count of vectors.
+            size_t M;                // Number of allowed edges per node in graph.
+            size_t efConstruction;   // EF parameter for HNSW graph accuracy/latency for indexing.
+            size_t efRuntime;        // EF parameter for HNSW graph accuracy/latency for search.
+            size_t max_level;        // Number of graph levels.
+            size_t entrypoint;       // Entrypoint vector label.
+            VecSimMetric metric;     // Index distance metric
+            uint64_t memory;         // Index memory consumption.
+            VecSimType type;         // Datatype the index holds.
+            size_t dim;              // Vector size (dimension).
+            VecSearchMode last_mode; // The mode in which the last query ran.
         } hnswInfo;
         struct {
-            size_t indexSize;    // Current count of vectors.
-            size_t blockSize;    // Brute force algorithm vector block (mini matrix) size
-            VecSimMetric metric; // Index distance metric
-            uint64_t memory;     // Index memory consumption.
-            VecSimType type;     // Datatype the index holds.
-            size_t dim;          // Vector size (dimension).
+            size_t indexSize;        // Current count of vectors.
+            size_t blockSize;        // Brute force algorithm vector block (mini matrix) size
+            VecSimMetric metric;     // Index distance metric
+            uint64_t memory;         // Index memory consumption.
+            VecSimType type;         // Datatype the index holds.
+            size_t dim;              // Vector size (dimension).
+            VecSearchMode last_mode; // The mode in which the last query ran.
         } bfInfo;
     };
     VecSimAlgo algo; // Algorithm being used.
 } VecSimIndexInfo;
 
-// Memory function declerations.
+// Memory function declarations.
 typedef void *(*allocFn)(size_t n);
 typedef void *(*callocFn)(size_t nelem, size_t elemsz);
 typedef void *(*reallocFn)(void *p, size_t n);

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -437,6 +437,31 @@ TEST_F(BruteForceTest, test_dynamic_bf_info_iterator) {
     compareFlatIndexInfoToIterator(info, infoIter);
     VecSimInfoIterator_Free(infoIter);
 
+    // Perform (or simulate) Search in 3 modes.
+    VecSimIndex_AddVector(index, v, 0);
+    VecSimIndex_TopKQuery(index, v, 1, nullptr, BY_SCORE);
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(STANDARD_KNN, info.bfInfo.last_mode);
+    compareFlatIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 1, 1));
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(HYBRID_ADHOC_BF, info.bfInfo.last_mode);
+    compareFlatIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    // Set the index size artificially so that BATCHES mode will be selected by the heuristics.
+    reinterpret_cast<BruteForceIndex *>(index)->count = 1e4;
+    ASSERT_FALSE(VecSimIndex_PreferAdHocSearch(index, 7e3, 1));
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(HYBRID_BATCHES, info.bfInfo.last_mode);
+    compareFlatIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
     VecSimIndex_Free(index);
 }
 
@@ -1017,6 +1042,21 @@ TEST_F(BruteForceTest, preferAdHocOptimization) {
             }
             VecSimIndex_Free(index);
         }
+    }
+    // Corner cases - empty index.
+    VecSimParams params{
+        .algo = VecSimAlgo_BF,
+        .bfParams = BFParams{.type = VecSimType_FLOAT32, .dim = 4, .metric = VecSimMetric_IP}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 0, 50));
+
+    // Corner cases - subset size is greater than index size.
+    try {
+        VecSimIndex_PreferAdHocSearch(index, 1, 50);
+        FAIL() << "Expected std::runtime error";
+    } catch (std::runtime_error const &err) {
+        EXPECT_EQ(err.what(),
+                  std::string("internal error: subset size cannot be larger than index size"));
     }
 }
 

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -439,7 +439,8 @@ TEST_F(BruteForceTest, test_dynamic_bf_info_iterator) {
 
     // Perform (or simulate) Search in 3 modes.
     VecSimIndex_AddVector(index, v, 0);
-    VecSimIndex_TopKQuery(index, v, 1, nullptr, BY_SCORE);
+    auto res = VecSimIndex_TopKQuery(index, v, 1, nullptr, BY_SCORE);
+    VecSimQueryResult_Free(res);
     info = VecSimIndex_Info(index);
     infoIter = VecSimIndex_InfoIterator(index);
     ASSERT_EQ(STANDARD_KNN, info.bfInfo.last_mode);

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -1058,6 +1058,7 @@ TEST_F(BruteForceTest, preferAdHocOptimization) {
         EXPECT_EQ(err.what(),
                   std::string("internal error: subset size cannot be larger than index size"));
     }
+    VecSimIndex_Free(index);
 }
 
 TEST_F(BruteForceTest, batchIteratorSwapIndices) {

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -393,7 +393,8 @@ TEST_F(HNSWLibTest, test_dynamic_hnsw_info_iterator) {
 
     // Perform (or simulate) Search in 3 modes.
     VecSimIndex_AddVector(index, v, 0);
-    VecSimIndex_TopKQuery(index, v, 1, nullptr, BY_SCORE);
+    auto res = VecSimIndex_TopKQuery(index, v, 1, nullptr, BY_SCORE);
+    VecSimQueryResult_Free(res);
     info = VecSimIndex_Info(index);
     infoIter = VecSimIndex_InfoIterator(index);
     ASSERT_EQ(STANDARD_KNN, info.hnswInfo.last_mode);

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -1239,5 +1239,6 @@ TEST_F(HNSWLibTest, preferAdHocOptimization) {
         EXPECT_EQ(err.what(),
                   std::string("internal error: subset size cannot be larger than index size"));
     }
+    VecSimIndex_Free(index);
 }
 } // namespace hnswlib

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -50,7 +50,7 @@ void runBatchIteratorSearchTest(VecSimBatchIterator *batch_iterator, size_t n_re
 }
 
 void compareFlatIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *infoIter) {
-    ASSERT_EQ(7, VecSimInfoIterator_NumberOfFields(infoIter));
+    ASSERT_EQ(8, VecSimInfoIterator_NumberOfFields(infoIter));
     while (VecSimInfoIterator_HasNextField(infoIter)) {
         VecSim_InfoField *infoFiled = VecSimInfoIterator_NextField(infoIter);
         if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
@@ -69,6 +69,10 @@ void compareFlatIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
             // Metric.
             ASSERT_EQ(infoFiled->fieldType, INFOFIELD_STRING);
             ASSERT_STREQ(infoFiled->stringValue, VecSimMetric_ToString(info.bfInfo.metric));
+        } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::SEARCH_MODE_STRING)) {
+            // Search mode.
+            ASSERT_EQ(infoFiled->fieldType, INFOFIELD_STRING);
+            ASSERT_STREQ(infoFiled->stringValue, VecSimSearchMode_ToString(info.bfInfo.last_mode));
         } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::INDEX_SIZE_STRING)) {
             // Index size.
             ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);
@@ -88,7 +92,7 @@ void compareFlatIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
 }
 
 void compareHNSWIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *infoIter) {
-    ASSERT_EQ(11, VecSimInfoIterator_NumberOfFields(infoIter));
+    ASSERT_EQ(12, VecSimInfoIterator_NumberOfFields(infoIter));
     while (VecSimInfoIterator_HasNextField(infoIter)) {
         VecSim_InfoField *infoFiled = VecSimInfoIterator_NextField(infoIter);
         if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
@@ -107,6 +111,11 @@ void compareHNSWIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
             // Metric.
             ASSERT_EQ(infoFiled->fieldType, INFOFIELD_STRING);
             ASSERT_STREQ(infoFiled->stringValue, VecSimMetric_ToString(info.hnswInfo.metric));
+        } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::SEARCH_MODE_STRING)) {
+            // Search mode.
+            ASSERT_EQ(infoFiled->fieldType, INFOFIELD_STRING);
+            ASSERT_STREQ(infoFiled->stringValue,
+                         VecSimSearchMode_ToString(info.hnswInfo.last_mode));
         } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::INDEX_SIZE_STRING)) {
             // Index size.
             ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);


### PR DESCRIPTION
This is enabler for `ft.debug` to differentiate between the different modes when testing hybrid query in RediSearch