### PR TITLE
Update hybrid policy status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,10 @@ jobs:
       - setup-centos
       - tiny-build-steps
 
-  build-centos8:
+  build-rocky8:
     resource_class: large
     docker:
-      - image: centos:centos7
+      - image: rockylinux:8
     steps:
       - setup-centos
       - tiny-build-steps
@@ -338,9 +338,9 @@ workflows:
           <<: *on-any-branch
       - build-xenial:
           <<: *on-any-branch
-      - build-centos7:
+      - build-rocky8:
           <<: *on-any-branch
-      - build-centos8:
+      - build-rocky8:
           <<: *on-any-branch
       - build-macos:
           <<: *on-any-branch

--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -355,6 +355,7 @@ bool BruteForceIndex::preferAdHocSearch(size_t subsetSize, size_t k, bool initia
         }
     }
     // Set the mode - if this isn't the initial check, we switched mode form batches to ad-hoc.
-    this->last_mode = res ? (initial_check ? HYBRID_ADHOC_BF : HYBRID_BATCHES_TO_ADHOC_BF) : HYBRID_BATCHES;
+    this->last_mode =
+        res ? (initial_check ? HYBRID_ADHOC_BF : HYBRID_BATCHES_TO_ADHOC_BF) : HYBRID_BATCHES;
     return res;
 }

--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -289,7 +289,7 @@ VecSimBatchIterator *BruteForceIndex::newBatchIterator(const void *queryBlob) {
     return new (this->allocator) BF_BatchIterator(queryBlobCopy, this, this->allocator);
 }
 
-bool BruteForceIndex::preferAdHocSearch(size_t subsetSize, size_t k) {
+bool BruteForceIndex::preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) {
     // This heuristic is based on sklearn decision tree classifier (with 10 leaves nodes) -
     // see scripts/BF_batches_clf.py
     size_t index_size = this->indexSize();
@@ -354,6 +354,7 @@ bool BruteForceIndex::preferAdHocSearch(size_t subsetSize, size_t k) {
             }
         }
     }
-    this->last_mode = res ? HYBRID_ADHOC_BF : HYBRID_BATCHES;
+    // Set the mode - if this isn't the initial check, we switched mode form batches to ad-hoc.
+    this->last_mode = res ? (initial_check ? HYBRID_ADHOC_BF : HYBRID_BATCHES_TO_ADHOC_BF) : HYBRID_BATCHES;
     return res;
 }

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -26,7 +26,7 @@ public:
     virtual VecSimIndexInfo info() const override;
     virtual VecSimInfoIterator *infoIterator() override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob) override;
-    bool preferAdHocSearch(size_t subsetSize, size_t k) override;
+    bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) override;
 
     inline vecsim_stl::vector<VectorBlock *> getVectorBlocks() const { return vectorBlocks; }
     inline DISTFUNC<float> distFunc() const { return dist_func; }

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -209,7 +209,7 @@ VecSimInfoIterator *HNSWIndex::infoIterator() {
     return infoIterator;
 }
 
-bool HNSWIndex::preferAdHocSearch(size_t subsetSize, size_t k) {
+bool HNSWIndex::preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) {
     // This heuristic is based on sklearn decision tree classifier (with 20 leaves nodes) -
     // see scripts/HNSW_batches_clf.py
     size_t index_size = this->indexSize();
@@ -337,6 +337,7 @@ bool HNSWIndex::preferAdHocSearch(size_t subsetSize, size_t k) {
             }
         }
     }
-    this->last_mode = res ? HYBRID_ADHOC_BF : HYBRID_BATCHES;
+    // Set the mode - if this isn't the initial check, we switched mode form batches to ad-hoc.
+    this->last_mode = res ? (initial_check ? HYBRID_ADHOC_BF : HYBRID_BATCHES_TO_ADHOC_BF) : HYBRID_BATCHES;
     return res;
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -338,6 +338,7 @@ bool HNSWIndex::preferAdHocSearch(size_t subsetSize, size_t k, bool initial_chec
         }
     }
     // Set the mode - if this isn't the initial check, we switched mode form batches to ad-hoc.
-    this->last_mode = res ? (initial_check ? HYBRID_ADHOC_BF : HYBRID_BATCHES_TO_ADHOC_BF) : HYBRID_BATCHES;
+    this->last_mode =
+        res ? (initial_check ? HYBRID_ADHOC_BF : HYBRID_BATCHES_TO_ADHOC_BF) : HYBRID_BATCHES;
     return res;
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
@@ -23,7 +23,7 @@ public:
     virtual VecSimIndexInfo info() const override;
     virtual VecSimInfoIterator *infoIterator() override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob) override;
-    bool preferAdHocSearch(size_t subsetSize, size_t k) override;
+    bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) override;
 
     void setEf(size_t ef);
     inline std::shared_ptr<hnswlib::HierarchicalNSW<float>> getHNSWIndex() { return hnsw; }

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -119,6 +119,8 @@ const char *VecSimSearchMode_ToString(VecSearchMode vecsimSearchMode) {
         return "HYBRID_ADHOC_BF";
     case HYBRID_BATCHES:
         return "HYBRID_BATCHES";
+    case HYBRID_BATCHES_TO_ADHOC_BF:
+        return "HYBRID_BATCHES_TO_ADHOC_BF";
     default:
         return NULL;
     }

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -93,6 +93,7 @@ extern "C" void VecSim_SetMemoryFunctions(VecSimMemoryFunctions memoryfunctions)
     VecSimAllocator::setMemoryFunctions(memoryfunctions);
 }
 
-extern "C" bool VecSimIndex_PreferAdHocSearch(VecSimIndex *index, size_t subsetSize, size_t k) {
-    return index->preferAdHocSearch(subsetSize, k);
+extern "C" bool VecSimIndex_PreferAdHocSearch(VecSimIndex *index, size_t subsetSize, size_t k,
+                                              bool initial_check) {
+    return index->preferAdHocSearch(subsetSize, k, initial_check);
 }

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -139,7 +139,8 @@ VecSimBatchIterator *VecSimBatchIterator_New(VecSimIndex *index, const void *que
  * @param initial_check flag to indicate if this check is performed for the first time (upon
  * creating the hybrid iterator), or after running batches.
  */
-bool VecSimIndex_PreferAdHocSearch(VecSimIndex *index, size_t subsetSize, size_t k, bool initial_check);
+bool VecSimIndex_PreferAdHocSearch(VecSimIndex *index, size_t subsetSize, size_t k,
+                                   bool initial_check);
 
 /**
  * @brief Allow 3rd party memory functions to be used for memory management.

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -135,8 +135,11 @@ VecSimBatchIterator *VecSimBatchIterator_New(VecSimIndex *index, const void *que
  * (that is, query results can be only from a subset of vector of this size).
  *
  * @param k the number of required results to return from the query.
+ *
+ * @param initial_check flag to indicate if this check is performed for the first time (upon
+ * creating the hybrid iterator), or after running batches.
  */
-bool VecSimIndex_PreferAdHocSearch(VecSimIndex *index, size_t subsetSize, size_t k);
+bool VecSimIndex_PreferAdHocSearch(VecSimIndex *index, size_t subsetSize, size_t k, bool initial_check);
 
 /**
  * @brief Allow 3rd party memory functions to be used for memory management.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -97,12 +97,13 @@ typedef struct {
  *
  */
 typedef enum {
-    EMPTY_MODE,      // Default value to initialize the "last_mode" field with.
-    STANDARD_KNN,    // Run k-nn query over the entire vector index.
-    HYBRID_ADHOC_BF, // Measure ad-hoc the distance for every result that passes the filters,
-                     // and take the top k results.
-    HYBRID_BATCHES   // Get the top vector results in batches upon demand, and keep the results that
-                     // passes the filters until we reach k results.
+    EMPTY_MODE,                 // Default value to initialize the "last_mode" field with.
+    STANDARD_KNN,               // Run k-nn query over the entire vector index.
+    HYBRID_ADHOC_BF,            // Measure ad-hoc the distance for every result that passes the filters,
+                                // and take the top k results.
+    HYBRID_BATCHES,             // Get the top vector results in batches upon demand, and keep the results that
+                                // passes the filters until we reach k results.
+    HYBRID_BATCHES_TO_ADHOC_BF  // Start with batches and dynamically switched to ad-hoc BF.
 } VecSearchMode;
 
 /**

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -97,13 +97,13 @@ typedef struct {
  *
  */
 typedef enum {
-    EMPTY_MODE,                 // Default value to initialize the "last_mode" field with.
-    STANDARD_KNN,               // Run k-nn query over the entire vector index.
-    HYBRID_ADHOC_BF,            // Measure ad-hoc the distance for every result that passes the filters,
-                                // and take the top k results.
-    HYBRID_BATCHES,             // Get the top vector results in batches upon demand, and keep the results that
-                                // passes the filters until we reach k results.
-    HYBRID_BATCHES_TO_ADHOC_BF  // Start with batches and dynamically switched to ad-hoc BF.
+    EMPTY_MODE,      // Default value to initialize the "last_mode" field with.
+    STANDARD_KNN,    // Run k-nn query over the entire vector index.
+    HYBRID_ADHOC_BF, // Measure ad-hoc the distance for every result that passes the filters,
+                     // and take the top k results.
+    HYBRID_BATCHES,  // Get the top vector results in batches upon demand, and keep the results that
+                     // passes the filters until we reach k results.
+    HYBRID_BATCHES_TO_ADHOC_BF // Start with batches and dynamically switched to ad-hoc BF.
 } VecSearchMode;
 
 /**

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -118,6 +118,10 @@ public:
      * (that is, query results can be only from a subset of vector of this size).
      *
      * @param k the number of required results to return from the query.
+     *
+     * @param initial_check flag to indicate if this check is performed for the first time (upon
+     * creating the hybrid iterator), or after running batches.
      */
-    virtual bool preferAdHocSearch(size_t subsetSize, size_t k) = 0;
+
+    virtual bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) = 0;
 };

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -492,6 +492,15 @@ TEST_F(BruteForceTest, test_dynamic_bf_info_iterator) {
     compareFlatIndexInfoToIterator(info, infoIter);
     VecSimInfoIterator_Free(infoIter);
 
+    // Simulate the case where another call to the heuristics is done after realizing that
+    // the subset size is smaller, and change the policy as a result.
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 1, 1, false));
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(HYBRID_BATCHES_TO_ADHOC_BF, info.bfInfo.last_mode);
+    compareFlatIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
     VecSimIndex_Free(index);
 }
 

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -476,7 +476,7 @@ TEST_F(BruteForceTest, test_dynamic_bf_info_iterator) {
     compareFlatIndexInfoToIterator(info, infoIter);
     VecSimInfoIterator_Free(infoIter);
 
-    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 1, 1));
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 1, 1, true));
     info = VecSimIndex_Info(index);
     infoIter = VecSimIndex_InfoIterator(index);
     ASSERT_EQ(HYBRID_ADHOC_BF, info.bfInfo.last_mode);
@@ -485,7 +485,7 @@ TEST_F(BruteForceTest, test_dynamic_bf_info_iterator) {
 
     // Set the index size artificially so that BATCHES mode will be selected by the heuristics.
     reinterpret_cast<BruteForceIndex *>(index)->count = 1e4;
-    ASSERT_FALSE(VecSimIndex_PreferAdHocSearch(index, 7e3, 1));
+    ASSERT_FALSE(VecSimIndex_PreferAdHocSearch(index, 7e3, 1, true));
     info = VecSimIndex_Info(index);
     infoIter = VecSimIndex_InfoIterator(index);
     ASSERT_EQ(HYBRID_BATCHES, info.bfInfo.last_mode);
@@ -1085,7 +1085,7 @@ TEST_F(BruteForceTest, preferAdHocOptimization) {
             reinterpret_cast<BruteForceIndex *>(index)->count = index_size;
             ASSERT_EQ(VecSimIndex_IndexSize(index), index_size);
             for (float r : {0.1f, 0.3f, 0.5f, 0.7f, 0.9f}) {
-                bool res = VecSimIndex_PreferAdHocSearch(index, (size_t)(r * index_size), 50);
+                bool res = VecSimIndex_PreferAdHocSearch(index, (size_t)(r * index_size), 50, true);
                 // If r is below the threshold for this specific configuration of (index_size, dim),
                 // expect that result will be ad-hoc (i.e., true), and otherwise, batches (i.e.,
                 // false)
@@ -1100,11 +1100,11 @@ TEST_F(BruteForceTest, preferAdHocOptimization) {
         .algo = VecSimAlgo_BF,
         .bfParams = BFParams{.type = VecSimType_FLOAT32, .dim = 4, .metric = VecSimMetric_IP}};
     VecSimIndex *index = VecSimIndex_New(&params);
-    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 0, 50));
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 0, 50, true));
 
     // Corner cases - subset size is greater than index size.
     try {
-        VecSimIndex_PreferAdHocSearch(index, 1, 50);
+        VecSimIndex_PreferAdHocSearch(index, 1, 50, true);
         FAIL() << "Expected std::runtime error";
     } catch (std::runtime_error const &err) {
         EXPECT_EQ(err.what(),

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -446,6 +446,15 @@ TEST_F(HNSWLibTest, test_dynamic_hnsw_info_iterator) {
     compareHNSWIndexInfoToIterator(info, infoIter);
     VecSimInfoIterator_Free(infoIter);
 
+    // Simulate the case where another call to the heuristics is done after realizing that
+    // the subset size is smaller, and change the policy as a result.
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 1, 10, false));
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(HYBRID_BATCHES_TO_ADHOC_BF, info.hnswInfo.last_mode);
+    compareHNSWIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
     VecSimIndex_Free(index);
 }
 

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -430,7 +430,7 @@ TEST_F(HNSWLibTest, test_dynamic_hnsw_info_iterator) {
     compareHNSWIndexInfoToIterator(info, infoIter);
     VecSimInfoIterator_Free(infoIter);
 
-    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 1, 1));
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 1, 1, true));
     info = VecSimIndex_Info(index);
     infoIter = VecSimIndex_InfoIterator(index);
     ASSERT_EQ(HYBRID_ADHOC_BF, info.hnswInfo.last_mode);
@@ -439,7 +439,7 @@ TEST_F(HNSWLibTest, test_dynamic_hnsw_info_iterator) {
 
     // Set the index size artificially so that BATCHES mode will be selected by the heuristics.
     reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->cur_element_count = 1e6;
-    ASSERT_FALSE(VecSimIndex_PreferAdHocSearch(index, 10, 1));
+    ASSERT_FALSE(VecSimIndex_PreferAdHocSearch(index, 10, 1, true));
     info = VecSimIndex_Info(index);
     infoIter = VecSimIndex_InfoIterator(index);
     ASSERT_EQ(HYBRID_BATCHES, info.hnswInfo.last_mode);
@@ -1265,7 +1265,7 @@ TEST_F(HNSWLibTest, preferAdHocOptimization) {
         // Set the index size artificially to be the required one.
         reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->cur_element_count = index_size;
         ASSERT_EQ(VecSimIndex_IndexSize(index), index_size);
-        bool res = VecSimIndex_PreferAdHocSearch(index, (size_t)(r * (float)index_size), k);
+        bool res = VecSimIndex_PreferAdHocSearch(index, (size_t)(r * (float)index_size), k, true);
         ASSERT_EQ(res, comb.second);
         VecSimIndex_Free(index);
     }
@@ -1274,11 +1274,11 @@ TEST_F(HNSWLibTest, preferAdHocOptimization) {
         .algo = VecSimAlgo_HNSWLIB,
         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32, .dim = 4, .metric = VecSimMetric_L2}};
     VecSimIndex *index = VecSimIndex_New(&params);
-    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 0, 50));
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 0, 50, true));
 
     // Corner cases - subset size is greater than index size.
     try {
-        VecSimIndex_PreferAdHocSearch(index, 1, 50);
+        VecSimIndex_PreferAdHocSearch(index, 1, 50, true);
         FAIL() << "Expected std::runtime error";
     } catch (std::runtime_error const &err) {
         EXPECT_EQ(err.what(),


### PR DESCRIPTION
Add the HYBRID_BATCHES_TO_ADHOC_BF option the VecSearchMode enum, and set this status when changing from BATCHES to AD-HOC BF after executing batches (for info)