### PR TITLE
Normalize query vector in batch search cosine

### DIFF
--- a/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
+++ b/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
@@ -116,9 +116,9 @@ VecSimQueryResult *BF_BatchIterator::selectBasedSearch(size_t n_res) {
     return results;
 }
 
-BF_BatchIterator::BF_BatchIterator(const void *query_vector, const BruteForceIndex *bf_index,
+BF_BatchIterator::BF_BatchIterator(void *query_vector, const BruteForceIndex *bf_index,
                                    std::shared_ptr<VecSimAllocator> allocator)
-    : VecSimBatchIterator(query_vector, bf_index->info().bfInfo.dim, allocator), index(bf_index), scores_valid_start_pos(0) {
+    : VecSimBatchIterator(query_vector, allocator), index(bf_index), scores_valid_start_pos(0) {
     BF_BatchIterator::next_id++;
 }
 

--- a/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
+++ b/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
@@ -118,7 +118,7 @@ VecSimQueryResult *BF_BatchIterator::selectBasedSearch(size_t n_res) {
 
 BF_BatchIterator::BF_BatchIterator(const void *query_vector, const BruteForceIndex *bf_index,
                                    std::shared_ptr<VecSimAllocator> allocator)
-    : VecSimBatchIterator(query_vector, allocator), index(bf_index), scores_valid_start_pos(0) {
+    : VecSimBatchIterator(query_vector, bf_index->info().bfInfo.dim, allocator), index(bf_index), scores_valid_start_pos(0) {
     BF_BatchIterator::next_id++;
 }
 

--- a/src/VecSim/algorithms/brute_force/bf_batch_iterator.h
+++ b/src/VecSim/algorithms/brute_force/bf_batch_iterator.h
@@ -20,7 +20,7 @@ private:
     void swapScores(const unordered_map<size_t, size_t> &TopCandidatesIndices, size_t res_num);
 
 public:
-    BF_BatchIterator(const void *query_vector, const BruteForceIndex *index,
+    BF_BatchIterator(void *query_vector, const BruteForceIndex *index,
                      std::shared_ptr<VecSimAllocator> allocator);
 
     inline const BruteForceIndex *getIndex() const { return index; };

--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -227,7 +227,7 @@ VecSimQueryResult_List BruteForceIndex::topKQuery(const void *queryBlob, size_t 
     return results;
 }
 
-VecSimIndexInfo BruteForceIndex::info() {
+VecSimIndexInfo BruteForceIndex::info() const {
 
     VecSimIndexInfo info;
     info.algo = VecSimAlgo_BF;

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -23,7 +23,7 @@ public:
                                             VecSimQueryParams *qparams) override;
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
-    virtual VecSimIndexInfo info() override;
+    virtual VecSimIndexInfo info() const override;
     virtual VecSimInfoIterator *infoIterator() override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob) override;
     bool preferAdHocSearch(size_t subsetSize, size_t k) override;

--- a/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
@@ -127,9 +127,9 @@ candidatesMaxHeap HNSW_BatchIterator::scanGraph(candidatesMinHeap &candidates,
     return top_candidates;
 }
 
-HNSW_BatchIterator::HNSW_BatchIterator(const void *query_vector, HNSWIndex *index_wrapper,
+HNSW_BatchIterator::HNSW_BatchIterator(void *query_vector, HNSWIndex *index_wrapper,
                                        std::shared_ptr<VecSimAllocator> allocator)
-    : VecSimBatchIterator(query_vector, index_wrapper->info().hnswInfo.dim, std::move(allocator)), index_wrapper(index_wrapper),
+    : VecSimBatchIterator(query_vector, std::move(allocator)), index_wrapper(index_wrapper),
       depleted(false), top_candidates_extras(this->allocator), candidates(this->allocator) {
     this->space = index_wrapper->getSpace();
 

--- a/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
@@ -129,7 +129,7 @@ candidatesMaxHeap HNSW_BatchIterator::scanGraph(candidatesMinHeap &candidates,
 
 HNSW_BatchIterator::HNSW_BatchIterator(const void *query_vector, HNSWIndex *index_wrapper,
                                        std::shared_ptr<VecSimAllocator> allocator)
-    : VecSimBatchIterator(query_vector, std::move(allocator)), index_wrapper(index_wrapper),
+    : VecSimBatchIterator(query_vector, index_wrapper->info().hnswInfo.dim, std::move(allocator)), index_wrapper(index_wrapper),
       depleted(false), top_candidates_extras(this->allocator), candidates(this->allocator) {
     this->space = index_wrapper->getSpace();
 

--- a/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.h
@@ -36,7 +36,7 @@ private:
     inline bool hasVisitedNode(idType node_id) const;
 
 public:
-    HNSW_BatchIterator(const void *query_vector, HNSWIndex *index,
+    HNSW_BatchIterator(void *query_vector, HNSWIndex *index,
                        std::shared_ptr<VecSimAllocator> allocator);
 
     VecSimQueryResult_List getNextResults(size_t n_res, VecSimQueryResult_Order order) override;

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -131,7 +131,7 @@ VecSimQueryResult_List HNSWIndex::topKQuery(const void *query_data, size_t k,
     }
 }
 
-VecSimIndexInfo HNSWIndex::info() {
+VecSimIndexInfo HNSWIndex::info() const {
 
     VecSimIndexInfo info;
     info.algo = VecSimAlgo_HNSWLIB;

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -149,7 +149,16 @@ VecSimIndexInfo HNSWIndex::info() const {
 }
 
 VecSimBatchIterator *HNSWIndex::newBatchIterator(const void *queryBlob) {
-    return new (this->allocator) HNSW_BatchIterator(queryBlob, this, this->allocator);
+    // As this is the only supported type, we always allocate 4 bytes for every element in the
+    // vector.
+    assert(this->vecType == VecSimType_FLOAT32);
+    auto *queryBlobCopy = this->allocator->allocate(sizeof(float) * this->dim);
+    memcpy(queryBlobCopy, queryBlob, dim * sizeof(float));
+    if (metric == VecSimMetric_Cosine) {
+        float_vector_normalize((float *)queryBlobCopy, dim);
+    }
+    // Ownership of queryBlobCopy moves to HNSW_BatchIterator that will free it at the end.
+    return new (this->allocator) HNSW_BatchIterator(queryBlobCopy, this, this->allocator);
 }
 
 VecSimInfoIterator *HNSWIndex::infoIterator() {

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
@@ -20,7 +20,7 @@ public:
                                             VecSimQueryParams *qparams) override;
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
-    virtual VecSimIndexInfo info() override;
+    virtual VecSimIndexInfo info() const override;
     virtual VecSimInfoIterator *infoIterator() override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob) override;
     bool preferAdHocSearch(size_t subsetSize, size_t k) override;

--- a/src/VecSim/batch_iterator.h
+++ b/src/VecSim/batch_iterator.h
@@ -9,15 +9,19 @@
  */
 struct VecSimBatchIterator : public VecsimBaseObject {
 private:
-    const void *query_vector;
+    void *query_vector_;
     size_t returned_results_count;
 
 public:
-    explicit VecSimBatchIterator(const void *query_vector,
+    explicit VecSimBatchIterator(const void *query_vector, size_t dim,
                                  std::shared_ptr<VecSimAllocator> allocator)
-        : VecsimBaseObject(allocator), query_vector(query_vector), returned_results_count(0){};
+        : VecsimBaseObject(allocator), returned_results_count(0){
+        // Assuming that every element in the vector has 4 bytes.
+        query_vector_ = allocator->allocate(dim * 4);
+        memcpy(this->query_vector_, query_vector, dim * 4);
+    };
 
-    inline const void *getQueryBlob() const { return query_vector; }
+    inline const void *getQueryBlob() const { return query_vector_; }
 
     inline size_t getResultsCount() const { return returned_results_count; }
 
@@ -35,5 +39,7 @@ public:
     // Reset the iterator to the initial state, before any results has been returned.
     virtual void reset() = 0;
 
-    virtual ~VecSimBatchIterator() = default;
+    virtual ~VecSimBatchIterator() {
+        allocator->free_allocation(this->query_vector_);
+    };
 };

--- a/src/VecSim/batch_iterator.h
+++ b/src/VecSim/batch_iterator.h
@@ -9,19 +9,14 @@
  */
 struct VecSimBatchIterator : public VecsimBaseObject {
 private:
-    void *query_vector_;
+    void *query_vector;
     size_t returned_results_count;
 
 public:
-    explicit VecSimBatchIterator(const void *query_vector, size_t dim,
-                                 std::shared_ptr<VecSimAllocator> allocator)
-        : VecsimBaseObject(allocator), returned_results_count(0){
-        // Assuming that every element in the vector has 4 bytes.
-        query_vector_ = allocator->allocate(dim * 4);
-        memcpy(this->query_vector_, query_vector, dim * 4);
-    };
+    explicit VecSimBatchIterator(void *query_vector, std::shared_ptr<VecSimAllocator> allocator)
+        : VecsimBaseObject(allocator), query_vector(query_vector), returned_results_count(0){};
 
-    inline const void *getQueryBlob() const { return query_vector_; }
+    inline const void *getQueryBlob() const { return query_vector; }
 
     inline size_t getResultsCount() const { return returned_results_count; }
 
@@ -39,7 +34,5 @@ public:
     // Reset the iterator to the initial state, before any results has been returned.
     virtual void reset() = 0;
 
-    virtual ~VecSimBatchIterator() {
-        allocator->free_allocation(this->query_vector_);
-    };
+    virtual ~VecSimBatchIterator() { allocator->free_allocation(this->query_vector); };
 };

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -80,24 +80,6 @@ extern "C" VecSimInfoIterator *VecSimIndex_InfoIterator(VecSimIndex *index) {
 }
 
 extern "C" VecSimBatchIterator *VecSimBatchIterator_New(VecSimIndex *index, const void *queryBlob) {
-    auto index_info = index->info();
-    size_t dim = 0; // initialize to 0, so that normalized_data array will not take space on stack.
-    bool normalization_required  = false;
-    if (index_info.algo == VecSimAlgo_HNSWLIB && index_info.hnswInfo.metric == VecSimMetric_Cosine) {
-        dim = index_info.hnswInfo.dim;
-        normalization_required = true;
-    }
-    if (index_info.algo == VecSimAlgo_BF && index_info.bfInfo.metric == VecSimMetric_Cosine) {
-        dim = index_info.bfInfo.dim;
-        normalization_required = true;
-    }
-    // If metric is cosine, normalize the vector and set the blob to it.
-    float normalized_data[dim];
-    if (normalization_required) {
-        memcpy(normalized_data, queryBlob, dim * sizeof(float));
-        float_vector_normalize(normalized_data, dim);
-        queryBlob = normalized_data;
-    }
     return index->newBatchIterator(queryBlob);
 }
 

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -80,6 +80,24 @@ extern "C" VecSimInfoIterator *VecSimIndex_InfoIterator(VecSimIndex *index) {
 }
 
 extern "C" VecSimBatchIterator *VecSimBatchIterator_New(VecSimIndex *index, const void *queryBlob) {
+    auto index_info = index->info();
+    size_t dim = 0; // initialize to 0, so that normalized_data array will not take space on stack.
+    bool normalization_required  = false;
+    if (index_info.algo == VecSimAlgo_HNSWLIB && index_info.hnswInfo.metric == VecSimMetric_Cosine) {
+        dim = index_info.hnswInfo.dim;
+        normalization_required = true;
+    }
+    if (index_info.algo == VecSimAlgo_BF && index_info.bfInfo.metric == VecSimMetric_Cosine) {
+        dim = index_info.bfInfo.dim;
+        normalization_required = true;
+    }
+    // If metric is cosine, normalize the vector and set the blob to it.
+    float normalized_data[dim];
+    if (normalization_required) {
+        memcpy(normalized_data, queryBlob, dim * sizeof(float));
+        float_vector_normalize(normalized_data, dim);
+        queryBlob = normalized_data;
+    }
     return index->newBatchIterator(queryBlob);
 }
 

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -90,7 +90,7 @@ public:
      *
      * @return Index general and specific meta-data.
      */
-    virtual VecSimIndexInfo info() = 0;
+    virtual VecSimIndexInfo info() const = 0;
 
     /**
      * @brief Returns an index information in an iterable structure.

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -1082,3 +1082,67 @@ TEST_F(BruteForceTest, batchIteratorSwapIndices) {
     VecSimBatchIterator_Free(batchIterator);
     VecSimIndex_Free(index);
 }
+
+
+TEST_F(BruteForceTest, testCosine) {
+    size_t dim = 128;
+    size_t n = 100;
+
+    VecSimParams params{.algo = VecSimAlgo_BF,
+            .bfParams = BFParams{.type = VecSimType_FLOAT32,
+                    .dim = dim,
+                    .metric = VecSimMetric_Cosine,
+                    .initialCapacity = n}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    for (size_t i = 1; i <= n; i++) {
+        float f[dim];
+        f[0] = (float)i/n;
+        for (size_t j = 1; j < dim; j++) {
+            f[j] = 1.0f;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    float query[dim];
+    for (size_t i = 0; i < dim; i++) {
+        query[i] = 1.0f;
+    }
+    auto verify_res = [&](size_t id, float score, size_t index) {
+        ASSERT_EQ(id, (n - index));
+        float first_coordinate = (float)id/n;
+        // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query vector and B is
+        // the current result vector.
+        float expected_score = 1.0f - ((first_coordinate + (float)dim - 1.0f) /
+                (sqrtf((float)dim) * sqrtf((float)(dim-1) + first_coordinate*first_coordinate)));
+        // Verify that abs difference between the actual and expected score is at most 1/10^6.
+        ASSERT_NEAR(score, expected_score, 1e-6);
+    };
+    runTopKSearchTest(index, query, 10, verify_res);
+
+    // Test with batch iterator.
+    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query);
+    size_t iteration_num = 0;
+
+    // get the 10 vectors whose ids are the maximal among those that hasn't been returned yet,
+    // in every iteration. The order should be from the largest to the lowest id.
+    size_t n_res = 10;
+    while (VecSimBatchIterator_HasNext(batchIterator)) {
+        std::vector<size_t> expected_ids(n_res);
+        auto verify_res_batch = [&](size_t id, float score, size_t index) {
+            ASSERT_EQ(id, (n - n_res*iteration_num - index));
+            float first_coordinate = (float)id/n;
+            // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query vector and B is
+            // the current result vector.
+            float expected_score = 1.0f - ((first_coordinate + (float)dim - 1.0f) /
+                                           (sqrtf((float)dim) * sqrtf((float)(dim-1) + first_coordinate*first_coordinate)));
+            // Verify that abs difference between the actual and expected score is at most 1/10^6.
+            ASSERT_NEAR(score, expected_score, 1e-6);
+        };
+        runBatchIteratorSearchTest(batchIterator, n_res, verify_res_batch);
+        iteration_num++;
+    }
+    ASSERT_EQ(iteration_num, n / n_res);
+    VecSimBatchIterator_Free(batchIterator);
+    VecSimIndex_Free(index);
+}

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -1083,21 +1083,20 @@ TEST_F(BruteForceTest, batchIteratorSwapIndices) {
     VecSimIndex_Free(index);
 }
 
-
 TEST_F(BruteForceTest, testCosine) {
     size_t dim = 128;
     size_t n = 100;
 
     VecSimParams params{.algo = VecSimAlgo_BF,
-            .bfParams = BFParams{.type = VecSimType_FLOAT32,
-                    .dim = dim,
-                    .metric = VecSimMetric_Cosine,
-                    .initialCapacity = n}};
+                        .bfParams = BFParams{.type = VecSimType_FLOAT32,
+                                             .dim = dim,
+                                             .metric = VecSimMetric_Cosine,
+                                             .initialCapacity = n}};
     VecSimIndex *index = VecSimIndex_New(&params);
 
     for (size_t i = 1; i <= n; i++) {
         float f[dim];
-        f[0] = (float)i/n;
+        f[0] = (float)i / n;
         for (size_t j = 1; j < dim; j++) {
             f[j] = 1.0f;
         }
@@ -1110,11 +1109,13 @@ TEST_F(BruteForceTest, testCosine) {
     }
     auto verify_res = [&](size_t id, float score, size_t index) {
         ASSERT_EQ(id, (n - index));
-        float first_coordinate = (float)id/n;
-        // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query vector and B is
-        // the current result vector.
-        float expected_score = 1.0f - ((first_coordinate + (float)dim - 1.0f) /
-                (sqrtf((float)dim) * sqrtf((float)(dim-1) + first_coordinate*first_coordinate)));
+        float first_coordinate = (float)id / n;
+        // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query vector
+        // and B is the current result vector.
+        float expected_score =
+            1.0f -
+            ((first_coordinate + (float)dim - 1.0f) /
+             (sqrtf((float)dim) * sqrtf((float)(dim - 1) + first_coordinate * first_coordinate)));
         // Verify that abs difference between the actual and expected score is at most 1/10^6.
         ASSERT_NEAR(score, expected_score, 1e-6);
     };
@@ -1130,12 +1131,14 @@ TEST_F(BruteForceTest, testCosine) {
     while (VecSimBatchIterator_HasNext(batchIterator)) {
         std::vector<size_t> expected_ids(n_res);
         auto verify_res_batch = [&](size_t id, float score, size_t index) {
-            ASSERT_EQ(id, (n - n_res*iteration_num - index));
-            float first_coordinate = (float)id/n;
-            // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query vector and B is
-            // the current result vector.
-            float expected_score = 1.0f - ((first_coordinate + (float)dim - 1.0f) /
-                                           (sqrtf((float)dim) * sqrtf((float)(dim-1) + first_coordinate*first_coordinate)));
+            ASSERT_EQ(id, (n - n_res * iteration_num - index));
+            float first_coordinate = (float)id / n;
+            // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query
+            // vector and B is the current result vector.
+            float expected_score =
+                1.0f - ((first_coordinate + (float)dim - 1.0f) /
+                        (sqrtf((float)dim) *
+                         sqrtf((float)(dim - 1) + first_coordinate * first_coordinate)));
             // Verify that abs difference between the actual and expected score is at most 1/10^6.
             ASSERT_NEAR(score, expected_score, 1e-6);
         };

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -1200,4 +1200,71 @@ TEST_F(HNSWLibTest, preferAdHocOptimization) {
         VecSimIndex_Free(index);
     }
 }
+
+TEST_F(HNSWLibTest, testCosine) {
+    size_t dim = 128;
+    size_t n = 100;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_Cosine,
+                                                 .initialCapacity = n}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    for (size_t i = 1; i <= n; i++) {
+        float f[dim];
+        f[0] = (float)i / n;
+        for (size_t j = 1; j < dim; j++) {
+            f[j] = 1.0f;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    float query[dim];
+    for (size_t i = 0; i < dim; i++) {
+        query[i] = 1.0f;
+    }
+    auto verify_res = [&](size_t id, float score, size_t index) {
+        ASSERT_EQ(id, (n - index));
+        float first_coordinate = (float)id / n;
+        // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query vector
+        // and B is the current result vector.
+        float expected_score =
+            1.0f -
+            ((first_coordinate + (float)dim - 1.0f) /
+             (sqrtf((float)dim) * sqrtf((float)(dim - 1) + first_coordinate * first_coordinate)));
+        // Verify that abs difference between the actual and expected score is at most 1/10^6.
+        ASSERT_NEAR(score, expected_score, 1e-6);
+    };
+    runTopKSearchTest(index, query, 10, verify_res);
+
+    // Test with batch iterator.
+    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query);
+    size_t iteration_num = 0;
+
+    // get the 10 vectors whose ids are the maximal among those that hasn't been returned yet,
+    // in every iteration. The order should be from the largest to the lowest id.
+    size_t n_res = 10;
+    while (VecSimBatchIterator_HasNext(batchIterator)) {
+        std::vector<size_t> expected_ids(n_res);
+        auto verify_res_batch = [&](size_t id, float score, size_t index) {
+            ASSERT_EQ(id, (n - n_res * iteration_num - index));
+            float first_coordinate = (float)id / n;
+            // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query
+            // vector and B is the current result vector.
+            float expected_score =
+                1.0f - ((first_coordinate + (float)dim - 1.0f) /
+                        (sqrtf((float)dim) *
+                         sqrtf((float)(dim - 1) + first_coordinate * first_coordinate)));
+            // Verify that abs difference between the actual and expected score is at most 1/10^6.
+            ASSERT_NEAR(score, expected_score, 1e-6);
+        };
+        runBatchIteratorSearchTest(batchIterator, n_res, verify_res_batch);
+        iteration_num++;
+    }
+    ASSERT_EQ(iteration_num, n / n_res);
+    VecSimBatchIterator_Free(batchIterator);
+    VecSimIndex_Free(index);
+}
 } // namespace hnswlib


### PR DESCRIPTION
This include copying the blob when creating batch iterator (as currently we were relying on external buffer that may change).
Unit tests for Cosine were added to both indexes. 