### PR TITLE
Google benchmark - refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,14 @@ commands:
       - run:
           name: Valgrind test
           command: bash -l -c "make VG=1 build unit_test"
+      # todo: this for testing CI, to remove before we merge PR
+      - run:
+          name: Download pre-generated indices
+          command: wget -q -i tests/benchmark/data/hnsw_indices.txt -P tests/benchmark/data
+      - run:
+          name: Benchmark
+          command: bash -l -c "make benchmark"
+          no_output_timeout: 180m
       - run:
           name: Build Python bindings
           command: bash -l -c "make pybind"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,14 +116,6 @@ commands:
       - run:
           name: Valgrind test
           command: bash -l -c "make VG=1 build unit_test"
-      # todo: this for testing CI, to remove before we merge PR
-      - run:
-          name: Download pre-generated indices
-          command: wget -q -i tests/benchmark/data/hnsw_indices.txt -P tests/benchmark/data
-      - run:
-          name: Benchmark
-          command: bash -l -c "make benchmark"
-          no_output_timeout: 180m
       - run:
           name: Build Python bindings
           command: bash -l -c "make pybind"

--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -11,7 +11,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${LLVM_LD_FLAGS}")
 
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+  URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
@@ -21,6 +21,6 @@ option(BENCHMARK_ENABLE_GTEST_TESTS "" OFF)
 option(BENCHMARK_ENABLE_TESTING  "" OFF)
 FetchContent_Declare(
 	google_benchmark
-	URL https://github.com/google/benchmark/archive/refs/tags/v1.6.0.zip
+	URL https://github.com/google/benchmark/archive/refs/tags/v1.7.0.zip
 )
 FetchContent_MakeAvailable(google_benchmark)

--- a/tests/benchmark/bm_basics.cpp
+++ b/tests/benchmark/bm_basics.cpp
@@ -28,24 +28,24 @@ static void GetHNSWIndex(VecSimIndex *hnsw_index) {
 }
 
 static void GetTestVectors(std::vector<std::vector<float>> &queries, size_t dim) {
-	auto location = std::string(std::string(getenv("ROOT")));
-	auto file_name = location + "/tests/benchmark/data/DBpedia-test_vectors-n10k.raw";
+    auto location = std::string(std::string(getenv("ROOT")));
+    auto file_name = location + "/tests/benchmark/data/DBpedia-test_vectors-n10k.raw";
 
-	std::ifstream input(file_name, std::ios::binary);
-	size_t n_query_vectors = 10000;
+    std::ifstream input(file_name, std::ios::binary);
+    size_t n_query_vectors = 10000;
 
-	queries.reserve(n_query_vectors);
-	if (input.is_open()) {
-		input.seekg(0, std::ifstream::beg);
-		for (size_t i = 0; i < n_query_vectors; i++) {
-			std::vector<float> query(dim);
-			input.read((char *)query.data(), dim * sizeof (float));
-			queries[i] = query;
-		}
-	} else {
-		std::cerr << "Test vectors file was not found in path. Exiting..." << std::endl;
-		exit(1);
-	}
+    queries.reserve(n_query_vectors);
+    if (input.is_open()) {
+        input.seekg(0, std::ifstream::beg);
+        for (size_t i = 0; i < n_query_vectors; i++) {
+            std::vector<float> query(dim);
+            input.read((char *)query.data(), dim * sizeof(float));
+            queries[i] = query;
+        }
+    } else {
+        std::cerr << "Test vectors file was not found in path. Exiting..." << std::endl;
+        exit(1);
+    }
 }
 
 class BM_VecSimBasics : public benchmark::Fixture {
@@ -55,112 +55,110 @@ protected:
     size_t dim;
     size_t n_vectors;
     std::vector<std::vector<float>> *queries;
-	static BM_VecSimBasics *instance;
-	static size_t ref_count;
+
+    // We use this class as a single-tone for every test case, so we won't hold several indices (to
+    // reduce memory).
+    static BM_VecSimBasics *instance;
+    static size_t ref_count;
 
     BM_VecSimBasics() {
-	    dim = 768;
-	    n_vectors = 1000000;
-		ref_count++;
-		if (instance != nullptr) {
-			queries = instance->queries;
-			bf_index = instance->bf_index;
-			hnsw_index = instance->hnsw_index;
-		} else {
-			// Initialize and load HNSW index for DBPedia data set.
-			size_t M = 64;
-			size_t ef_c = 512;
-			VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
-					.hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-							.dim = dim,
-							.metric = VecSimMetric_Cosine,
-							.initialCapacity = n_vectors,
-							.M = M,
-							.efConstruction = ef_c}};
-			hnsw_index = VecSimIndex_New(&params);
+        dim = 768;
+        n_vectors = 1000000;
+        ref_count++;
+        if (instance != nullptr) {
+            // Use the same indices and query vectors for every instance.
+            queries = instance->queries;
+            bf_index = instance->bf_index;
+            hnsw_index = instance->hnsw_index;
+        } else {
+            // Initialize and load HNSW index for DBPedia data set.
+            size_t M = 64;
+            size_t ef_c = 512;
+            VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
+                                   .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                            .dim = dim,
+                                                            .metric = VecSimMetric_Cosine,
+                                                            .initialCapacity = n_vectors,
+                                                            .M = M,
+                                                            .efConstruction = ef_c}};
+            hnsw_index = VecSimIndex_New(&params);
 
-			// Load pre-generated HNSW index.
-			GetHNSWIndex(hnsw_index);
-			size_t ef_r = 10;
-			reinterpret_cast<HNSWIndex *>(hnsw_index)->setEf(ef_r);
+            // Load pre-generated HNSW index.
+            GetHNSWIndex(hnsw_index);
+            size_t ef_r = 10;
+            reinterpret_cast<HNSWIndex *>(hnsw_index)->setEf(ef_r);
 
-			VecSimParams bf_params = {.algo = VecSimAlgo_BF,
-					.bfParams = BFParams{.type = VecSimType_FLOAT32,
-							.dim = dim,
-							.metric = VecSimMetric_Cosine,
-							.initialCapacity = n_vectors}};
-			bf_index = VecSimIndex_New(&bf_params);
+            VecSimParams bf_params = {.algo = VecSimAlgo_BF,
+                                      .bfParams = BFParams{.type = VecSimType_FLOAT32,
+                                                           .dim = dim,
+                                                           .metric = VecSimMetric_Cosine,
+                                                           .initialCapacity = n_vectors}};
+            bf_index = VecSimIndex_New(&bf_params);
 
-			// Add the same vectors to Flat index.
-			for (size_t i = 0; i < n_vectors; ++i) {
-				char *blob =
-						reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex()->getDataByInternalId(i);
-				VecSimIndex_AddVector(bf_index, blob, i);
-			}
-			// Load the test query vectors.
-			queries = new std::vector<std::vector<float>>;
-			GetTestVectors(*queries, dim);
-			instance = this;
-		}
+            // Add the same vectors to Flat index.
+            for (size_t i = 0; i < n_vectors; ++i) {
+                char *blob = reinterpret_cast<HNSWIndex *>(hnsw_index)
+                                 ->getHNSWIndex()
+                                 ->getDataByInternalId(i);
+                VecSimIndex_AddVector(bf_index, blob, i);
+            }
+            // Load the test query vectors form file.
+            queries = new std::vector<std::vector<float>>;
+            GetTestVectors(*queries, dim);
+            instance = this;
+        }
     }
 
 public:
-    void SetUp(const ::benchmark::State &state) {
-
-
-    }
-
-    void TearDown(const ::benchmark::State &state) {
-
-    }
-
     ~BM_VecSimBasics() {
-		ref_count--;
-		if (ref_count == 0) {
-			VecSimIndex_Free(hnsw_index);
-			VecSimIndex_Free(bf_index);
-			delete queries;
-		}
-	}
+        ref_count--;
+        if (ref_count == 0) {
+            VecSimIndex_Free(hnsw_index);
+            VecSimIndex_Free(bf_index);
+            delete queries;
+        }
+    }
 };
 
 size_t BM_VecSimBasics::ref_count = 0;
 BM_VecSimBasics *BM_VecSimBasics::instance = nullptr;
 
 BENCHMARK_DEFINE_F(BM_VecSimBasics, AddVectorHNSW)(benchmark::State &st) {
-	// Add a new vector from the test vectors in every iteration.
+    // Add a new vector from the test vectors in every iteration.
     size_t iter = 0;
-	size_t new_id = VecSimIndex_IndexSize(hnsw_index);
+    size_t new_id = VecSimIndex_IndexSize(hnsw_index);
     for (auto _ : st) {
         VecSimIndex_AddVector(hnsw_index, (*queries)[iter++].data(), new_id++);
     }
-	// Clean-up.
-	size_t new_index_size = VecSimIndex_IndexSize(hnsw_index);
-	for (size_t id = n_vectors; id < new_index_size; id++) {
-		VecSimIndex_DeleteVector(hnsw_index, id);
-	}
+    // Clean-up.
+    size_t new_index_size = VecSimIndex_IndexSize(hnsw_index);
+    for (size_t id = n_vectors; id < new_index_size; id++) {
+        VecSimIndex_DeleteVector(hnsw_index, id);
+    }
 }
 
 BENCHMARK_DEFINE_F(BM_VecSimBasics, DeleteVectorHNSW)(benchmark::State &st) {
     // Remove a different vector in every execution.
-	float *blobs[1000];
-	size_t id_to_remove = 0;
+    float *blobs[1000];
+    size_t id_to_remove = 0;
 
     for (auto _ : st) {
-		st.PauseTiming();
-		blobs[id_to_remove] = new float[dim];
-	    memcpy(blobs[id_to_remove],
-	           reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex()->getDataByInternalId(id_to_remove),
-	           dim * sizeof(float));
-		st.ResumeTiming();
+        st.PauseTiming();
+        blobs[id_to_remove] = new float[dim];
+        memcpy(blobs[id_to_remove],
+               reinterpret_cast<HNSWIndex *>(hnsw_index)
+                   ->getHNSWIndex()
+                   ->getDataByInternalId(id_to_remove),
+               dim * sizeof(float));
+        st.ResumeTiming();
         VecSimIndex_DeleteVector(hnsw_index, id_to_remove++);
     }
 
-	// Restore state.
-	for (size_t i = 0; i < id_to_remove; i++) {
-		VecSimIndex_AddVector(hnsw_index,blobs[i], i);
-		delete[] blobs[i];
-	}
+    // Restore index state.
+    for (size_t i = 0; i < id_to_remove; i++) {
+        VecSimIndex_AddVector(hnsw_index, blobs[i], i);
+        delete[] blobs[i];
+    }
 }
 
 BENCHMARK_DEFINE_F(BM_VecSimBasics, TopK_BF)(benchmark::State &st) {
@@ -172,12 +170,13 @@ BENCHMARK_DEFINE_F(BM_VecSimBasics, TopK_BF)(benchmark::State &st) {
 }
 
 BENCHMARK_DEFINE_F(BM_VecSimBasics, TopK_HNSW)(benchmark::State &st) {
-	size_t ef = st.range(0);
-	size_t k = st.range(1);
-	size_t correct = 0.0f;
+    size_t ef = st.range(0);
+    size_t k = st.range(1);
+    size_t correct = 0.0f;
     size_t iter = 0;
     for (auto _ : st) {
-		auto query_params = VecSimQueryParams {.hnswRuntimeParams = HNSWRuntimeParams {.efRuntime = ef}};
+        auto query_params =
+            VecSimQueryParams{.hnswRuntimeParams = HNSWRuntimeParams{.efRuntime = ef}};
         auto hnsw_results =
             VecSimIndex_TopKQuery(hnsw_index, (*queries)[iter].data(), k, &query_params, BY_SCORE);
         st.PauseTiming();
@@ -214,11 +213,12 @@ BENCHMARK_DEFINE_F(BM_VecSimBasics, Range_BF)(benchmark::State &st) {
     size_t iter = 0;
     size_t total_res = 0;
 
-	for (auto _ : st) {
-		auto res = VecSimIndex_RangeQuery(bf_index, (*queries)[iter++].data(), radius, nullptr, BY_ID);
-		total_res += VecSimQueryResult_Len(res);
-	}
-	st.counters["Avg. results number"] = (double)total_res / iter;
+    for (auto _ : st) {
+        auto res =
+            VecSimIndex_RangeQuery(bf_index, (*queries)[iter++].data(), radius, nullptr, BY_ID);
+        total_res += VecSimQueryResult_Len(res);
+    }
+    st.counters["Avg. results number"] = (double)total_res / iter;
 }
 
 // Register the function as a benchmark
@@ -240,12 +240,17 @@ BENCHMARK_REGISTER_F(BM_VecSimBasics, TopK_BF)
     ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_REGISTER_F(BM_VecSimBasics, TopK_HNSW)
-    // {ef_runtime, k}
-	->Args({10, 10})->Iterations(100)
-	->Args({200, 10})->Iterations(100)
-	->Args({100, 100})->Iterations(100)
-	->Args({200, 100})->Iterations(100)
-	->Args({500, 500})->Iterations(100)
+    // {ef_runtime, k} (recall that always ef_runtime >= k)
+    ->Args({10, 10})
+    ->Iterations(100)
+    ->Args({200, 10})
+    ->Iterations(100)
+    ->Args({100, 100})
+    ->Iterations(100)
+    ->Args({200, 100})
+    ->Iterations(100)
+    ->Args({500, 500})
+    ->Iterations(100)
     ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/bm_basics.cpp
+++ b/tests/benchmark/bm_basics.cpp
@@ -27,122 +27,164 @@ static void GetHNSWIndex(VecSimIndex *hnsw_index) {
     }
 }
 
+static void GetTestVectors(std::vector<std::vector<float>> &queries, size_t dim) {
+	auto location = std::string(std::string(getenv("ROOT")));
+	auto file_name = location + "/tests/benchmark/data/DBpedia-test_vectors-n10k.raw";
+
+	std::ifstream input(file_name, std::ios::binary);
+	size_t n_query_vectors = 10000;
+
+	queries.reserve(n_query_vectors);
+	if (input.is_open()) {
+		input.seekg(0, std::ifstream::beg);
+		for (size_t i = 0; i < n_query_vectors; i++) {
+			std::vector<float> query(dim);
+			input.read((char *)query.data(), dim * sizeof (float));
+			queries[i] = query;
+		}
+	} else {
+		std::cerr << "Test vectors file was not found in path. Exiting..." << std::endl;
+		exit(1);
+	}
+}
+
 class BM_VecSimBasics : public benchmark::Fixture {
 protected:
-    std::mt19937 rng;
     VecSimIndex *bf_index;
     VecSimIndex *hnsw_index;
     size_t dim;
     size_t n_vectors;
-    std::vector<float> query;
+    std::vector<std::vector<float>> *queries;
+	static BM_VecSimBasics *instance;
+	static size_t ref_count;
 
     BM_VecSimBasics() {
-        dim = 768;
-        n_vectors = 1000000;
-        query.reserve(dim);
-        rng.seed(47);
+	    dim = 768;
+	    n_vectors = 1000000;
+		ref_count++;
+		if (instance != nullptr) {
+			queries = instance->queries;
+			bf_index = instance->bf_index;
+			hnsw_index = instance->hnsw_index;
+		} else {
+			// Initialize and load HNSW index for DBPedia data set.
+			size_t M = 64;
+			size_t ef_c = 512;
+			VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
+					.hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+							.dim = dim,
+							.metric = VecSimMetric_Cosine,
+							.initialCapacity = n_vectors,
+							.M = M,
+							.efConstruction = ef_c}};
+			hnsw_index = VecSimIndex_New(&params);
+
+			// Load pre-generated HNSW index.
+			GetHNSWIndex(hnsw_index);
+			size_t ef_r = 10;
+			reinterpret_cast<HNSWIndex *>(hnsw_index)->setEf(ef_r);
+
+			VecSimParams bf_params = {.algo = VecSimAlgo_BF,
+					.bfParams = BFParams{.type = VecSimType_FLOAT32,
+							.dim = dim,
+							.metric = VecSimMetric_Cosine,
+							.initialCapacity = n_vectors}};
+			bf_index = VecSimIndex_New(&bf_params);
+
+			// Add the same vectors to Flat index.
+			for (size_t i = 0; i < n_vectors; ++i) {
+				char *blob =
+						reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex()->getDataByInternalId(i);
+				VecSimIndex_AddVector(bf_index, blob, i);
+			}
+			// Load the test query vectors.
+			queries = new std::vector<std::vector<float>>;
+			GetTestVectors(*queries, dim);
+			instance = this;
+		}
     }
 
 public:
     void SetUp(const ::benchmark::State &state) {
 
-        // Initialize and load HNSW index for DBPedia data set.
-        size_t M = 64;
-        size_t ef_c = 512;
-        VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
-                               .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-                                                        .dim = dim,
-                                                        .metric = VecSimMetric_Cosine,
-                                                        .initialCapacity = n_vectors + 1,
-                                                        .M = M,
-                                                        .efConstruction = ef_c}};
-        hnsw_index = VecSimIndex_New(&params);
 
-        // Load pre-generated HNSW index.
-        GetHNSWIndex(hnsw_index);
-        size_t ef_r = 500;
-        reinterpret_cast<HNSWIndex *>(hnsw_index)->setEf(ef_r);
-
-        VecSimParams bf_params = {.algo = VecSimAlgo_BF,
-                                  .bfParams = BFParams{.type = VecSimType_FLOAT32,
-                                                       .dim = dim,
-                                                       .metric = VecSimMetric_Cosine,
-                                                       .initialCapacity = n_vectors}};
-        bf_index = VecSimIndex_New(&bf_params);
-
-        // Add the same vectors to Flat index.
-        for (size_t i = 0; i < n_vectors; ++i) {
-            char *blob =
-                reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex()->getDataByInternalId(i);
-            VecSimIndex_AddVector(bf_index, blob, i);
-        }
     }
 
     void TearDown(const ::benchmark::State &state) {
-        VecSimIndex_Free(hnsw_index);
-        VecSimIndex_Free(bf_index);
+
     }
 
-    ~BM_VecSimBasics() {}
+    ~BM_VecSimBasics() {
+		ref_count--;
+		if (ref_count == 0) {
+			VecSimIndex_Free(hnsw_index);
+			VecSimIndex_Free(bf_index);
+			delete queries;
+		}
+	}
 };
 
+size_t BM_VecSimBasics::ref_count = 0;
+BM_VecSimBasics *BM_VecSimBasics::instance = nullptr;
+
 BENCHMARK_DEFINE_F(BM_VecSimBasics, AddVectorHNSW)(benchmark::State &st) {
-    // Save the first 500 vectors, remove then from the index, and add a different vector in every
-    // execution.
-    size_t n_vectors_to_add = 500;
-    float *blobs[n_vectors_to_add];
-    for (size_t i = 0; i < n_vectors_to_add; i++) {
-        blobs[i] = new float[dim];
-        memcpy(blobs[i],
-               reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex()->getDataByInternalId(i),
-               dim * sizeof(float));
-        VecSimIndex_DeleteVector(hnsw_index, i);
-    }
+	// Add a new vector from the test vectors in every iteration.
+    size_t iter = 0;
+	size_t new_id = VecSimIndex_IndexSize(hnsw_index);
     for (auto _ : st) {
-        size_t id = n_vectors - VecSimIndex_IndexSize(hnsw_index) - 1;
-        VecSimIndex_AddVector(hnsw_index, query.data(), id);
+        VecSimIndex_AddVector(hnsw_index, (*queries)[iter++].data(), new_id++);
     }
+	// Clean-up.
+	size_t new_index_size = VecSimIndex_IndexSize(hnsw_index);
+	for (size_t id = n_vectors; id < new_index_size; id++) {
+		VecSimIndex_DeleteVector(hnsw_index, id);
+	}
 }
 
 BENCHMARK_DEFINE_F(BM_VecSimBasics, DeleteVectorHNSW)(benchmark::State &st) {
     // Remove a different vector in every execution.
+	float *blobs[1000];
+	size_t id_to_remove = 0;
+
     for (auto _ : st) {
-        size_t id = n_vectors - VecSimIndex_IndexSize(hnsw_index);
-        VecSimIndex_DeleteVector(hnsw_index, id);
+		st.PauseTiming();
+		blobs[id_to_remove] = new float[dim];
+	    memcpy(blobs[id_to_remove],
+	           reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex()->getDataByInternalId(id_to_remove),
+	           dim * sizeof(float));
+		st.ResumeTiming();
+        VecSimIndex_DeleteVector(hnsw_index, id_to_remove++);
     }
+
+	// Restore state.
+	for (size_t i = 0; i < id_to_remove; i++) {
+		VecSimIndex_AddVector(hnsw_index,blobs[i], i);
+		delete[] blobs[i];
+	}
 }
 
 BENCHMARK_DEFINE_F(BM_VecSimBasics, TopK_BF)(benchmark::State &st) {
     size_t k = st.range(0);
+    size_t iter = 0;
     for (auto _ : st) {
-        st.PauseTiming();
-        // Generate random query vector before test.
-        std::uniform_real_distribution<double> distrib(-1.0, 1.0);
-        for (size_t i = 0; i < dim; ++i) {
-            query[i] = (float)distrib(rng);
-        }
-        st.ResumeTiming();
-        VecSimIndex_TopKQuery(bf_index, query.data(), k, nullptr, BY_SCORE);
+        VecSimIndex_TopKQuery(bf_index, (*queries)[iter++].data(), k, nullptr, BY_SCORE);
     }
 }
 
 BENCHMARK_DEFINE_F(BM_VecSimBasics, TopK_HNSW)(benchmark::State &st) {
-    size_t k = st.range(0);
-    size_t correct = 0.0f;
+	size_t ef = st.range(0);
+	size_t k = st.range(1);
+	size_t correct = 0.0f;
     size_t iter = 0;
     for (auto _ : st) {
-        st.PauseTiming();
-        // Generate random query vector before test.
-        std::uniform_real_distribution<double> distrib(-1.0, 1.0);
-        for (size_t i = 0; i < dim; ++i) {
-            query[i] = (float)distrib(rng);
-        }
-        st.ResumeTiming();
-        auto hnsw_results = VecSimIndex_TopKQuery(hnsw_index, query.data(), k, nullptr, BY_SCORE);
+		auto query_params = VecSimQueryParams {.hnswRuntimeParams = HNSWRuntimeParams {.efRuntime = ef}};
+        auto hnsw_results =
+            VecSimIndex_TopKQuery(hnsw_index, (*queries)[iter].data(), k, &query_params, BY_SCORE);
         st.PauseTiming();
 
         // Measure recall:
-        auto bf_results = VecSimIndex_TopKQuery(bf_index, query.data(), k, nullptr, BY_SCORE);
+        auto bf_results =
+            VecSimIndex_TopKQuery(bf_index, (*queries)[iter].data(), k, nullptr, BY_SCORE);
         auto hnsw_it = VecSimQueryResult_List_GetIterator(hnsw_results);
         while (VecSimQueryResult_IteratorHasNext(hnsw_it)) {
             auto hnsw_res_item = VecSimQueryResult_IteratorNext(hnsw_it);
@@ -171,29 +213,20 @@ BENCHMARK_DEFINE_F(BM_VecSimBasics, Range_BF)(benchmark::State &st) {
     float radius = (1.0f / 100.0f) * (float)st.range(0);
     size_t iter = 0;
     size_t total_res = 0;
-    for (auto _ : st) {
-        st.PauseTiming();
-        // Generate random query vector before test.
-        std::uniform_real_distribution<double> distrib(-1.0, 1.0);
-        for (size_t i = 0; i < dim; ++i) {
-            query[i] = (float)distrib(rng);
-        }
-        st.ResumeTiming();
-        auto res = VecSimIndex_RangeQuery(bf_index, query.data(), radius, nullptr, BY_ID);
-        st.PauseTiming();
-        total_res += VecSimQueryResult_Len(res);
-        iter++;
-        st.ResumeTiming();
-    }
-    st.counters["Avg. results number"] = (double)total_res / iter;
+
+	for (auto _ : st) {
+		auto res = VecSimIndex_RangeQuery(bf_index, (*queries)[iter++].data(), radius, nullptr, BY_ID);
+		total_res += VecSimQueryResult_Len(res);
+	}
+	st.counters["Avg. results number"] = (double)total_res / iter;
 }
 
 // Register the function as a benchmark
 BENCHMARK_REGISTER_F(BM_VecSimBasics, Range_BF)
     // The actual radius will the given arg divided by 100, since arg must me and integer.
-    ->Arg(92)
-    ->Arg(95)
-    ->Arg(100)
+    ->Arg(20)
+    ->Arg(35)
+    ->Arg(50)
     ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_REGISTER_F(BM_VecSimBasics, AddVectorHNSW)->Unit(benchmark::kMillisecond);
@@ -207,9 +240,12 @@ BENCHMARK_REGISTER_F(BM_VecSimBasics, TopK_BF)
     ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_REGISTER_F(BM_VecSimBasics, TopK_HNSW)
-    ->Arg(10)
-    ->Arg(100)
-    ->Arg(500)
+    // {ef_runtime, k}
+	->Args({10, 10})->Iterations(100)
+	->Args({200, 10})->Iterations(100)
+	->Args({100, 100})->Iterations(100)
+	->Args({200, 100})->Iterations(100)
+	->Args({500, 500})->Iterations(100)
     ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/bm_basics.cpp
+++ b/tests/benchmark/bm_basics.cpp
@@ -18,12 +18,10 @@ static void GetHNSWIndex(VecSimIndex *hnsw_index) {
         serializer.loadIndex(file_name,
                              reinterpret_cast<HNSWIndex *>(hnsw_index)->getSpace().get());
         if (!serializer.checkIntegrity().valid_state) {
-            std::cerr << "The loaded HNSW index is corrupted. Exiting..." << std::endl;
-            exit(1);
+            throw std::runtime_error("The loaded HNSW index is corrupted. Exiting...");
         }
     } else {
-        std::cerr << "HNSW index file was not found in path. Exiting..." << std::endl;
-        exit(1);
+        throw std::runtime_error("HNSW index file was not found in path. Exiting...");
     }
 }
 
@@ -42,8 +40,7 @@ static void GetTestVectors(std::vector<std::vector<float>> &queries, size_t n_qu
             queries[i] = query;
         }
     } else {
-        std::cerr << "Test vectors file was not found in path. Exiting..." << std::endl;
-        exit(1);
+        throw std::runtime_error("Test vectors file was not found in path. Exiting...");
     }
 }
 
@@ -56,7 +53,7 @@ protected:
     std::vector<std::vector<float>> *queries;
     size_t n_queries;
 
-    // We use this class as a single-tone for every test case, so we won't hold several indices (to
+    // We use this class as a singleton for every test case, so we won't hold several indices (to
     // reduce memory consumption).
     static BM_VecSimBasics *instance;
     static size_t ref_count;
@@ -229,7 +226,7 @@ BENCHMARK_DEFINE_F(BM_VecSimBasics, Range_BF)(benchmark::State &st) {
 
 // Register the function as a benchmark
 BENCHMARK_REGISTER_F(BM_VecSimBasics, Range_BF)
-    // The actual radius will the given arg divided by 100, since arg must me and integer.
+    // The actual radius will be the given arg divided by 100, since arg must be an integer.
     ->Arg(20)
     ->Arg(35)
     ->Arg(50)

--- a/tests/benchmark/bm_batch_iterator.cpp
+++ b/tests/benchmark/bm_batch_iterator.cpp
@@ -8,83 +8,103 @@
 
 class BM_BatchIterator : public benchmark::Fixture {
 protected:
-    std::mt19937 rng;
     VecSimIndex *bf_index;
     VecSimIndex *hnsw_index;
     size_t dim;
     size_t n_vectors;
-    std::vector<float> query;
+	std::vector<std::vector<float>> *queries;
+	static BM_BatchIterator *instance;
+	static size_t ref_count;
 
     BM_BatchIterator() {
-        dim = 768;
-        n_vectors = 1000000;
-        query.reserve(dim);
-        rng.seed(47);
+	    dim = 768;
+	    n_vectors = 1000000;
+	    ref_count++;
+	    if (instance != nullptr) {
+		    queries = instance->queries;
+		    bf_index = instance->bf_index;
+		    hnsw_index = instance->hnsw_index;
+	    } else {
+		    // Initialize and load HNSW index for DBPedia data set.
+		    size_t M = 64;
+		    size_t ef_c = 512;
+		    VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
+				    .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+						    .dim = dim,
+						    .metric = VecSimMetric_Cosine,
+						    .initialCapacity = n_vectors,
+						    .M = M,
+						    .efConstruction = ef_c}};
+		    hnsw_index = VecSimIndex_New(&params);
+
+		    // Load pre-generated HNSW index.
+		    auto location = std::string(std::string(getenv("ROOT")));
+		    auto file_name = location + "/tests/benchmark/data/DBpedia-n1M-cosine-d768-M64-EFC512.hnsw_v1";
+		    auto serializer =
+				    hnswlib::HNSWIndexSerializer(reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex());
+		    serializer.loadIndex(file_name,
+		                         reinterpret_cast<HNSWIndex *>(hnsw_index)->getSpace().get());
+		    size_t ef_r = 10;
+		    reinterpret_cast<HNSWIndex *>(hnsw_index)->setEf(ef_r);
+
+		    VecSimParams bf_params = {.algo = VecSimAlgo_BF,
+				    .bfParams = BFParams{.type = VecSimType_FLOAT32,
+						    .dim = dim,
+						    .metric = VecSimMetric_Cosine,
+						    .initialCapacity = n_vectors}};
+		    bf_index = VecSimIndex_New(&bf_params);
+
+		    // Add the same vectors to Flat index.
+		    for (size_t i = 0; i < n_vectors; ++i) {
+			    char *blob =
+					    reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex()->getDataByInternalId(i);
+			    VecSimIndex_AddVector(bf_index, blob, i);
+		    }
+		    // Load the test query vectors.
+		    size_t n_query_vectors = 10000;
+		    queries = new std::vector<std::vector<float>>(n_query_vectors);
+		    file_name = location + "/tests/benchmark/data/DBpedia-test_vectors-n10k.raw";
+		    std::ifstream input(file_name, std::ios::binary);
+		    input.seekg(0, std::ifstream::beg);
+		    for (size_t i = 0; i < n_query_vectors; i++) {
+			    std::vector<float> query(dim);
+			    input.read((char *) query.data(), dim * sizeof(float));
+			    (*queries)[i] = query;
+		    }
+		    instance = this;
+	    }
     }
 
 public:
     void SetUp(const ::benchmark::State &state) {
 
-        // Initialize and load HNSW index for DBPedia data set.
-        size_t M = 64;
-        size_t ef_c = 512;
-        VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
-                               .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-                                                        .dim = dim,
-                                                        .metric = VecSimMetric_Cosine,
-                                                        .initialCapacity = n_vectors + 1,
-                                                        .M = M,
-                                                        .efConstruction = ef_c}};
-        hnsw_index = VecSimIndex_New(&params);
-
-        // Load pre-generated HNSW index.
-        auto location = std::string(getenv("ROOT"));
-        auto file_name = std::string(location) +
-                         "/tests/benchmark/data/DBpedia-n1M-cosine-d768-M64-EFC512.hnsw_v1";
-        auto serializer =
-            hnswlib::HNSWIndexSerializer(reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex());
-        serializer.loadIndex(file_name,
-                             reinterpret_cast<HNSWIndex *>(hnsw_index)->getSpace().get());
-        size_t ef_r = 500;
-        reinterpret_cast<HNSWIndex *>(hnsw_index)->setEf(ef_r);
-
-        VecSimParams bf_params = {.algo = VecSimAlgo_BF,
-                                  .bfParams = BFParams{.type = VecSimType_FLOAT32,
-                                                       .dim = dim,
-                                                       .metric = VecSimMetric_Cosine,
-                                                       .initialCapacity = n_vectors}};
-        bf_index = VecSimIndex_New(&bf_params);
-
-        // Add the same vectors to Flat index.
-        for (size_t i = 0; i < n_vectors; ++i) {
-            char *blob =
-                reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex()->getDataByInternalId(i);
-            VecSimIndex_AddVector(bf_index, blob, i);
-        }
     }
 
     void TearDown(const ::benchmark::State &state) {
-        VecSimIndex_Free(bf_index);
-        VecSimIndex_Free(hnsw_index);
+
     }
 
-    ~BM_BatchIterator() {}
+    ~BM_BatchIterator() {
+	    ref_count--;
+	    if (ref_count == 0) {
+		    VecSimIndex_Free(hnsw_index);
+		    VecSimIndex_Free(bf_index);
+		    delete queries;
+	    }
+	}
 };
+
+size_t BM_BatchIterator::ref_count = 0;
+BM_BatchIterator *BM_BatchIterator::instance = nullptr;
 
 BENCHMARK_DEFINE_F(BM_BatchIterator, BatchedSearch_BF)(benchmark::State &st) {
 
     size_t batch_size = st.range(0);
     size_t total_res_count = st.range(1);
+	size_t iter = 0;
     for (auto _ : st) {
-        st.PauseTiming();
-        // Generate random query vector before test.
-        std::uniform_real_distribution<> distrib;
-        for (size_t i = 0; i < dim; ++i) {
-            query[i] = (float)distrib(rng);
-        }
-        st.ResumeTiming();
         VecSimBatchIterator *batchIterator =
-            VecSimBatchIterator_New(bf_index, query.data(), nullptr);
+            VecSimBatchIterator_New(bf_index, (*queries)[iter++].data(), nullptr);
         size_t res_num = 0;
         while (VecSimBatchIterator_HasNext(batchIterator)) {
             VecSimQueryResult_List res =
@@ -115,16 +135,9 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, BatchedSearch_HNSW)(benchmark::State &st) {
     size_t correct = 0;
 
     for (auto _ : st) {
-        st.PauseTiming();
-        // Generate random query vector before test.
-        std::uniform_real_distribution<double> distrib(-1.0, 1.0);
-        for (size_t i = 0; i < dim; ++i) {
-            query[i] = (float)distrib(rng);
-        }
 
-        st.ResumeTiming();
         VecSimBatchIterator *batchIterator =
-            VecSimBatchIterator_New(hnsw_index, query.data(), nullptr);
+            VecSimBatchIterator_New(hnsw_index, (*queries)[iter].data(), nullptr);
         VecSimQueryResult_List accumulated_results[total_res_num];
         size_t batch_num = 0, res_num = 0;
         while (VecSimBatchIterator_HasNext(batchIterator)) {
@@ -140,7 +153,7 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, BatchedSearch_HNSW)(benchmark::State &st) {
 
         // Measure recall
         auto bf_results =
-            VecSimIndex_TopKQuery(bf_index, query.data(), total_res_num, nullptr, BY_SCORE);
+            VecSimIndex_TopKQuery(bf_index, (*queries)[iter].data(), total_res_num, nullptr, BY_SCORE);
         for (size_t i = 0; i < batch_num; i++) {
             auto hnsw_results = accumulated_results[i];
             auto hnsw_it = VecSimQueryResult_List_GetIterator(hnsw_results);
@@ -177,8 +190,9 @@ BENCHMARK_REGISTER_F(BM_BatchIterator, BatchedSearch_HNSW)
 
 BENCHMARK_DEFINE_F(BM_BatchIterator, TopK_BF)(benchmark::State &st) {
     size_t k = st.range(0);
+	size_t iter = 0;
     for (auto _ : st) {
-        VecSimIndex_TopKQuery(bf_index, query.data(), k, nullptr, BY_SCORE);
+        VecSimIndex_TopKQuery(bf_index, (*queries)[iter++].data(), k, nullptr, BY_SCORE);
     }
 }
 
@@ -187,18 +201,12 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, TopK_HNSW)(benchmark::State &st) {
     size_t correct = 0;
     size_t iter = 0;
     for (auto _ : st) {
-        st.PauseTiming();
-        // Generate random query vector before test.
-        std::uniform_real_distribution<double> distrib(-1.0, 1.0);
-        for (size_t i = 0; i < dim; ++i) {
-            query[i] = (float)distrib(rng);
-        }
-        st.ResumeTiming();
-        auto hnsw_results = VecSimIndex_TopKQuery(hnsw_index, query.data(), k, nullptr, BY_SCORE);
+
+        auto hnsw_results = VecSimIndex_TopKQuery(hnsw_index, (*queries)[iter].data(), k, nullptr, BY_SCORE);
         st.PauseTiming();
 
         // Measure recall:
-        auto bf_results = VecSimIndex_TopKQuery(bf_index, query.data(), k, nullptr, BY_SCORE);
+        auto bf_results = VecSimIndex_TopKQuery(bf_index, (*queries)[iter].data(), k, nullptr, BY_SCORE);
         auto hnsw_it = VecSimQueryResult_List_GetIterator(hnsw_results);
         while (VecSimQueryResult_IteratorHasNext(hnsw_it)) {
             auto hnsw_res_item = VecSimQueryResult_IteratorNext(hnsw_it);

--- a/tests/benchmark/bm_batch_iterator.cpp
+++ b/tests/benchmark/bm_batch_iterator.cpp
@@ -12,86 +12,81 @@ protected:
     VecSimIndex *hnsw_index;
     size_t dim;
     size_t n_vectors;
-	std::vector<std::vector<float>> *queries;
-	static BM_BatchIterator *instance;
-	static size_t ref_count;
+    std::vector<std::vector<float>> *queries;
+    static BM_BatchIterator *instance;
+    static size_t ref_count;
 
     BM_BatchIterator() {
-	    dim = 768;
-	    n_vectors = 1000000;
-	    ref_count++;
-	    if (instance != nullptr) {
-		    queries = instance->queries;
-		    bf_index = instance->bf_index;
-		    hnsw_index = instance->hnsw_index;
-	    } else {
-		    // Initialize and load HNSW index for DBPedia data set.
-		    size_t M = 64;
-		    size_t ef_c = 512;
-		    VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
-				    .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-						    .dim = dim,
-						    .metric = VecSimMetric_Cosine,
-						    .initialCapacity = n_vectors,
-						    .M = M,
-						    .efConstruction = ef_c}};
-		    hnsw_index = VecSimIndex_New(&params);
+        dim = 768;
+        n_vectors = 1000000;
+        ref_count++;
+        if (instance != nullptr) {
+            // Use the same indices and query vectors for every instance.
+            queries = instance->queries;
+            bf_index = instance->bf_index;
+            hnsw_index = instance->hnsw_index;
+        } else {
+            // Initialize and load HNSW index for DBPedia data set.
+            size_t M = 64;
+            size_t ef_c = 512;
+            VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
+                                   .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                            .dim = dim,
+                                                            .metric = VecSimMetric_Cosine,
+                                                            .initialCapacity = n_vectors,
+                                                            .M = M,
+                                                            .efConstruction = ef_c}};
+            hnsw_index = VecSimIndex_New(&params);
 
-		    // Load pre-generated HNSW index.
-		    auto location = std::string(std::string(getenv("ROOT")));
-		    auto file_name = location + "/tests/benchmark/data/DBpedia-n1M-cosine-d768-M64-EFC512.hnsw_v1";
-		    auto serializer =
-				    hnswlib::HNSWIndexSerializer(reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex());
-		    serializer.loadIndex(file_name,
-		                         reinterpret_cast<HNSWIndex *>(hnsw_index)->getSpace().get());
-		    size_t ef_r = 10;
-		    reinterpret_cast<HNSWIndex *>(hnsw_index)->setEf(ef_r);
+            // Load pre-generated HNSW index.
+            auto location = std::string(std::string(getenv("ROOT")));
+            auto file_name =
+                location + "/tests/benchmark/data/DBpedia-n1M-cosine-d768-M64-EFC512.hnsw_v1";
+            auto serializer = hnswlib::HNSWIndexSerializer(
+                reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex());
+            serializer.loadIndex(file_name,
+                                 reinterpret_cast<HNSWIndex *>(hnsw_index)->getSpace().get());
+            size_t ef_r = 10;
+            reinterpret_cast<HNSWIndex *>(hnsw_index)->setEf(ef_r);
 
-		    VecSimParams bf_params = {.algo = VecSimAlgo_BF,
-				    .bfParams = BFParams{.type = VecSimType_FLOAT32,
-						    .dim = dim,
-						    .metric = VecSimMetric_Cosine,
-						    .initialCapacity = n_vectors}};
-		    bf_index = VecSimIndex_New(&bf_params);
+            VecSimParams bf_params = {.algo = VecSimAlgo_BF,
+                                      .bfParams = BFParams{.type = VecSimType_FLOAT32,
+                                                           .dim = dim,
+                                                           .metric = VecSimMetric_Cosine,
+                                                           .initialCapacity = n_vectors}};
+            bf_index = VecSimIndex_New(&bf_params);
 
-		    // Add the same vectors to Flat index.
-		    for (size_t i = 0; i < n_vectors; ++i) {
-			    char *blob =
-					    reinterpret_cast<HNSWIndex *>(hnsw_index)->getHNSWIndex()->getDataByInternalId(i);
-			    VecSimIndex_AddVector(bf_index, blob, i);
-		    }
-		    // Load the test query vectors.
-		    size_t n_query_vectors = 10000;
-		    queries = new std::vector<std::vector<float>>(n_query_vectors);
-		    file_name = location + "/tests/benchmark/data/DBpedia-test_vectors-n10k.raw";
-		    std::ifstream input(file_name, std::ios::binary);
-		    input.seekg(0, std::ifstream::beg);
-		    for (size_t i = 0; i < n_query_vectors; i++) {
-			    std::vector<float> query(dim);
-			    input.read((char *) query.data(), dim * sizeof(float));
-			    (*queries)[i] = query;
-		    }
-		    instance = this;
-	    }
+            // Add the same vectors to Flat index.
+            for (size_t i = 0; i < n_vectors; ++i) {
+                char *blob = reinterpret_cast<HNSWIndex *>(hnsw_index)
+                                 ->getHNSWIndex()
+                                 ->getDataByInternalId(i);
+                VecSimIndex_AddVector(bf_index, blob, i);
+            }
+            // Load the test query vectors.
+            size_t n_query_vectors = 10000;
+            queries = new std::vector<std::vector<float>>(n_query_vectors);
+            file_name = location + "/tests/benchmark/data/DBpedia-test_vectors-n10k.raw";
+            std::ifstream input(file_name, std::ios::binary);
+            input.seekg(0, std::ifstream::beg);
+            for (size_t i = 0; i < n_query_vectors; i++) {
+                std::vector<float> query(dim);
+                input.read((char *)query.data(), dim * sizeof(float));
+                (*queries)[i] = query;
+            }
+            instance = this;
+        }
     }
 
 public:
-    void SetUp(const ::benchmark::State &state) {
-
-    }
-
-    void TearDown(const ::benchmark::State &state) {
-
-    }
-
     ~BM_BatchIterator() {
-	    ref_count--;
-	    if (ref_count == 0) {
-		    VecSimIndex_Free(hnsw_index);
-		    VecSimIndex_Free(bf_index);
-		    delete queries;
-	    }
-	}
+        ref_count--;
+        if (ref_count == 0) {
+            VecSimIndex_Free(hnsw_index);
+            VecSimIndex_Free(bf_index);
+            delete queries;
+        }
+    }
 };
 
 size_t BM_BatchIterator::ref_count = 0;
@@ -101,7 +96,7 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, BatchedSearch_BF)(benchmark::State &st) {
 
     size_t batch_size = st.range(0);
     size_t total_res_count = st.range(1);
-	size_t iter = 0;
+    size_t iter = 0;
     for (auto _ : st) {
         VecSimBatchIterator *batchIterator =
             VecSimBatchIterator_New(bf_index, (*queries)[iter++].data(), nullptr);
@@ -135,7 +130,6 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, BatchedSearch_HNSW)(benchmark::State &st) {
     size_t correct = 0;
 
     for (auto _ : st) {
-
         VecSimBatchIterator *batchIterator =
             VecSimBatchIterator_New(hnsw_index, (*queries)[iter].data(), nullptr);
         VecSimQueryResult_List accumulated_results[total_res_num];
@@ -152,8 +146,8 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, BatchedSearch_HNSW)(benchmark::State &st) {
         st.PauseTiming();
 
         // Measure recall
-        auto bf_results =
-            VecSimIndex_TopKQuery(bf_index, (*queries)[iter].data(), total_res_num, nullptr, BY_SCORE);
+        auto bf_results = VecSimIndex_TopKQuery(bf_index, (*queries)[iter].data(), total_res_num,
+                                                nullptr, BY_SCORE);
         for (size_t i = 0; i < batch_num; i++) {
             auto hnsw_results = accumulated_results[i];
             auto hnsw_it = VecSimQueryResult_List_GetIterator(hnsw_results);
@@ -190,7 +184,7 @@ BENCHMARK_REGISTER_F(BM_BatchIterator, BatchedSearch_HNSW)
 
 BENCHMARK_DEFINE_F(BM_BatchIterator, TopK_BF)(benchmark::State &st) {
     size_t k = st.range(0);
-	size_t iter = 0;
+    size_t iter = 0;
     for (auto _ : st) {
         VecSimIndex_TopKQuery(bf_index, (*queries)[iter++].data(), k, nullptr, BY_SCORE);
     }
@@ -201,12 +195,13 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, TopK_HNSW)(benchmark::State &st) {
     size_t correct = 0;
     size_t iter = 0;
     for (auto _ : st) {
-
-        auto hnsw_results = VecSimIndex_TopKQuery(hnsw_index, (*queries)[iter].data(), k, nullptr, BY_SCORE);
+        auto hnsw_results =
+            VecSimIndex_TopKQuery(hnsw_index, (*queries)[iter].data(), k, nullptr, BY_SCORE);
         st.PauseTiming();
 
         // Measure recall:
-        auto bf_results = VecSimIndex_TopKQuery(bf_index, (*queries)[iter].data(), k, nullptr, BY_SCORE);
+        auto bf_results =
+            VecSimIndex_TopKQuery(bf_index, (*queries)[iter].data(), k, nullptr, BY_SCORE);
         auto hnsw_it = VecSimQueryResult_List_GetIterator(hnsw_results);
         while (VecSimQueryResult_IteratorHasNext(hnsw_it)) {
             auto hnsw_res_item = VecSimQueryResult_IteratorNext(hnsw_it);

--- a/tests/benchmark/bm_batch_iterator.cpp
+++ b/tests/benchmark/bm_batch_iterator.cpp
@@ -110,6 +110,8 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, BatchedSearch_BF)(benchmark::State &st) {
             }
         }
         VecSimBatchIterator_Free(batchIterator);
+        if (iter == queries->size())
+            break;
     }
 }
 
@@ -169,6 +171,8 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, BatchedSearch_HNSW)(benchmark::State &st) {
         }
         VecSimQueryResult_Free(bf_results);
         iter++;
+        if (iter == queries->size())
+            break;
         st.ResumeTiming();
     }
     st.counters["Intersection ratio"] = (float)correct / (total_res_num * iter);
@@ -187,6 +191,8 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, TopK_BF)(benchmark::State &st) {
     size_t iter = 0;
     for (auto _ : st) {
         VecSimIndex_TopKQuery(bf_index, (*queries)[iter++].data(), k, nullptr, BY_SCORE);
+        if (iter == queries->size())
+            break;
     }
 }
 
@@ -221,6 +227,8 @@ BENCHMARK_DEFINE_F(BM_BatchIterator, TopK_HNSW)(benchmark::State &st) {
         VecSimQueryResult_Free(bf_results);
         VecSimQueryResult_Free(hnsw_results);
         iter++;
+        if (iter == queries->size())
+            break;
         st.ResumeTiming();
     }
     st.counters["Recall"] = (float)correct / (k * iter);

--- a/tests/benchmark/data/hnsw_indices.txt
+++ b/tests/benchmark/data/hnsw_indices.txt
@@ -1,4 +1,5 @@
 http://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/DBpedia-n1M-cosine-d768-M64-EFC512.hnsw_v1
+http://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/DBpedia-test_vectors-n10k.raw
 http://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/mnist-784-euclidean-M=32-ef=150.hnsw
 http://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/glove-25-angular-M=16-ef=100.hnsw
 http://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/glove-50-angular-M=24-ef=150.hnsw


### PR DESCRIPTION
This refactor includes the following:
1. Switch to using query vector from DBPedia test set for the benchmark test cases (instead of random vectors). We load these upon constructing the benchmark class from a file that has been uploaded to s3.
2. Use the same query vectors in every test case, but different vectors in every iteration (rather than using a new random vector in every iteration of every test). 
3. Load HNSW and FLAT indices in the constructor, rather than in the setup method. This saves significant amount of time. Note that google benchmark is creating an instance for every test case class *before* it runs the tests. To reduce the memory usage, we create the base class as a single-tone, and reuse the indices among different test cases (that are guaranteed to run serially).
4. Upgrade google-test and google-benchmark versions.
   