### PR TITLE
Fix bug in batch iterators for the case where batch_size=0

### DIFF
--- a/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
+++ b/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
@@ -127,8 +127,8 @@ VecSimQueryResult_List BF_BatchIterator::getNextResults(size_t n_res,
     assert((order == BY_ID || order == BY_SCORE) &&
            "Possible order values are only 'BY_ID' or 'BY_SCORE'");
     // Only in the first iteration we need to compute all the scores
-    if (getResultsCount() == 0) {
-        assert(this->scores.empty());
+    if (this->scores.empty()) {
+        assert(getResultsCount() == 0);
         this->scores.reserve(this->index->indexSize());
         vecsim_stl::vector<VectorBlock *> blocks = this->index->getVectorBlocks();
         for (auto &block : blocks) {

--- a/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
@@ -48,7 +48,8 @@ candidatesMaxHeap HNSW_BatchIterator::scanGraph(candidatesMinHeap &candidates,
     auto dist_func = this->space->get_dist_func();
 
     // In the first iteration, add the entry point to the empty candidates set.
-    if (this->getResultsCount() == 0) {
+    if (this->getResultsCount() == 0 && this->top_candidates_extras.empty() &&
+        this->candidates.empty()) {
         float dist =
             dist_func(this->getQueryBlob(), this->hnsw_index->getDataByInternalId(entry_point),
                       this->space->get_data_dim());

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -870,6 +870,24 @@ TEST_F(BruteForceTest, brute_force_batch_iterator_corner_cases) {
                                              .initialCapacity = n}};
     VecSimIndex *index = VecSimIndex_New(&params);
 
+    // query for (n,n,...,n) vector (recall that n is the largest id in te index)
+    float query[dim];
+    for (size_t j = 0; j < dim; j++) {
+        query[j] = (float)n;
+    }
+
+    // Create batch iterator for empty index.
+    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query);
+    // try to get more results even though there are no.
+    VecSimQueryResult_List res = VecSimBatchIterator_Next(batchIterator, 1, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    VecSimQueryResult_Free(res);
+    // retry to get results.
+    res = VecSimBatchIterator_Next(batchIterator, 1, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    VecSimQueryResult_Free(res);
+    VecSimBatchIterator_Free(batchIterator);
+
     for (size_t i = 0; i < n; i++) {
         float f[dim];
         for (size_t j = 0; j < dim; j++) {
@@ -879,14 +897,14 @@ TEST_F(BruteForceTest, brute_force_batch_iterator_corner_cases) {
     }
     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
 
-    // query for (n,n,...,n) vector (recall that n is the largest id in te index)
-    float query[dim];
-    for (size_t j = 0; j < dim; j++) {
-        query[j] = (float)n;
-    }
-    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query);
+    batchIterator = VecSimBatchIterator_New(index, query);
 
-    // get all in first iteration, expect to use select search
+    // Ask for zero results.
+    res = VecSimBatchIterator_Next(batchIterator, 0, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    VecSimQueryResult_Free(res);
+
+    // get all in first iteration, expect to use select search.
     size_t n_res = n;
     auto verify_res = [&](size_t id, float score, size_t index) {
         ASSERT_TRUE(id == n - 1 - index);
@@ -895,7 +913,7 @@ TEST_F(BruteForceTest, brute_force_batch_iterator_corner_cases) {
     ASSERT_FALSE(VecSimBatchIterator_HasNext(batchIterator));
 
     // try to get more results even though there are no.
-    VecSimQueryResult_List res = VecSimBatchIterator_Next(batchIterator, n_res, BY_SCORE);
+    res = VecSimBatchIterator_Next(batchIterator, n_res, BY_SCORE);
     ASSERT_EQ(VecSimQueryResult_Len(res), 0);
     VecSimQueryResult_Free(res);
 

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -916,12 +916,18 @@ TEST_F(HNSWLibTest, hnsw_batch_iterator_advanced) {
     }
     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
 
+    // Reset the iterator after it was depleted.
+    VecSimBatchIterator_Reset(batchIterator);
+
+    // Try to get 0 results.
+    res = VecSimBatchIterator_Next(batchIterator, 0, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    VecSimQueryResult_Free(res);
+
     // n_res does not divide into ef or vice versa - expect leftovers between the graph scans.
     size_t n_res = 7;
     size_t iteration_num = 0;
 
-    // Reset the iterator after it was depleted.
-    VecSimBatchIterator_Reset(batchIterator);
     while (VecSimBatchIterator_HasNext(batchIterator)) {
         iteration_num++;
         std::vector<size_t> expected_ids;
@@ -943,6 +949,11 @@ TEST_F(HNSWLibTest, hnsw_batch_iterator_advanced) {
         }
     }
     ASSERT_EQ(iteration_num, n / n_res + 1);
+    // Try to get more results even though there are no.
+    res = VecSimBatchIterator_Next(batchIterator, 1, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    VecSimQueryResult_Free(res);
+
     VecSimBatchIterator_Free(batchIterator);
     VecSimIndex_Free(index);
 }


### PR DESCRIPTION
In brute force - instead of asserting that we hadn't computed the scores when the number of returned results by the batch iterator is 0, we should assert that the number of returned results by the iterator is 0 if the scores hadn't been computed yet (otherwise, we crash after asking for 0 results).
In HNSW - we should insert the entry point node to the candidates heap only when both the returned results count is 0 and the `top_candidates_extra` queue is empty. Otherwise, we might get that the entry point will be returned twice (if we ask for 0 results, and moved the entry point to the `top_candidates_extra`, and then reinsert the entry point to the candidates).