### PR TITLE
HNSW blocksize param

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -19,7 +19,7 @@ BruteForceIndex::BruteForceIndex(const BFParams *params, std::shared_ptr<VecSimA
     : VecSimIndex(allocator), dim(params->dim), vecType(params->type), metric(params->metric),
       labelToIdLookup(allocator), idToVectorBlockMemberMapping(allocator), deletedIds(allocator),
       vectorBlocks(allocator),
-      vectorBlockSize(params->blockSize ? params->blockSize : BF_DEFAULT_BLOCK_SIZE), count(0),
+      vectorBlockSize(params->blockSize ? params->blockSize : DEFAULT_BLOCK_SIZE), count(0),
       space(params->metric == VecSimMetric_L2
                 ? static_cast<SpaceInterface<float> *>(new (allocator)
                                                            L2Space(params->dim, allocator))

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -150,6 +150,7 @@ VecSimIndexInfo HNSWIndex::info() const {
     info.hnswInfo.dim = this->dim;
     info.hnswInfo.type = this->vecType;
     info.hnswInfo.metric = this->metric;
+    info.hnswInfo.blockSize = this->blockSize;
     info.hnswInfo.M = this->hnsw->getM();
     info.hnswInfo.efConstruction = this->hnsw->getEfConstruction();
     info.hnswInfo.efRuntime = this->hnsw->getEf();

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -17,6 +17,7 @@ using namespace hnswlib;
 
 HNSWIndex::HNSWIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator)
     : VecSimIndex(allocator), dim(params->dim), vecType(params->type), metric(params->metric),
+      blockSize(params->blockSize ? params->blockSize : DEFAULT_BLOCK_SIZE),
       space(params->metric == VecSimMetric_L2
                 ? static_cast<SpaceInterface<float> *>(new (allocator)
                                                            L2Space(params->dim, allocator))
@@ -56,8 +57,7 @@ int HNSWIndex::addVector(const void *vector_data, size_t id) {
             vector_data = normalized_data;
         }
         if (hnsw->getIndexSize() == this->hnsw->getIndexCapacity()) {
-            this->hnsw->resizeIndex(
-                std::max<size_t>(std::ceil(this->hnsw->getIndexCapacity() * 1.1), 2));
+            this->hnsw->resizeIndex(this->hnsw->getIndexCapacity() + this->blockSize);
         }
         this->hnsw->addPoint(vector_data, id);
         return true;

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
@@ -9,6 +9,7 @@ protected:
     size_t dim;
     VecSimType vecType;
     VecSimMetric metric;
+    size_t blockSize;
 
 public:
     HNSWIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator);

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -114,6 +114,7 @@ typedef struct {
     union {
         struct {
             size_t indexSize;        // Current count of vectors.
+            size_t blockSize;        // Sets the amount to grow when resizing
             size_t M;                // Number of allowed edges per node in graph.
             size_t efConstruction;   // EF parameter for HNSW graph accuracy/latency for indexing.
             size_t efRuntime;        // EF parameter for HNSW graph accuracy/latency for search.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -7,10 +7,10 @@ extern "C" {
 #include <stdint.h>
 
 // HNSW default parameters
-#define HNSW_DEFAULT_M        16
-#define HNSW_DEFAULT_EF_C     200
-#define HNSW_DEFAULT_EF_RT    10
-#define BF_DEFAULT_BLOCK_SIZE 1024 * 1024
+#define HNSW_DEFAULT_M     16
+#define HNSW_DEFAULT_EF_C  200
+#define HNSW_DEFAULT_EF_RT 10
+#define DEFAULT_BLOCK_SIZE 100
 
 // Datatypes for indexing.
 typedef enum {
@@ -57,6 +57,7 @@ typedef struct {
     size_t dim;          // Vector's dimension.
     VecSimMetric metric; // Distance metric to use in the index.
     size_t initialCapacity;
+    size_t blockSize;
     size_t M;
     size_t efConstruction;
     size_t efRuntime;

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -391,7 +391,7 @@ TEST_F(BruteForceTest, test_bf_info) {
     ASSERT_EQ(info.algo, VecSimAlgo_BF);
     ASSERT_EQ(info.bfInfo.dim, d);
     // Default args
-    ASSERT_EQ(info.bfInfo.blockSize, BF_DEFAULT_BLOCK_SIZE);
+    ASSERT_EQ(info.bfInfo.blockSize, DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(info.bfInfo.indexSize, 0);
     VecSimIndex_Free(index);
 

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -331,17 +331,20 @@ TEST_F(HNSWLibTest, test_hnsw_info) {
     ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
     ASSERT_EQ(info.hnswInfo.dim, d);
     // Default args
+    ASSERT_EQ(info.hnswInfo.blockSize, DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(info.hnswInfo.M, HNSW_DEFAULT_M);
     ASSERT_EQ(info.hnswInfo.efConstruction, HNSW_DEFAULT_EF_C);
     ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
     VecSimIndex_Free(index);
 
     d = 1280;
+    size_t bs = 42;
     params = {.algo = VecSimAlgo_HNSWLIB,
               .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
                                        .dim = d,
                                        .metric = VecSimMetric_L2,
                                        .initialCapacity = n,
+                                       .blockSize = bs,
                                        .M = 200,
                                        .efConstruction = 1000,
                                        .efRuntime = 500}};
@@ -350,6 +353,7 @@ TEST_F(HNSWLibTest, test_hnsw_info) {
     ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
     ASSERT_EQ(info.hnswInfo.dim, d);
     // User args
+    ASSERT_EQ(info.hnswInfo.blockSize, bs);
     ASSERT_EQ(info.hnswInfo.efConstruction, 1000);
     ASSERT_EQ(info.hnswInfo.M, 200);
     ASSERT_EQ(info.hnswInfo.efRuntime, 500);

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -43,11 +43,13 @@ TEST_F(HNSWLibTest, hnswlib_vector_add_test) {
 TEST_F(HNSWLibTest, resizeIndex) {
     size_t dim = 4;
     size_t n = 15;
+    size_t bs = 50;
     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
                                                  .dim = dim,
                                                  .metric = VecSimMetric_L2,
-                                                 .initialCapacity = n}};
+                                                 .initialCapacity = n,
+                                                 .blockSize = bs}};
     VecSimIndex *index = VecSimIndex_New(&params);
     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
 
@@ -61,11 +63,10 @@ TEST_F(HNSWLibTest, resizeIndex) {
     ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(), n);
 
     // Add another vector, since index size equals to the capacity, this should cause resizing
-    // (by 10% factor from the index size).
+    // by the block size parameter.
     VecSimIndex_AddVector(index, (const void *)a, n + 1);
     ASSERT_EQ(VecSimIndex_IndexSize(index), n + 1);
-    ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(),
-              std::ceil(1.1 * n));
+    ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(), bs + n);
     VecSimIndex_Free(index);
 }
 


### PR DESCRIPTION
adding a new `blocksize` parameter, to set the number of new vectors we need to allocate memory for when we need to resize the index