### PR TITLE
Range query support for HNSW

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -168,6 +168,37 @@ VecSimQueryResult_List HNSWIndex::topKQuery(const void *query_data, size_t k,
     return rl;
 }
 
+VecSimQueryResult_List HNSWIndex::rangeQuery(const void *queryBlob, float radius,
+                                                   VecSimQueryParams *queryParams) {
+	auto rl = (VecSimQueryResult_List){0};
+	void *timeoutCtx = nullptr;
+	this->last_mode = RANGE_QUERY;
+
+	float normalized_blob[this->dim]; // This will be use only if metric == VecSimMetric_Cosine
+	if (this->metric == VecSimMetric_Cosine) {
+		// TODO: need more generic when other types will be supported.
+		memcpy(normalized_blob, queryBlob, this->dim * sizeof(float));
+		float_vector_normalize(normalized_blob, this->dim);
+		queryBlob = normalized_blob;
+	}
+
+	float originalEpsilon = this->hnsw->getEpsilon();
+	if (queryParams) {
+		timeoutCtx = queryParams->timeoutCtx;
+		if (queryParams->hnswRuntimeParams.epsilon != 0) {
+			hnsw->setEpsilon(queryParams->hnswRuntimeParams.epsilon);
+		}
+	}
+	// call searchRange in hnswlib
+
+	// Restore epsilon
+	hnsw->setEpsilon(originalEpsilon);
+	assert(hnsw->getEpsilon() == originalEpsilon);
+
+	rl.code = VecSim_QueryResult_OK;
+	return rl;
+}
+
 VecSimIndexInfo HNSWIndex::info() const {
 
     VecSimIndexInfo info;

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -28,7 +28,7 @@ HNSWIndex::HNSWIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator> 
           params->efConstruction ? params->efConstruction : HNSW_DEFAULT_EF_C)),
       last_mode(EMPTY_MODE) {
     hnsw->setEf(params->efRuntime ? params->efRuntime : HNSW_DEFAULT_EF_RT);
-    hnsw->setEpsilon((params->epsilon > 0.0f) ? params->epsilon : HNSW_DEFAULT_EPSILON);
+    hnsw->setEpsilon((params->epsilon > 0.0) ? params->epsilon : HNSW_DEFAULT_EPSILON);
 }
 
 /******************** Implementation **************/
@@ -183,10 +183,10 @@ VecSimQueryResult_List HNSWIndex::rangeQuery(const void *queryBlob, float radius
         queryBlob = normalized_blob;
     }
 
-    float originalEpsilon = this->hnsw->getEpsilon();
+    double originalEpsilon = this->hnsw->getEpsilon();
     if (queryParams) {
         timeoutCtx = queryParams->timeoutCtx;
-        if (queryParams->hnswRuntimeParams.epsilon != 0) {
+        if (queryParams->hnswRuntimeParams.epsilon != 0.0) {
             hnsw->setEpsilon(queryParams->hnswRuntimeParams.epsilon);
         }
     }
@@ -216,6 +216,7 @@ VecSimIndexInfo HNSWIndex::info() const {
     info.hnswInfo.M = this->hnsw->getM();
     info.hnswInfo.efConstruction = this->hnsw->getEfConstruction();
     info.hnswInfo.efRuntime = this->hnsw->getEf();
+    info.hnswInfo.epsilon = this->hnsw->getEpsilon();
     info.hnswInfo.indexSize = this->hnsw->getIndexSize();
     info.hnswInfo.max_level = this->hnsw->getMaxLevel();
     info.hnswInfo.entrypoint = this->hnsw->getEntryPointLabel();
@@ -286,6 +287,10 @@ VecSimInfoIterator *HNSWIndex::infoIterator() {
         VecSim_InfoField{.fieldName = VecSimCommonStrings::SEARCH_MODE_STRING,
                          .fieldType = INFOFIELD_STRING,
                          .stringValue = VecSimSearchMode_ToString(info.hnswInfo.last_mode)});
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::HNSW_EPSILON_STRING,
+                         .fieldType = INFOFIELD_FLOAT64,
+                         .floatingPointValue = info.hnswInfo.epsilon});
 
     return infoIterator;
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
@@ -22,11 +22,7 @@ public:
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
     VecSimQueryResult_List rangeQuery(const void *queryBlob, float radius,
-                                      VecSimQueryParams *queryParams) override
-    // TODO: implement
-    {
-        return (VecSimQueryResult_List){nullptr};
-    }
+                                      VecSimQueryParams *queryParams) override;
     virtual VecSimIndexInfo info() const override;
     virtual VecSimInfoIterator *infoIterator() override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob,

--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -1367,7 +1367,7 @@ VecSimQueryResult *HierarchicalNSW<dist_t>::searchRangeBottomLayer_WithTimeout(
         dynamic_range = radius; // to ensure that dyn_range >= radius.
     }
 
-    candidate_set.emplace(-dynamic_range, ep_id);
+    candidate_set.emplace(-ep_dist, ep_id);
     this->visited_nodes_handler->tagNode(ep_id, visited_tag);
 
     while (!candidate_set.empty()) {

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -32,6 +32,7 @@ const char *VecSimCommonStrings::MEMORY_STRING = "MEMORY";
 const char *VecSimCommonStrings::HNSW_EF_RUNTIME_STRING = "EF_RUNTIME";
 const char *VecSimCommonStrings::HNSW_M_STRING = "M";
 const char *VecSimCommonStrings::HNSW_EF_CONSTRUCTION_STRING = "EF_CONSTRUCTION";
+const char *VecSimCommonStrings::HNSW_EPSILON_STRING = "EPSILON";
 const char *VecSimCommonStrings::HNSW_MAX_LEVEL = "MAX_LEVEL";
 const char *VecSimCommonStrings::HNSW_ENTRYPOINT = "ENTRYPOINT";
 

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -37,6 +37,7 @@ public:
     static const char *HNSW_EF_RUNTIME_STRING;
     static const char *HNSW_EF_CONSTRUCTION_STRING;
     static const char *HNSW_M_STRING;
+    static const char *HNSW_EPSILON_STRING;
     static const char *HNSW_MAX_LEVEL;
     static const char *HNSW_ENTRYPOINT;
 

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -85,6 +85,7 @@ typedef struct {
 
 typedef struct {
     size_t efRuntime; // EF parameter for HNSW graph accuracy/latency for search.
+	float epsilon;    // Epsilon parameter for HNSW graph accuracy/latency for range search.
 } HNSWRuntimeParams;
 
 /**

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -10,7 +10,7 @@ extern "C" {
 #define HNSW_DEFAULT_M       16
 #define HNSW_DEFAULT_EF_C    200
 #define HNSW_DEFAULT_EF_RT   10
-#define HNSW_DEFAULT_EPSILON 0.01f
+#define HNSW_DEFAULT_EPSILON 0.01
 #define DEFAULT_BLOCK_SIZE   1024
 
 // Datatypes for indexing.
@@ -66,7 +66,7 @@ typedef struct {
     size_t M;
     size_t efConstruction;
     size_t efRuntime;
-    float epsilon;
+    double epsilon;
 } HNSWParams;
 
 typedef struct {
@@ -87,7 +87,7 @@ typedef struct {
 
 typedef struct {
     size_t efRuntime; // EF parameter for HNSW graph accuracy/latency for search.
-    float epsilon;    // Epsilon parameter for HNSW graph accuracy/latency for range search.
+    double epsilon;   // Epsilon parameter for HNSW graph accuracy/latency for range search.
 } HNSWRuntimeParams;
 
 /**
@@ -127,12 +127,13 @@ typedef struct {
 typedef struct {
     union {
         struct {
-            size_t indexSize;        // Current count of vectors.
-            size_t blockSize;        // Sets the amount to grow when resizing
-            size_t M;                // Number of allowed edges per node in graph.
-            size_t efConstruction;   // EF parameter for HNSW graph accuracy/latency for indexing.
-            size_t efRuntime;        // EF parameter for HNSW graph accuracy/latency for search.
-            size_t max_level;        // Number of graph levels.
+            size_t indexSize;      // Current count of vectors.
+            size_t blockSize;      // Sets the amount to grow when resizing
+            size_t M;              // Number of allowed edges per node in graph.
+            size_t efConstruction; // EF parameter for HNSW graph accuracy/latency for indexing.
+            size_t efRuntime;      // EF parameter for HNSW graph accuracy/latency for search.
+            double epsilon;   // Epsilon parameter for HNSW graph accuracy/latency for range search.
+            size_t max_level; // Number of graph levels.
             size_t entrypoint;       // Entrypoint vector label.
             VecSimMetric metric;     // Index distance metric
             uint64_t memory;         // Index memory consumption.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -10,7 +10,7 @@ extern "C" {
 #define HNSW_DEFAULT_M       16
 #define HNSW_DEFAULT_EF_C    200
 #define HNSW_DEFAULT_EF_RT   10
-#define HNSW_DEFAULT_EPSILON 0.1f
+#define HNSW_DEFAULT_EPSILON 0.01f
 #define DEFAULT_BLOCK_SIZE   1024
 
 // Datatypes for indexing.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -7,10 +7,11 @@ extern "C" {
 #include <stdint.h>
 
 // HNSW default parameters
-#define HNSW_DEFAULT_M     16
-#define HNSW_DEFAULT_EF_C  200
-#define HNSW_DEFAULT_EF_RT 10
-#define DEFAULT_BLOCK_SIZE 1024
+#define HNSW_DEFAULT_M       16
+#define HNSW_DEFAULT_EF_C    200
+#define HNSW_DEFAULT_EF_RT   10
+#define HNSW_DEFAULT_EPSILON 0.1f
+#define DEFAULT_BLOCK_SIZE   1024
 
 // Datatypes for indexing.
 typedef enum {
@@ -65,6 +66,7 @@ typedef struct {
     size_t M;
     size_t efConstruction;
     size_t efRuntime;
+    float epsilon;
 } HNSWParams;
 
 typedef struct {
@@ -85,7 +87,7 @@ typedef struct {
 
 typedef struct {
     size_t efRuntime; // EF parameter for HNSW graph accuracy/latency for search.
-	float epsilon;    // Epsilon parameter for HNSW graph accuracy/latency for range search.
+    float epsilon;    // Epsilon parameter for HNSW graph accuracy/latency for range search.
 } HNSWRuntimeParams;
 
 /**

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -177,7 +177,8 @@ PYBIND11_MODULE(VecSim, m) {
         .def_readwrite("initialCapacity", &HNSWParams::initialCapacity)
         .def_readwrite("M", &HNSWParams::M)
         .def_readwrite("efConstruction", &HNSWParams::efConstruction)
-        .def_readwrite("efRuntime", &HNSWParams::efRuntime);
+        .def_readwrite("efRuntime", &HNSWParams::efRuntime)
+        .def_readwrite("epsilon", &HNSWParams::epsilon);
 
     py::class_<BFParams>(m, "BFParams")
         .def(py::init())
@@ -200,7 +201,8 @@ PYBIND11_MODULE(VecSim, m) {
 
     py::class_<HNSWRuntimeParams>(queryParams, "HNSWRuntimeParams")
         .def(py::init<>())
-        .def_readwrite("efRuntime", &HNSWRuntimeParams::efRuntime);
+        .def_readwrite("efRuntime", &HNSWRuntimeParams::efRuntime)
+        .def_readwrite("epsilon", &HNSWRuntimeParams::epsilon);
 
     py::class_<PyVecSimIndex>(m, "VecSimIndex")
         .def(py::init([](const VecSimParams &params) { return new PyVecSimIndex(params); }),

--- a/tests/benchmark/bm_basics.cpp
+++ b/tests/benchmark/bm_basics.cpp
@@ -223,8 +223,8 @@ BENCHMARK_DEFINE_F(BM_VecSimBasics, Range_BF)(benchmark::State &st) {
 }
 
 BENCHMARK_DEFINE_F(BM_VecSimBasics, Range_HNSW)(benchmark::State &st) {
-    float radius = (1.0f / 100.0f) * (float)st.range(0);
-    float epsilon = (1.0f / 1000.0f) * (float)st.range(1);
+    double radius = (1.0f / 100.0f) * (float)st.range(0);
+    double epsilon = (1.0f / 1000.0f) * (float)st.range(1);
     size_t iter = 0;
     size_t total_res = 0;
     size_t total_res_bf = 0;
@@ -262,6 +262,8 @@ BENCHMARK_REGISTER_F(BM_VecSimBasics, Range_BF)
 // Register the function as a benchmark
 BENCHMARK_REGISTER_F(BM_VecSimBasics, Range_HNSW)
     // {radius*100, epsilon*1000}
+    // The actual radius will be the given arg divided by 100, and the actual epsilon values
+    // will be the given arg divided by 1000.
     ->Args({20, 1})
     ->Args({20, 10})
     ->Args({20, 100})

--- a/tests/benchmark/bm_basics.cpp
+++ b/tests/benchmark/bm_basics.cpp
@@ -228,13 +228,10 @@ BENCHMARK_DEFINE_F(BM_VecSimBasics, Range_HNSW)(benchmark::State &st) {
     size_t iter = 0;
     size_t total_res = 0;
     size_t total_res_bf = 0;
+    auto query_params =
+        VecSimQueryParams{.hnswRuntimeParams = HNSWRuntimeParams{.epsilon = epsilon}};
 
     for (auto _ : st) {
-        st.PauseTiming();
-
-        auto query_params =
-            VecSimQueryParams{.hnswRuntimeParams = HNSWRuntimeParams{.epsilon = epsilon}};
-        st.ResumeTiming();
         auto hnsw_results = VecSimIndex_RangeQuery(hnsw_index, (*queries)[iter % n_queries].data(),
                                                    radius, &query_params, BY_ID);
         st.PauseTiming();

--- a/tests/flow/test_hnswlib.py
+++ b/tests/flow/test_hnswlib.py
@@ -356,12 +356,11 @@ def test_range_query():
     query_data = np.float32(np.random.random((1, dim)))
 
     radius = 13.0
+    recalls = {}
 
     for epsilon_rt in [0.001, 0.01, 0.1]:
         query_params = VecSimQueryParams()
-        if epsilon_rt != 0.01:
-            # Set epsilon for the current run, except for the default value which is 0.01.
-            query_params.hnswRuntimeParams.epsilon = epsilon_rt
+        query_params.hnswRuntimeParams.epsilon = epsilon_rt
         start = time.time()
         hnsw_labels, hnsw_distances = index.range_query(query_data, radius=radius, query_param=query_params)
         end = time.time()
@@ -377,6 +376,10 @@ def test_range_query():
         assert np.all(np.isin(hnsw_labels, np.array([label for label, _ in actual_results])))
 
         assert max(hnsw_distances[0]) <= radius
+        recalls[epsilon_rt] = res_num/len(actual_results)
+
+    # Expect higher recalls for higher epsilon values.
+    assert recalls[0.001] <= recalls[0.01] <= recalls[0.1]
 
     # Expect zero results for radius==0
     hnsw_labels, hnsw_distances = index.range_query(query_data, radius=0)

--- a/tests/flow/test_hnswlib.py
+++ b/tests/flow/test_hnswlib.py
@@ -366,8 +366,8 @@ def test_range_query():
         end = time.time()
         res_num = len(hnsw_labels[0])
 
-        dists = sorted([(key, spatial.distance.euclidean(query_data, vec)) for key, vec in vectors])
-        actual_results = [(key, dist) for key, dist in dists if dist <= radius**0.5]
+        dists = sorted([(key, spatial.distance.sqeuclidean(query_data, vec)) for key, vec in vectors])
+        actual_results = [(key, dist) for key, dist in dists if dist <= radius]
 
         print(f'\nlookup time for {num_elements} vectors with dim={dim} took {end - start} seconds with epsilon={epsilon_rt},'
               f' got {res_num} results, which are {res_num/len(actual_results)} of the entire results in the range.')

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -335,6 +335,7 @@ TEST_F(HNSWLibTest, test_hnsw_info) {
     ASSERT_EQ(info.hnswInfo.M, HNSW_DEFAULT_M);
     ASSERT_EQ(info.hnswInfo.efConstruction, HNSW_DEFAULT_EF_C);
     ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
+    ASSERT_DOUBLE_EQ(info.hnswInfo.epsilon, HNSW_DEFAULT_EPSILON);
     VecSimIndex_Free(index);
 
     d = 1280;
@@ -347,7 +348,8 @@ TEST_F(HNSWLibTest, test_hnsw_info) {
                                        .blockSize = bs,
                                        .M = 200,
                                        .efConstruction = 1000,
-                                       .efRuntime = 500}};
+                                       .efRuntime = 500,
+                                       .epsilon = 0.005}};
     index = VecSimIndex_New(&params);
     info = VecSimIndex_Info(index);
     ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
@@ -357,6 +359,7 @@ TEST_F(HNSWLibTest, test_hnsw_info) {
     ASSERT_EQ(info.hnswInfo.efConstruction, 1000);
     ASSERT_EQ(info.hnswInfo.M, 200);
     ASSERT_EQ(info.hnswInfo.efRuntime, 500);
+    ASSERT_EQ(info.hnswInfo.epsilon, 0.005);
     VecSimIndex_Free(index);
 }
 
@@ -390,7 +393,8 @@ TEST_F(HNSWLibTest, test_dynamic_hnsw_info_iterator) {
                                                  .initialCapacity = n,
                                                  .M = 100,
                                                  .efConstruction = 250,
-                                                 .efRuntime = 400}};
+                                                 .efRuntime = 400,
+                                                 .epsilon = 0.004}};
     float v[d];
     for (size_t i = 0; i < d; i++) {
         v[i] = (float)i;
@@ -401,6 +405,7 @@ TEST_F(HNSWLibTest, test_dynamic_hnsw_info_iterator) {
     ASSERT_EQ(100, info.hnswInfo.M);
     ASSERT_EQ(250, info.hnswInfo.efConstruction);
     ASSERT_EQ(400, info.hnswInfo.efRuntime);
+    ASSERT_EQ(0.004, info.hnswInfo.epsilon);
     ASSERT_EQ(0, info.hnswInfo.indexSize);
     ASSERT_EQ(-1, info.hnswInfo.max_level);
     ASSERT_EQ(-1, info.hnswInfo.entrypoint);

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -94,7 +94,7 @@ void compareFlatIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
 }
 
 void compareHNSWIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *infoIter) {
-    ASSERT_EQ(12, VecSimInfoIterator_NumberOfFields(infoIter));
+    ASSERT_EQ(13, VecSimInfoIterator_NumberOfFields(infoIter));
     while (VecSimInfoIterator_HasNextField(infoIter)) {
         VecSim_InfoField *infoFiled = VecSimInfoIterator_NextField(infoIter);
         if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
@@ -131,6 +131,10 @@ void compareHNSWIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
             // EF runtime.
             ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);
             ASSERT_EQ(infoFiled->uintegerValue, info.hnswInfo.efRuntime);
+        } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::HNSW_EPSILON_STRING)) {
+            // Epsilon.
+            ASSERT_EQ(infoFiled->fieldType, INFOFIELD_FLOAT64);
+            ASSERT_EQ(infoFiled->floatingPointValue, info.hnswInfo.epsilon);
         } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::HNSW_M_STRING)) {
             // M.
             ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);


### PR DESCRIPTION
Implement based on option B in the design doc - https://redislabs.atlassian.net/wiki/spaces/DX/pages/2644312347/VecSim+-+Range+query

This includes adding test cases to google benchmark and adding the new `epsilon` parameter to the python bindings (+ using it in flow tests). Also, `epsilon` parameter is now exposed as part of the HNSW index info.