### PR TITLE
Fixing benchmark run for #175 (#182)

### DIFF
--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(bm_basics VectorSimilarity benchmark::benchmark)
 # Adding files to complie after this line will have an effect on the resulted binaries. #
 #########################################################################################
 
+add_library(bm_spaces_class bm_spaces_class.cpp)
+target_link_libraries(bm_spaces_class benchmark::benchmark)
+
 include(CheckCXXCompilerFlag)
 # TODO: Remove this once cpu_features get support for M1
 if(NOT APPLE)
@@ -51,5 +54,6 @@ if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
 		message("Building with SSE")
 	endif()
 endif()
+
 add_executable(bm_spaces bm_spaces.cpp)
-target_link_libraries(bm_spaces VectorSimilarity benchmark::benchmark)
+target_link_libraries(bm_spaces VectorSimilarity benchmark::benchmark bm_spaces_class)

--- a/tests/benchmark/bm_spaces.cpp
+++ b/tests/benchmark/bm_spaces.cpp
@@ -6,47 +6,16 @@
 #include "VecSim/spaces/space_interface.h"
 #include "VecSim/spaces/space_aux.h"
 
-#include "VecSim/spaces/L2/L2.h"
-#include "VecSim/spaces/IP/IP.h"
-
-class BM_VecSimSpaces : public benchmark::Fixture {
-protected:
-    std::mt19937 rng;
-    size_t dim;
-    float *v1, *v2;
-    Arch_Optimization opt;
-
-    BM_VecSimSpaces() {
-        rng.seed(47);
-        opt = getArchitectureOptimization();
-    }
-
-public:
-    void SetUp(const ::benchmark::State &state) {
-        dim = state.range(0);
-        v1 = new float[dim];
-        v2 = new float[dim];
-        std::uniform_real_distribution<double> distrib(-1.0, 1.0);
-        for (size_t i = 0; i < dim; i++) {
-            v1[i] = (float)distrib(rng);
-            v2[i] = (float)distrib(rng);
-        }
-    }
-
-    void TearDown(const ::benchmark::State &state) {
-        delete v1;
-        delete v2;
-    }
-
-    ~BM_VecSimSpaces() {}
-};
+#include "bm_spaces_class.h"
 
 // Defining the generic benchmark flow: if there is support for the optimization, benchmark the
 // function.
 #define BENCHMARK_DISTANCE_F(arch, settings, func)                                                 \
     BENCHMARK_DEFINE_F(BM_VecSimSpaces, arch##_##settings)(benchmark::State & st) {                \
-        if (opt < ARCH_OPT_##arch)                                                                 \
+        if (opt < ARCH_OPT_##arch) {                                                               \
+            st.SkipWithError("This benchmark requires " #arch ", which is not available");         \
             return;                                                                                \
+        }                                                                                          \
         for (auto _ : st) {                                                                        \
             func(v1, v2, &dim);                                                                    \
         }                                                                                          \
@@ -101,6 +70,9 @@ BENCHMARK_DISTANCE_F(SSE, IP_4_Residuals, InnerProductSIMD4ExtResiduals_SSE)
 #endif // SSE
 
 // Naive algorithms
+
+#include "VecSim/spaces/L2/L2.h"
+#include "VecSim/spaces/IP/IP.h"
 
 BENCHMARK_DEFINE_F(BM_VecSimSpaces, NAIVE_IP)(benchmark::State &st) {
     for (auto _ : st) {

--- a/tests/benchmark/bm_spaces_class.cpp
+++ b/tests/benchmark/bm_spaces_class.cpp
@@ -1,0 +1,22 @@
+#include "bm_spaces_class.h"
+
+BM_VecSimSpaces::BM_VecSimSpaces() {
+    rng.seed(47);
+    opt = getArchitectureOptimization();
+}
+
+void BM_VecSimSpaces::SetUp(const ::benchmark::State &state) {
+    dim = state.range(0);
+    v1 = new float[dim];
+    v2 = new float[dim];
+    std::uniform_real_distribution<double> distrib(-1.0, 1.0);
+    for (size_t i = 0; i < dim; i++) {
+        v1[i] = (float)distrib(rng);
+        v2[i] = (float)distrib(rng);
+    }
+}
+
+void BM_VecSimSpaces::TearDown(const ::benchmark::State &state) {
+    delete v1;
+    delete v2;
+}

--- a/tests/benchmark/bm_spaces_class.h
+++ b/tests/benchmark/bm_spaces_class.h
@@ -1,0 +1,22 @@
+#include <benchmark/benchmark.h>
+#include <random>
+#include <unistd.h>
+#include "VecSim/utils/arr_cpp.h"
+#include "VecSim/spaces/space_includes.h"
+#include "VecSim/spaces/space_interface.h"
+#include "VecSim/spaces/space_aux.h"
+
+class BM_VecSimSpaces : public benchmark::Fixture {
+protected:
+    std::mt19937 rng;
+    size_t dim;
+    float *v1, *v2;
+    Arch_Optimization opt;
+
+public:
+    BM_VecSimSpaces();
+    ~BM_VecSimSpaces() {}
+
+    void SetUp(const ::benchmark::State &state);
+    void TearDown(const ::benchmark::State &state);
+};


### PR DESCRIPTION
* compile bm_saces class without optimizations

* changed names and moved functions

* improved benchmarks definitions

Co-authored-by: DvirDukhan <dvir@redis.com>