### PR TITLE
updating CI xcode version from 11.6.0 to 11.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
 
   build-macos:
       macos:
-        xcode: 11.6.0
+        xcode: 11.7.0
       steps:
        - abort_for_docs
        - abort_for_noci


### PR DESCRIPTION
updating CI xcode version from 11.6.0 to 11.7.0, which is the only xcode 11 version supported right now