### PR TITLE
using prefetch on all architectures

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
@@ -107,15 +107,15 @@ candidatesMaxHeap HNSW_BatchIterator::scanGraph(candidatesMinHeap &candidates,
         unsigned short links_num = this->hnsw_index->getListCount(cur_node_links_header);
         auto *node_links = (unsigned int *)(cur_node_links_header + 1);
 
-        __builtin_prefetch((char *)(visited_list->getElementsTags() + *node_links));
-        __builtin_prefetch((char *)(visited_list->getElementsTags() + *node_links + 64));
+        __builtin_prefetch(visited_list->getElementsTags() + *node_links);
+        __builtin_prefetch(visited_list->getElementsTags() + *node_links + 64);
         __builtin_prefetch(hnsw_index->getDataByInternalId(*node_links));
         __builtin_prefetch(hnsw_index->getDataByInternalId(*(node_links + 1)));
 
         for (size_t j = 0; j < links_num; j++) {
             unsigned int candidate_id = *(node_links + j);
 
-            __builtin_prefetch((char *)(visited_list->getElementsTags() + *(node_links + j + 1)));
+            __builtin_prefetch(visited_list->getElementsTags() + *(node_links + j + 1));
             __builtin_prefetch(hnsw_index->getDataByInternalId(*(node_links + j + 1)));
 
             if (this->hasVisitedNode(candidate_id)) {

--- a/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
@@ -106,20 +106,18 @@ candidatesMaxHeap HNSW_BatchIterator::scanGraph(candidatesMinHeap &candidates,
             this->hnsw_index->get_linklist_at_level(curr_node_id, 0);
         unsigned short links_num = this->hnsw_index->getListCount(cur_node_links_header);
         auto *node_links = (unsigned int *)(cur_node_links_header + 1);
-#ifdef USE_SSE
-        _mm_prefetch((char *)(visited_list->getElementsTags() + *node_links), _MM_HINT_T0);
-        _mm_prefetch((char *)(visited_list->getElementsTags() + *node_links + 64), _MM_HINT_T0);
-        _mm_prefetch(hnsw_index->getDataByInternalId(*node_links), _MM_HINT_T0);
-        _mm_prefetch(hnsw_index->getDataByInternalId(*(node_links + 1)), _MM_HINT_T0);
-#endif
+
+        __builtin_prefetch((char *)(visited_list->getElementsTags() + *node_links));
+        __builtin_prefetch((char *)(visited_list->getElementsTags() + *node_links + 64));
+        __builtin_prefetch(hnsw_index->getDataByInternalId(*node_links));
+        __builtin_prefetch(hnsw_index->getDataByInternalId(*(node_links + 1)));
 
         for (size_t j = 0; j < links_num; j++) {
             unsigned int candidate_id = *(node_links + j);
-#ifdef USE_SSE
-            _mm_prefetch((char *)(visited_list->getElementsTags() + *(node_links + j + 1)),
-                         _MM_HINT_T0);
-            _mm_prefetch(hnsw_index->getDataByInternalId(*(node_links + j + 1)), _MM_HINT_T0);
-#endif
+
+            __builtin_prefetch((char *)(visited_list->getElementsTags() + *(node_links + j + 1)));
+            __builtin_prefetch(hnsw_index->getDataByInternalId(*(node_links + j + 1)));
+
             if (this->hasVisitedNode(candidate_id)) {
                 continue;
             }

--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -370,7 +370,7 @@ dist_t HierarchicalNSW<dist_t>::processCandidate(tableint curNodeId, const void 
     for (size_t j = 0; j < links_num; j++) {
         tableint candidate_id = *(node_links + j);
 
-        __builtin_prefetch((char *)(visited_nodes_handler->getElementsTags() + *(node_links + j + 1)));
+        __builtin_prefetch(visited_nodes_handler->getElementsTags() + *(node_links + j + 1));
         __builtin_prefetch(getDataByInternalId(*(node_links + j + 1)));
 
         if (this->visited_nodes_handler->getNodeTag(candidate_id) == visited_tag)

--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -362,8 +362,8 @@ dist_t HierarchicalNSW<dist_t>::processCandidate(tableint curNodeId, const void 
     size_t links_num = getListCount(node_ll);
     auto *node_links = (tableint *)(node_ll + 1);
 
-    __builtin_prefetch((char *)(visited_nodes_handler->getElementsTags() + *(node_ll + 1)));
-    __builtin_prefetch((char *)(visited_nodes_handler->getElementsTags() + *(node_ll + 1) + 64));
+    __builtin_prefetch(visited_nodes_handler->getElementsTags() + *(node_ll + 1));
+    __builtin_prefetch(visited_nodes_handler->getElementsTags() + *(node_ll + 1) + 64);
     __builtin_prefetch(getDataByInternalId(*node_links));
     __builtin_prefetch(getDataByInternalId(*(node_links + 1)));
 

--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -4,7 +4,6 @@
 #include "VecSim/spaces/L2_space.h"
 #include "VecSim/spaces/IP_space.h"
 #include "VecSim/spaces/space_interface.h"
-#include "VecSim/spaces/space_includes.h"
 #include "VecSim/utils/arr_cpp.h"
 #include "VecSim/memory/vecsim_malloc.h"
 #include "VecSim/utils/vecsim_stl.h"
@@ -362,21 +361,18 @@ dist_t HierarchicalNSW<dist_t>::processCandidate(tableint curNodeId, const void 
     linklistsizeint *node_ll = get_linklist_at_level(curNodeId, layer);
     size_t links_num = getListCount(node_ll);
     auto *node_links = (tableint *)(node_ll + 1);
-#ifdef USE_SSE
-    _mm_prefetch((char *)(visited_nodes_handler->getElementsTags() + *(node_ll + 1)), _MM_HINT_T0);
-    _mm_prefetch((char *)(visited_nodes_handler->getElementsTags() + *(node_ll + 1) + 64),
-                 _MM_HINT_T0);
-    _mm_prefetch(getDataByInternalId(*node_links), _MM_HINT_T0);
-    _mm_prefetch(getDataByInternalId(*(node_links + 1)), _MM_HINT_T0);
-#endif
+
+    __builtin_prefetch((char *)(visited_nodes_handler->getElementsTags() + *(node_ll + 1)));
+    __builtin_prefetch((char *)(visited_nodes_handler->getElementsTags() + *(node_ll + 1) + 64));
+    __builtin_prefetch(getDataByInternalId(*node_links));
+    __builtin_prefetch(getDataByInternalId(*(node_links + 1)));
 
     for (size_t j = 0; j < links_num; j++) {
         tableint candidate_id = *(node_links + j);
-#ifdef USE_SSE
-        _mm_prefetch((char *)(visited_nodes_handler->getElementsTags() + *(node_links + j + 1)),
-                     _MM_HINT_T0);
-        _mm_prefetch(getDataByInternalId(*(node_links + j + 1)), _MM_HINT_T0);
-#endif
+
+        __builtin_prefetch((char *)(visited_nodes_handler->getElementsTags() + *(node_links + j + 1)));
+        __builtin_prefetch(getDataByInternalId(*(node_links + j + 1)));
+
         if (this->visited_nodes_handler->getNodeTag(candidate_id) == visited_tag)
             continue;
         this->visited_nodes_handler->tagNode(candidate_id, visited_tag);
@@ -385,9 +381,9 @@ dist_t HierarchicalNSW<dist_t>::processCandidate(tableint curNodeId, const void 
         dist_t dist1 = fstdistfunc_(data_point, currObj1, dist_func_param_);
         if (top_candidates.size() < ef || lowerBound > dist1) {
             candidate_set.emplace(-dist1, candidate_id);
-#ifdef USE_SSE
-            _mm_prefetch(getDataByInternalId(candidate_set.top().second), _MM_HINT_T0);
-#endif
+
+            __builtin_prefetch(getDataByInternalId(candidate_set.top().second));
+
             top_candidates.emplace(dist1, candidate_id);
 
             if (top_candidates.size() > ef)


### PR DESCRIPTION
In this PR I remove the USE_SSE flag as all modern processors supports prefetch commands, including ARM based CPUs.

I also replaced the `_mm_prefetch` command with the more general `__builtin_prefetch` command, that is supported on gcc, clang, intel compiler and arm compiler, for both x86 and ARM.

we used the `_mm_prefetch` with the default flag, so we can use `__builtin_prefetch` with no more parameters but the address we want to prefetch.

prefetch commands were introduced to ARM from version v5te and v6, so this PR will drop support for using the lib binaries on earlier versions, but all the compilers should handle (ignore) `__builtin_prefetch` when compiling on this machines, if we ever want to support them

This PR does not include tests beside passing the ARM build on the CI. we should add tests when we add more complex optimizations for ARM  