### PR TITLE
Optional runtime params for hybrid queries

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -179,37 +179,40 @@ size_t BruteForceIndex::indexSize() const { return this->count; }
 
 VecSimResolveCode BruteForceIndex::resolveParams(VecSimRawParam *rparams, int paramNum,
                                                  VecSimQueryParams *qparams) {
-	if (!qparams || (!rparams && (paramNum != 0))) {
-		return VecSimParamResolverErr_NullParam;
-	}
-	bzero(qparams, sizeof(VecSimQueryParams));
-	long long num_val;
-	for (int i = 0; i < paramNum; i++) {
-		if (!strcasecmp(rparams[i].name, VecSimCommonStrings::BATCH_SIZE_STRING)) {
-			if (qparams->batchSize != 0) {
-				return VecSimParamResolverErr_AlreadySet;
-			}
-			if (validate_numeric_param(rparams[i], &num_val) != VecSimParamResolver_OK) {
-				return VecSimParamResolverErr_BadValue;
-			}
-			qparams->batchSize = (size_t)num_val;
-		} else if (!strcasecmp(rparams[i].name, VecSimCommonStrings::HYBRID_POLICY_STRING)) {
-			if (!strcasecmp(rparams[i].value, "batches")) {
-				qparams->searchMode = HYBRID_BATCHES;
-			} else if (!strcasecmp(rparams[i].value, "adhoc_bf")) {
-				qparams->searchMode = HYBRID_ADHOC_BF;
-			} else {
-				return VecSimParamResolverErr_InvalidPolicy;
-			}
-		} else {
-			return VecSimParamResolverErr_UnknownParam;
-		}
-	}
-	// The combination of AD-HOC with batch_size is invalid, as there are no batches in this policy.
-	if (qparams->searchMode == HYBRID_ADHOC_BF && qparams->batchSize > 0) {
-		return VecSimParamResolverErr_InvalidPolicy;
-	}
-	return (VecSimResolveCode)VecSim_OK;
+    if (!qparams || (!rparams && (paramNum != 0))) {
+        return VecSimParamResolverErr_NullParam;
+    }
+    bzero(qparams, sizeof(VecSimQueryParams));
+    long long num_val;
+    for (int i = 0; i < paramNum; i++) {
+        if (!strcasecmp(rparams[i].name, VecSimCommonStrings::BATCH_SIZE_STRING)) {
+            if (qparams->batchSize != 0) {
+                return VecSimParamResolverErr_AlreadySet;
+            }
+            if (validate_numeric_param(rparams[i], &num_val) != VecSimParamResolver_OK) {
+                return VecSimParamResolverErr_BadValue;
+            }
+            qparams->batchSize = (size_t)num_val;
+        } else if (!strcasecmp(rparams[i].name, VecSimCommonStrings::HYBRID_POLICY_STRING)) {
+            if (qparams->searchMode != 0) {
+                return VecSimParamResolverErr_AlreadySet;
+            }
+            if (!strcasecmp(rparams[i].value, "batches")) {
+                qparams->searchMode = HYBRID_BATCHES;
+            } else if (!strcasecmp(rparams[i].value, "adhoc_bf")) {
+                qparams->searchMode = HYBRID_ADHOC_BF;
+            } else {
+                return VecSimParamResolverErr_InvalidPolicy;
+            }
+        } else {
+            return VecSimParamResolverErr_UnknownParam;
+        }
+    }
+    // The combination of AD-HOC with batch_size is invalid, as there are no batches in this policy.
+    if (qparams->searchMode == HYBRID_ADHOC_BF && qparams->batchSize > 0) {
+        return VecSimParamResolverErr_InvalidPolicy;
+    }
+    return (VecSimResolveCode)VecSim_OK;
 }
 
 VecSimQueryResult_List BruteForceIndex::topKQuery(const void *queryBlob, size_t k,

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -74,43 +74,46 @@ VecSimResolveCode HNSWIndex::resolveParams(VecSimRawParam *rparams, int paramNum
         return VecSimParamResolverErr_NullParam;
     }
     bzero(qparams, sizeof(VecSimQueryParams));
-	long long num_val;
+    long long num_val;
     for (int i = 0; i < paramNum; i++) {
         if (!strcasecmp(rparams[i].name, VecSimCommonStrings::HNSW_EF_RUNTIME_STRING)) {
             if (qparams->hnswRuntimeParams.efRuntime != 0) {
-	            return VecSimParamResolverErr_AlreadySet;
+                return VecSimParamResolverErr_AlreadySet;
             }
             if (validate_numeric_param(rparams[i], &num_val) != VecSimParamResolver_OK) {
-	            return VecSimParamResolverErr_BadValue;
-			}
-			qparams->hnswRuntimeParams.efRuntime = (size_t)num_val;
+                return VecSimParamResolverErr_BadValue;
+            }
+            qparams->hnswRuntimeParams.efRuntime = (size_t)num_val;
         } else if (!strcasecmp(rparams[i].name, VecSimCommonStrings::BATCH_SIZE_STRING)) {
             if (qparams->batchSize != 0) {
-	            return VecSimParamResolverErr_AlreadySet;
+                return VecSimParamResolverErr_AlreadySet;
             }
             if (validate_numeric_param(rparams[i], &num_val) != VecSimParamResolver_OK) {
-	            return VecSimParamResolverErr_BadValue;
+                return VecSimParamResolverErr_BadValue;
             }
             qparams->batchSize = (size_t)num_val;
-		} else if (!strcasecmp(rparams[i].name, VecSimCommonStrings::HYBRID_POLICY_STRING)) {
-	        if (qparams->searchMode != 0) {
-		        return VecSimParamResolverErr_AlreadySet;
-	        }
-			if (!strcasecmp(rparams[i].value, "batches")) {
-				qparams->searchMode = HYBRID_BATCHES;
-			} else if (!strcasecmp(rparams[i].value, "adhoc_bf")) {
-				qparams->searchMode = HYBRID_ADHOC_BF;
-			} else {
-				return VecSimParamResolverErr_InvalidPolicy;
-			}
-		} else {
+        } else if (!strcasecmp(rparams[i].name, VecSimCommonStrings::HYBRID_POLICY_STRING)) {
+            if (qparams->searchMode != 0) {
+                return VecSimParamResolverErr_AlreadySet;
+            }
+            if (!strcasecmp(rparams[i].value, "batches")) {
+                qparams->searchMode = HYBRID_BATCHES;
+            } else if (!strcasecmp(rparams[i].value, "adhoc_bf")) {
+                qparams->searchMode = HYBRID_ADHOC_BF;
+            } else {
+                return VecSimParamResolverErr_InvalidPolicy;
+            }
+        } else {
             return VecSimParamResolverErr_UnknownParam;
         }
     }
-	// The combination of AD-HOC with batch_size is invalid, as there are no batches in this policy.
-	if (qparams->searchMode == HYBRID_ADHOC_BF && qparams->batchSize > 0) {
-		return VecSimParamResolverErr_InvalidPolicy;
-	}
+    // The combination of AD-HOC with batch_size is invalid, as there are no batches in this policy.
+    // Also, 'ef_runtime' is meaning less in AD-HOC policy, since it doesn't involve search in HNSW
+    // graph.
+    if (qparams->searchMode == HYBRID_ADHOC_BF &&
+        (qparams->batchSize > 0 || qparams->hnswRuntimeParams.efRuntime > 0)) {
+        return VecSimParamResolverErr_InvalidPolicy;
+    }
     return (VecSimResolveCode)VecSim_OK;
 }
 

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -2,6 +2,8 @@
 #include "VecSim/query_result_struct.h"
 #include <cmath>
 #include <cassert>
+#include <cerrno>
+#include <climits>
 
 #ifndef __COMPAR_FN_T
 #define __COMPAR_FN_T
@@ -35,6 +37,9 @@ const char *VecSimCommonStrings::HNSW_ENTRYPOINT = "ENTRYPOINT";
 
 const char *VecSimCommonStrings::BLOCK_SIZE_STRING = "BLOCK_SIZE";
 const char *VecSimCommonStrings::SEARCH_MODE_STRING = "LAST_SEARCH_MODE";
+const char *VecSimCommonStrings::HYBRID_POLICY_STRING = "HYBRID_POLICY";
+const char *VecSimCommonStrings::BATCH_SIZE_STRING = "BATCH_SIZE";
+
 
 int cmpVecSimQueryResultById(const VecSimQueryResult *res1, const VecSimQueryResult *res2) {
     return (int)(VecSimQueryResult_GetId(res1) - VecSimQueryResult_GetId(res2));
@@ -68,6 +73,20 @@ void sort_results_by_id(VecSimQueryResult_List results) {
 void sort_results_by_score(VecSimQueryResult_List results) {
     qsort(results, VecSimQueryResult_Len(results), sizeof(VecSimQueryResult),
           (__compar_fn_t)cmpVecSimQueryResultByScore);
+}
+
+VecSimResolveCode validate_numeric_param(VecSimRawParam rawParam, long long *val) {
+	char *ep; // For checking that strtoll used all rawParam.valLen chars.
+	errno = 0;
+	*val = strtoll(rawParam.value, &ep, 0);
+	// Here we verify that val is positive and strtoll was successful.
+	// The last test checks that the entire rawParam.value was used.
+	// We catch here inputs like "3.14", "123text" and so on.
+	if (*val <= 0 || *val == LLONG_MAX || errno != 0 ||
+	    (rawParam.value + rawParam.valLen) != ep) {
+		return VecSimParamResolverErr_BadValue;
+	}
+	return VecSimParamResolver_OK;
 }
 
 const char *VecSimAlgo_ToString(VecSimAlgo vecsimAlgo) {

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -40,7 +40,6 @@ const char *VecSimCommonStrings::SEARCH_MODE_STRING = "LAST_SEARCH_MODE";
 const char *VecSimCommonStrings::HYBRID_POLICY_STRING = "HYBRID_POLICY";
 const char *VecSimCommonStrings::BATCH_SIZE_STRING = "BATCH_SIZE";
 
-
 int cmpVecSimQueryResultById(const VecSimQueryResult *res1, const VecSimQueryResult *res2) {
     return (int)(VecSimQueryResult_GetId(res1) - VecSimQueryResult_GetId(res2));
 }
@@ -76,17 +75,16 @@ void sort_results_by_score(VecSimQueryResult_List results) {
 }
 
 VecSimResolveCode validate_numeric_param(VecSimRawParam rawParam, long long *val) {
-	char *ep; // For checking that strtoll used all rawParam.valLen chars.
-	errno = 0;
-	*val = strtoll(rawParam.value, &ep, 0);
-	// Here we verify that val is positive and strtoll was successful.
-	// The last test checks that the entire rawParam.value was used.
-	// We catch here inputs like "3.14", "123text" and so on.
-	if (*val <= 0 || *val == LLONG_MAX || errno != 0 ||
-	    (rawParam.value + rawParam.valLen) != ep) {
-		return VecSimParamResolverErr_BadValue;
-	}
-	return VecSimParamResolver_OK;
+    char *ep; // For checking that strtoll used all rawParam.valLen chars.
+    errno = 0;
+    *val = strtoll(rawParam.value, &ep, 0);
+    // Here we verify that val is positive and strtoll was successful.
+    // The last test checks that the entire rawParam.value was used.
+    // We catch here inputs like "3.14", "123text" and so on.
+    if (*val <= 0 || *val == LLONG_MAX || errno != 0 || (rawParam.value + rawParam.valLen) != ep) {
+        return VecSimParamResolverErr_BadValue;
+    }
+    return VecSimParamResolver_OK;
 }
 
 const char *VecSimAlgo_ToString(VecSimAlgo vecsimAlgo) {

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -42,6 +42,8 @@ public:
 
     static const char *BLOCK_SIZE_STRING;
     static const char *SEARCH_MODE_STRING;
+	static const char *HYBRID_POLICY_STRING;
+	static const char *BATCH_SIZE_STRING;
 };
 
 void float_vector_normalize(float *x, size_t dim);
@@ -49,6 +51,8 @@ void float_vector_normalize(float *x, size_t dim);
 void sort_results_by_id(VecSimQueryResult_List results);
 
 void sort_results_by_score(VecSimQueryResult_List results);
+
+VecSimResolveCode validate_numeric_param(VecSimRawParam rawParam, long long *val);
 
 const char *VecSimAlgo_ToString(VecSimAlgo vecsimAlgo);
 

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -42,8 +42,8 @@ public:
 
     static const char *BLOCK_SIZE_STRING;
     static const char *SEARCH_MODE_STRING;
-	static const char *HYBRID_POLICY_STRING;
-	static const char *BATCH_SIZE_STRING;
+    static const char *HYBRID_POLICY_STRING;
+    static const char *BATCH_SIZE_STRING;
 };
 
 void float_vector_normalize(float *x, size_t dim);

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -46,7 +46,7 @@ typedef enum {
     VecSimParamResolverErr_AlreadySet,
     VecSimParamResolverErr_UnknownParam,
     VecSimParamResolverErr_BadValue,
-	VecSimParamResolverErr_InvalidPolicy
+    VecSimParamResolverErr_InvalidPolicy
 } VecSimResolveCode;
 
 /**
@@ -88,12 +88,12 @@ typedef struct {
  *
  */
 typedef enum {
-	EMPTY_MODE,      // Default value to initialize the "last_mode" field with.
-	STANDARD_KNN,    // Run k-nn query over the entire vector index.
-	HYBRID_ADHOC_BF, // Measure ad-hoc the distance for every result that passes the filters,
-	// and take the top k results.
-	HYBRID_BATCHES   // Get the top vector results in batches upon demand, and keep the results that
-	// passes the filters until we reach k results.
+    EMPTY_MODE,      // Default value to initialize the "last_mode" field with.
+    STANDARD_KNN,    // Run k-nn query over the entire vector index.
+    HYBRID_ADHOC_BF, // Measure ad-hoc the distance for every result that passes the filters,
+    // and take the top k results.
+    HYBRID_BATCHES // Get the top vector results in batches upon demand, and keep the results that
+                   // passes the filters until we reach k results.
 } VecSearchMode;
 
 /**
@@ -104,10 +104,9 @@ typedef struct {
     union {
         HNSWRuntimeParams hnswRuntimeParams;
     };
-	size_t batchSize;
-	VecSearchMode searchMode;
+    size_t batchSize;
+    VecSearchMode searchMode;
 } VecSimQueryParams;
-
 
 /**
  * @brief Index information. Mainly used for debug/testing.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -45,7 +45,8 @@ typedef enum {
     VecSimParamResolverErr_NullParam,
     VecSimParamResolverErr_AlreadySet,
     VecSimParamResolverErr_UnknownParam,
-    VecSimParamResolverErr_BadValue
+    VecSimParamResolverErr_BadValue,
+	VecSimParamResolverErr_InvalidPolicy
 } VecSimResolveCode;
 
 /**
@@ -83,6 +84,19 @@ typedef struct {
 } HNSWRuntimeParams;
 
 /**
+ * @brief Query runtime information - the search mode in RediSearch (used for debug/testing).
+ *
+ */
+typedef enum {
+	EMPTY_MODE,      // Default value to initialize the "last_mode" field with.
+	STANDARD_KNN,    // Run k-nn query over the entire vector index.
+	HYBRID_ADHOC_BF, // Measure ad-hoc the distance for every result that passes the filters,
+	// and take the top k results.
+	HYBRID_BATCHES   // Get the top vector results in batches upon demand, and keep the results that
+	// passes the filters until we reach k results.
+} VecSearchMode;
+
+/**
  * @brief Query Runtime parameters.
  *
  */
@@ -90,20 +104,10 @@ typedef struct {
     union {
         HNSWRuntimeParams hnswRuntimeParams;
     };
+	size_t batchSize;
+	VecSearchMode searchMode;
 } VecSimQueryParams;
 
-/**
- * @brief Query runtime information - the search mode in RediSearch (used for debug/testing).
- *
- */
-typedef enum {
-    EMPTY_MODE,      // Default value to initialize the "last_mode" field with.
-    STANDARD_KNN,    // Run k-nn query over the entire vector index.
-    HYBRID_ADHOC_BF, // Measure ad-hoc the distance for every result that passes the filters,
-                     // and take the top k results.
-    HYBRID_BATCHES   // Get the top vector results in batches upon demand, and keep the results that
-                     // passes the filters until we reach k results.
-} VecSearchMode;
 
 /**
  * @brief Index information. Mainly used for debug/testing.

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -1049,37 +1049,78 @@ TEST_F(HNSWLibTest, hnsw_resolve_params) {
     ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), NULL),
               VecSimParamResolverErr_NullParam);
 
-	// Testing with hybrid query params.
-	rparams[1] = (VecSimRawParam){.name = "HYBRID_POLICY", .nameLen = strlen("HYBRID_POLICY"),
-								  .value = "batches_wrong", .valLen = strlen("batches_wrong")};
-	ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-		          VecSimParamResolverErr_InvalidPolicy);
-	rparams[1].value = "batches";
-	rparams[1].valLen = strlen("batches");
-	ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSim_OK);
+    // Testing with hybrid query params.
+    rparams[1] = (VecSimRawParam){.name = "HYBRID_POLICY",
+                                  .nameLen = strlen("HYBRID_POLICY"),
+                                  .value = "batches_wrong",
+                                  .valLen = strlen("batches_wrong")};
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimParamResolverErr_InvalidPolicy);
+    rparams[1].value = "batches";
+    rparams[1].valLen = strlen("batches");
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSim_OK);
+    ASSERT_EQ(qparams.searchMode, HYBRID_BATCHES);
 
-	rparams[0] = (VecSimRawParam){.name = "HYBRID_POLICY", .nameLen = strlen("HYBRID_POLICY"),
-				.value = "batches", .valLen = strlen("batches")};
-	ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-	          VecSimParamResolverErr_AlreadySet);
+    // Both params are "hybrid policy".
+    rparams[0] = (VecSimRawParam){.name = "HYBRID_POLICY",
+                                  .nameLen = strlen("HYBRID_POLICY"),
+                                  .value = "ADhOC_bf",
+                                  .valLen = strlen("ADhOC_bf")};
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimParamResolverErr_AlreadySet);
 
-	rparams[1] = (VecSimRawParam){.name = "HYBRID_POLICY", .nameLen = strlen("HYBRID_POLICY"),
-				.value = "AD_hOC", .valLen = strlen("AD_hOC")};
-	ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-		          VecSimParamResolverErr_AlreadySet);
+    // Sending HYBRID_POLICY=adhoc as the single parameter is valid.
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, 1, &qparams), VecSim_OK);
+    ASSERT_EQ(qparams.searchMode, HYBRID_ADHOC_BF);
 
-	rparams[0] = (VecSimRawParam){.name = "batch_size", .nameLen = strlen("batch_size"),
-				.value = "10", .valLen = strlen("10")};
-	ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
-	          VecSimParamResolverErr_InvalidPolicy);
+    // Cannot set ef_runtime param with "hybrid_policy" which is "ADHOC_BF"
+    rparams[1] = (VecSimRawParam){.name = "ef_runtime", .nameLen = 10, .value = "100", .valLen = 3};
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimParamResolverErr_InvalidPolicy);
 
-	rparams[1] = (VecSimRawParam){.name = "HYBRID_POLICY", .nameLen = strlen("HYBRID_POLICY"),
-				.value = "batches", .valLen = strlen("batches")};
-	ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSim_OK);
+    // Cannot set batch_size param with "hybrid_policy" which is "ADHOC_BF"
+    rparams[1] = (VecSimRawParam){.name = "batch_size",
+                                  .nameLen = strlen("batch_size"),
+                                  .value = "10",
+                                  .valLen = strlen("10")};
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimParamResolverErr_InvalidPolicy);
 
+    rparams[0] = (VecSimRawParam){.name = "HYBRID_POLICY",
+                                  .nameLen = strlen("HYBRID_POLICY"),
+                                  .value = "batches",
+                                  .valLen = strlen("batches")};
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams), VecSim_OK);
+    ASSERT_EQ(qparams.searchMode, HYBRID_BATCHES);
+    ASSERT_EQ(qparams.batchSize, 10);
 
+    // Check for invalid batch sizes params.
+    rparams[1].value = "not_a_number";
+    rparams[1].valLen = strlen("not_a_number");
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimParamResolverErr_BadValue);
 
-		VecSimIndex_Free(index);
+    rparams[1].value = "9223372036854775808"; // LLONG_MAX+1
+    rparams[1].valLen = strlen("9223372036854775808");
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimParamResolverErr_BadValue);
+
+    rparams[1].value = "-5";
+    rparams[1].valLen = strlen("-5");
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimParamResolverErr_BadValue);
+
+    rparams[1].value = "0";
+    rparams[1].valLen = strlen("0");
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimParamResolverErr_BadValue);
+
+    rparams[1].value = "10f";
+    rparams[1].valLen = strlen("10f");
+    ASSERT_EQ(VecSimIndex_ResolveParams(index, rparams, array_len(rparams), &qparams),
+              VecSimParamResolverErr_BadValue);
+
+    VecSimIndex_Free(index);
     array_free(rparams);
 }
 


### PR DESCRIPTION
Add support for 2 additional runtime params - "HYBRID_POLICY" and "BATCH_SIZE" - to allow users to override the hybrid query default configuration.