### PR TITLE
Inheritance Refactor (#196)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ add_subdirectory(VecSim/spaces)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall")
 add_library(VectorSimilarity ${VECSIM_LIBTYPE}
     VecSim/algorithms/brute_force/brute_force.cpp
+    VecSim/algorithms/brute_force/brute_force_single.cpp
     VecSim/algorithms/brute_force/vector_block.cpp
 	VecSim/algorithms/hnsw/visited_nodes_handler.cpp
 	VecSim/algorithms/hnsw/hnsw_wrapper.cpp

--- a/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
+++ b/src/VecSim/algorithms/brute_force/bf_batch_iterator.cpp
@@ -8,13 +8,11 @@
 #include "VecSim/utils/vec_utils.h"
 #include "VecSim/query_result_struct.h"
 
-unsigned char BF_BatchIterator::next_id = 0;
-
 // heuristics: decide if using heap or select search, based on the ratio between the
 // number of remaining results and the index size.
 VecSimQueryResult_List BF_BatchIterator::searchByHeuristics(size_t n_res,
                                                             VecSimQueryResult_Order order) {
-    if ((this->index->indexSize() - this->getResultsCount()) / 1000 > n_res) {
+    if ((this->index->indexLabelCount() - this->getResultsCount()) / 1000 > n_res) {
         // Heap based search always returns the results ordered by score
         return this->heapBasedSearch(n_res);
     }
@@ -123,9 +121,7 @@ BF_BatchIterator::BF_BatchIterator(void *query_vector, const BruteForceIndex *bf
                                    VecSimQueryParams *queryParams,
                                    std::shared_ptr<VecSimAllocator> allocator)
     : VecSimBatchIterator(query_vector, queryParams ? queryParams->timeoutCtx : nullptr, allocator),
-      index(bf_index), scores_valid_start_pos(0) {
-    BF_BatchIterator::next_id++;
-}
+      index(bf_index), scores_valid_start_pos(0) {}
 
 VecSimQueryResult_List BF_BatchIterator::getNextResults(size_t n_res,
                                                         VecSimQueryResult_Order order) {
@@ -134,26 +130,14 @@ VecSimQueryResult_List BF_BatchIterator::getNextResults(size_t n_res,
     // Only in the first iteration we need to compute all the scores
     if (this->scores.empty()) {
         assert(getResultsCount() == 0);
-        this->scores.reserve(this->index->indexSize());
-        vecsim_stl::vector<VectorBlock *> blocks = this->index->getVectorBlocks();
-        VecSimQueryResult_Code rc;
 
-        idType curr_id = 0;
-        for (auto &block : blocks) {
-            // compute the scores for the vectors in every block and extend the scores array.
-            auto block_scores = this->index->computeBlockScores(block, this->getQueryBlob(),
-                                                                this->getTimeoutCtx(), &rc);
-            if (VecSim_OK != rc) {
-                return {NULL, rc};
-            }
-            for (size_t i = 0; i < block_scores.size(); i++) {
-                this->scores.emplace_back(block_scores[i], index->getVectorLabel(curr_id));
-                ++curr_id;
-            }
+        auto rc = calculateScores();
+
+        if (VecSim_OK != rc) {
+            return {NULL, rc};
         }
-        assert(curr_id == index->indexSize());
     }
-    if (__builtin_expect(VecSimIndex::timeoutCallback(this->getTimeoutCtx()), 0)) {
+    if (__builtin_expect(VecSimIndexAbstract::timeoutCallback(this->getTimeoutCtx()), 0)) {
         return {NULL, VecSim_QueryResult_TimedOut};
     }
     VecSimQueryResult_List rl = searchByHeuristics(n_res, order);
@@ -166,8 +150,8 @@ VecSimQueryResult_List BF_BatchIterator::getNextResults(size_t n_res,
 }
 
 bool BF_BatchIterator::isDepleted() {
-    assert(this->getResultsCount() <= this->index->indexSize());
-    bool depleted = this->getResultsCount() == this->index->indexSize();
+    assert(this->getResultsCount() <= this->index->indexLabelCount());
+    bool depleted = this->getResultsCount() == this->index->indexLabelCount();
     return depleted;
 }
 
@@ -175,4 +159,27 @@ void BF_BatchIterator::reset() {
     this->scores.clear();
     this->resetResultsCount();
     this->scores_valid_start_pos = 0;
+}
+
+VecSimQueryResult_Code BF_BatchIterator::calculateScores() {
+
+    this->scores.reserve(this->index->indexLabelCount());
+    vecsim_stl::vector<VectorBlock *> blocks = this->index->getVectorBlocks();
+    VecSimQueryResult_Code rc;
+
+    idType curr_id = 0;
+    for (auto &block : blocks) {
+        // compute the scores for the vectors in every block and extend the scores array.
+        auto block_scores = this->index->computeBlockScores(block, this->getQueryBlob(),
+                                                            this->getTimeoutCtx(), &rc);
+        if (VecSim_OK != rc) {
+            return rc;
+        }
+        for (size_t i = 0; i < block_scores.size(); i++) {
+            this->scores.emplace_back(block_scores[i], index->getVectorLabel(curr_id));
+            ++curr_id;
+        }
+    }
+    assert(curr_id == index->indexSize());
+    return VecSim_QueryResult_OK;
 }

--- a/src/VecSim/algorithms/brute_force/bf_batch_iterator.h
+++ b/src/VecSim/algorithms/brute_force/bf_batch_iterator.h
@@ -12,13 +12,14 @@ private:
     vector<pair<float, labelType>> scores; // vector of scores for every label.
     size_t scores_valid_start_pos; // the first index in the scores vector that contains a vector
                                    // that hasn't been returned already.
-    static unsigned char next_id;  // this holds the next available id to be used by a new instance.
 
     VecSimQueryResult_List searchByHeuristics(size_t n_res, VecSimQueryResult_Order order);
     VecSimQueryResult_List selectBasedSearch(size_t n_res);
     VecSimQueryResult_List heapBasedSearch(size_t n_res);
     void swapScores(const vecsim_stl::unordered_map<size_t, size_t> &TopCandidatesIndices,
                     size_t res_num);
+
+    inline VecSimQueryResult_Code calculateScores();
 
 public:
     BF_BatchIterator(void *query_vector, const BruteForceIndex *index,

--- a/src/VecSim/algorithms/brute_force/brute_force.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force.cpp
@@ -1,9 +1,9 @@
 
 #include "brute_force.h"
 #include "VecSim/spaces/spaces.h"
-#include "VecSim/utils/vec_utils.h"
 #include "VecSim/query_result_struct.h"
 #include "VecSim/algorithms/brute_force/bf_batch_iterator.h"
+#include "VecSim/algorithms/brute_force/brute_force_single.h"
 
 #include <memory>
 #include <cstring>
@@ -12,16 +12,12 @@
 #include <cmath>
 
 using namespace std;
-using spaces::dist_func_t;
 
 /******************** Ctor / Dtor **************/
 BruteForceIndex::BruteForceIndex(const BFParams *params, std::shared_ptr<VecSimAllocator> allocator)
-    : VecSimIndex(allocator), dim(params->dim), vecType(params->type), metric(params->metric),
-      labelToIdLookup(allocator), idToLabelMapping(allocator), vectorBlocks(allocator),
-      vectorBlockSize(params->blockSize ? params->blockSize : DEFAULT_BLOCK_SIZE), count(0),
-      last_mode(EMPTY_MODE) {
-    assert(VecSimType_sizeof(vecType));
-    spaces::SetDistFunc(metric, dim, &dist_func);
+    : VecSimIndexAbstract(allocator, params->dim, params->type, params->metric, params->blockSize,
+                          params->multi),
+      idToLabelMapping(allocator), vectorBlocks(allocator), count(0) {
     this->idToLabelMapping.resize(params->initialCapacity);
 }
 
@@ -31,10 +27,23 @@ BruteForceIndex::~BruteForceIndex() {
     }
 }
 
+/******************** inheritance factory **************/
+
+BruteForceIndex *BruteForceIndex::BruteForceIndex_New(const BFParams *params,
+                                                      std::shared_ptr<VecSimAllocator> allocator) {
+    assert(!params->multi);
+    return new (allocator) BruteForceIndex_Single(params, allocator);
+}
+
 /******************** Implementation **************/
 size_t BruteForceIndex::estimateInitialSize(const BFParams *params) {
     // Constant part (not effected by parameters).
-    size_t est = sizeof(VecSimAllocator) + sizeof(BruteForceIndex) + sizeof(size_t);
+    size_t est = sizeof(VecSimAllocator) + sizeof(size_t);
+    if (params->multi)
+        est += sizeof(BruteForceIndex); // change to BruteForceIndex_Multi
+    else
+        est += sizeof(BruteForceIndex_Single);
+
     // Parameters related part.
 
     if (params->initialCapacity) {
@@ -49,33 +58,7 @@ size_t BruteForceIndex::estimateElementMemory(const BFParams *params) {
     return params->dim * sizeof(float) + sizeof(idType);
 }
 
-void BruteForceIndex::updateVector(idType id, const void *vector_data) {
-
-    // Get the vector block
-    VectorBlock *vectorBlock = getVectorVectorBlock(id);
-    size_t index = getVectorRelativeIndex(id);
-
-    // Update vector data in the block.
-    vectorBlock->updateVector(index, vector_data);
-}
-
-int BruteForceIndex::addVector(const void *vector_data, size_t label) {
-
-    float normalized_data[this->dim]; // This will be use only if metric == VecSimMetric_Cosine
-    if (this->metric == VecSimMetric_Cosine) {
-        // TODO: need more generic
-        memcpy(normalized_data, vector_data, this->dim * sizeof(float));
-        float_vector_normalize(normalized_data, this->dim);
-        vector_data = normalized_data;
-    }
-
-    auto optionalID = this->labelToIdLookup.find(label);
-    // Check if label already exists, so it is an update operation.
-    if (optionalID != this->labelToIdLookup.end()) {
-        idType id = optionalID->second;
-        updateVector(id, vector_data);
-        return true;
-    }
+int BruteForceIndex::appendVector(const void *vector_data, labelType label) {
 
     // Give the vector new id and increase count.
     idType id = count++;
@@ -83,9 +66,9 @@ int BruteForceIndex::addVector(const void *vector_data, size_t label) {
     // Get vector block to store the vector in.
 
     // if vectorBlocks vector is empty or last_vector_block is full create a new block
-    if (id % vectorBlockSize == 0) {
+    if (id % blockSize == 0) {
         VectorBlock *new_vectorBlock =
-            new (this->allocator) VectorBlock(this->vectorBlockSize, this->dim, this->allocator);
+            new (this->allocator) VectorBlock(this->blockSize, this->dim, this->allocator);
         this->vectorBlocks.push_back(new_vectorBlock);
     }
 
@@ -98,35 +81,25 @@ int BruteForceIndex::addVector(const void *vector_data, size_t label) {
     vectorBlock->addVector(vector_data);
 
     // if idToLabelMapping is full,
-    // resize and align idToLabelMapping by vectorBlockSize
+    // resize and align idToLabelMapping by blockSize
     size_t idToLabelMapping_size = this->idToLabelMapping.size();
 
     if (id >= idToLabelMapping_size) {
-        size_t last_block_vectors_count = id % vectorBlockSize;
-        this->idToLabelMapping.resize(
-            idToLabelMapping_size + vectorBlockSize - last_block_vectors_count, 0);
+        size_t last_block_vectors_count = id % blockSize;
+        this->idToLabelMapping.resize(idToLabelMapping_size + blockSize - last_block_vectors_count,
+                                      0);
     }
 
     // add label to idToLabelMapping
     setVectorLabel(id, label);
 
     // add id to label:id map
-    this->labelToIdLookup.emplace(label, id);
+    setVectorId(label, id);
 
     return true;
 }
 
-int BruteForceIndex::deleteVector(size_t label) {
-
-    // Find the id to delete.
-    auto deleted_label_id_pair = this->labelToIdLookup.find(label);
-    if (deleted_label_id_pair == this->labelToIdLookup.end()) {
-        // Nothing to delete.
-        return true;
-    }
-
-    // Get deleted vector id.
-    idType id_to_delete = deleted_label_id_pair->second;
+int BruteForceIndex::removeVector(idType id_to_delete) {
 
     // Get last vector id and label
     idType last_idx = --count;
@@ -138,10 +111,7 @@ int BruteForceIndex::deleteVector(size_t label) {
 
     float *last_vector_data = last_vector_block->removeAndFetchLastVector();
 
-    // Remove the pair of the deleted vector.
-    labelToIdLookup.erase(label);
-
-    // If we are *not* trying to remove the last vector, update mappind and move
+    // If we are *not* trying to remove the last vector, update mapping and move
     // the data of the last vector in the index in place of the deleted vector.
     if (id_to_delete != last_idx) {
         // Update id2labelmapping.
@@ -150,13 +120,13 @@ int BruteForceIndex::deleteVector(size_t label) {
 
         // Update label2id mapping.
         // Update this id in label:id pair of last index.
-        setLabelToId(last_idx_label, id_to_delete);
+        replaceIdOfLabel(last_idx_label, id_to_delete, last_idx);
 
         // Get the vectorBlock and the relative index of the deleted id.
         VectorBlock *deleted_vectorBlock = getVectorVectorBlock(id_to_delete);
         size_t id_to_delete_rel_idx = getVectorRelativeIndex(id_to_delete);
 
-        // Put data of last vector inpalce of the deleted vector.
+        // Put data of last vector inplace of the deleted vector.
         deleted_vectorBlock->updateVector(id_to_delete_rel_idx, last_vector_data);
     }
 
@@ -167,29 +137,15 @@ int BruteForceIndex::deleteVector(size_t label) {
 
         // Resize and align the id2labelmapping.
         size_t id2label_size = idToLabelMapping.size();
-        // If the new size is smaller by at least one block comparing to the id2labemapping
-        // align to be a multlipication of blocksize  and resize by one block.
-        if (count + vectorBlockSize <= id2label_size) {
-            size_t vector_to_align_count = id2label_size % vectorBlockSize;
-            this->idToLabelMapping.resize(id2label_size - vectorBlockSize - vector_to_align_count);
+        // If the new size is smaller by at least one block comparing to the id2labelmapping
+        // align to be a multiplication of blocksize  and resize by one block.
+        if (count + blockSize <= id2label_size) {
+            size_t vector_to_align_count = id2label_size % blockSize;
+            this->idToLabelMapping.resize(id2label_size - blockSize - vector_to_align_count);
         }
     }
 
     return true;
-}
-
-double BruteForceIndex::getDistanceFrom(size_t label, const void *vector_data) {
-    auto optionalId = this->labelToIdLookup.find(label);
-    if (optionalId == this->labelToIdLookup.end()) {
-        return INVALID_SCORE;
-    }
-    idType id = optionalId->second;
-
-    // Get the vectorBlock and the relative index of the required id.
-    VectorBlock *req_vectorBlock = getVectorVectorBlock(id);
-    size_t req_rel_idx = getVectorRelativeIndex(id);
-
-    return this->dist_func(req_vectorBlock->getVector(req_rel_idx), vector_data, &this->dim);
 }
 
 size_t BruteForceIndex::indexSize() const { return this->count; }
@@ -202,7 +158,7 @@ vecsim_stl::vector<float> BruteForceIndex::computeBlockScores(VectorBlock *block
     size_t len = block->getLength();
     vecsim_stl::vector<float> scores(len, this->allocator);
     for (size_t i = 0; i < len; i++) {
-        if (__builtin_expect(VecSimIndex::timeoutCallback(timeoutCtx), 0)) {
+        if (__builtin_expect(VecSimIndexAbstract::timeoutCallback(timeoutCtx), 0)) {
             *rc = VecSim_QueryResult_TimedOut;
             return scores;
         }
@@ -308,13 +264,15 @@ VecSimIndexInfo BruteForceIndex::info() const {
     info.bfInfo.type = this->vecType;
     info.bfInfo.metric = this->metric;
     info.bfInfo.indexSize = this->count;
-    info.bfInfo.blockSize = this->vectorBlockSize;
+    info.bfInfo.indexLabelCount = this->indexLabelCount();
+    info.bfInfo.blockSize = this->blockSize;
     info.bfInfo.memory = this->allocator->getAllocationSize();
+    info.bfInfo.isMulti = this->isMulti;
     info.bfInfo.last_mode = this->last_mode;
     return info;
 }
 
-VecSimInfoIterator *BruteForceIndex::infoIterator() {
+VecSimInfoIterator *BruteForceIndex::infoIterator() const {
     VecSimIndexInfo info = this->info();
     // For readability. Update this number when needed.
     size_t numberOfInfoFields = 8;
@@ -334,9 +292,16 @@ VecSimInfoIterator *BruteForceIndex::infoIterator() {
         VecSim_InfoField{.fieldName = VecSimCommonStrings::METRIC_STRING,
                          .fieldType = INFOFIELD_STRING,
                          .stringValue = VecSimMetric_ToString(info.bfInfo.metric)});
+    infoIterator->addInfoField(VecSim_InfoField{.fieldName = VecSimCommonStrings::IS_MULTI_STRING,
+                                                .fieldType = INFOFIELD_UINT64,
+                                                .uintegerValue = info.bfInfo.isMulti});
     infoIterator->addInfoField(VecSim_InfoField{.fieldName = VecSimCommonStrings::INDEX_SIZE_STRING,
                                                 .fieldType = INFOFIELD_UINT64,
                                                 .uintegerValue = info.bfInfo.indexSize});
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::INDEX_LABEL_COUNT_STRING,
+                         .fieldType = INFOFIELD_UINT64,
+                         .uintegerValue = info.bfInfo.indexLabelCount});
     infoIterator->addInfoField(VecSim_InfoField{.fieldName = VecSimCommonStrings::BLOCK_SIZE_STRING,
                                                 .fieldType = INFOFIELD_UINT64,
                                                 .uintegerValue = info.bfInfo.blockSize});

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -9,21 +9,18 @@
 #include <cassert>
 #include <limits>
 
-using spaces::dist_func_t;
-
-class BruteForceIndex : public VecSimIndex {
+class BruteForceIndex : public VecSimIndexAbstract {
 protected:
-    size_t dim;
-    VecSimType vecType;
-    VecSimMetric metric;
+    vecsim_stl::vector<labelType> idToLabelMapping;
+    vecsim_stl::vector<VectorBlock *> vectorBlocks;
+    idType count;
 
 public:
     BruteForceIndex(const BFParams *params, std::shared_ptr<VecSimAllocator> allocator);
+    static BruteForceIndex *BruteForceIndex_New(const BFParams *params,
+                                                std::shared_ptr<VecSimAllocator> allocator);
     static size_t estimateInitialSize(const BFParams *params);
     static size_t estimateElementMemory(const BFParams *params);
-    virtual int addVector(const void *vector_data, size_t label) override;
-    virtual int deleteVector(size_t id) override;
-    virtual double getDistanceFrom(size_t label, const void *vector_data) override;
     virtual size_t indexSize() const override;
     vecsim_stl::vector<float> computeBlockScores(VectorBlock *block, const void *queryBlob,
                                                  void *timeoutCtx,
@@ -33,42 +30,37 @@ public:
     VecSimQueryResult_List rangeQuery(const void *queryBlob, float radius,
                                       VecSimQueryParams *queryParams) override;
     virtual VecSimIndexInfo info() const override;
-    virtual VecSimInfoIterator *infoIterator() override;
+    virtual VecSimInfoIterator *infoIterator() const override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob,
                                                   VecSimQueryParams *queryParams) override;
     bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) override;
-    inline labelType getVectorLabel(idType id) const {
-        return idToLabelMapping.at(id);
-    } // throws out_of_range
-    inline labelType getVectorId(labelType label) const {
-        return labelToIdLookup.at(label);
-    } // throws out_of_range
+    inline labelType getVectorLabel(idType id) const { return idToLabelMapping.at(id); }
 
     inline vecsim_stl::vector<VectorBlock *> getVectorBlocks() const { return vectorBlocks; }
-    inline dist_func_t<float> distFunc() const { return dist_func; }
-    inline void setLastSearchMode(VecSearchMode mode) override { this->last_mode = mode; }
     virtual ~BruteForceIndex();
 
-private:
-    void updateVector(idType id, const void *vector_data);
-    inline VectorBlock *getVectorVectorBlock(idType id) {
-        return vectorBlocks.at(id / vectorBlockSize);
+protected:
+    // Private internal function that implements generic single vector insertion.
+    virtual int appendVector(const void *vector_data, labelType label);
+
+    // Private internal function that implements generic single vector deletion.
+    virtual int removeVector(idType id);
+
+    inline float *getDataByInternalId(idType id) const {
+        return vectorBlocks.at(id / blockSize)->getVector(id % blockSize);
     }
-    inline size_t getVectorRelativeIndex(idType id) { return id % vectorBlockSize; }
+    inline VectorBlock *getVectorVectorBlock(idType id) const {
+        return vectorBlocks.at(id / blockSize);
+    }
+    inline size_t getVectorRelativeIndex(idType id) const { return id % blockSize; }
     inline void setVectorLabel(idType id, labelType new_label) {
         idToLabelMapping.at(id) = new_label;
-    } // throws out_of_range
-    inline void setLabelToId(labelType label, idType new_id) {
-        labelToIdLookup.at(label) = new_id;
-    } // throws out_of_range
+    }
 
-    vecsim_stl::unordered_map<labelType, idType> labelToIdLookup;
-    vecsim_stl::vector<labelType> idToLabelMapping;
-    vecsim_stl::vector<VectorBlock *> vectorBlocks;
-    size_t vectorBlockSize;
-    idType count;
-    dist_func_t<float> dist_func;
-    VecSearchMode last_mode;
+    // inline label to id setters that need to be implemented by derived class
+    virtual inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) = 0;
+    virtual inline void setVectorId(labelType label, idType id) = 0;
+
 #ifdef BUILD_TESTS
     // Allow the following tests to access the index private members.
     friend class BruteForceTest_preferAdHocOptimization_Test;

--- a/src/VecSim/algorithms/brute_force/brute_force_single.cpp
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.cpp
@@ -1,0 +1,59 @@
+#include "brute_force_single.h"
+#include "VecSim/utils/vec_utils.h"
+#include "VecSim/query_result_struct.h"
+
+BruteForceIndex_Single::BruteForceIndex_Single(const BFParams *params,
+                                               std::shared_ptr<VecSimAllocator> allocator)
+    : BruteForceIndex(params, allocator), labelToIdLookup(allocator) {}
+
+BruteForceIndex_Single::~BruteForceIndex_Single() {}
+
+int BruteForceIndex_Single::addVector(const void *vector_data, size_t label) {
+
+    float normalized_data[this->dim]; // This will be use only if metric == VecSimMetric_Cosine
+    if (this->metric == VecSimMetric_Cosine) {
+        // TODO: need more generic
+        memcpy(normalized_data, vector_data, this->dim * sizeof(float));
+        float_vector_normalize(normalized_data, this->dim);
+        vector_data = normalized_data;
+    }
+
+    auto optionalID = this->labelToIdLookup.find(label);
+    // Check if label already exists, so it is an update operation.
+    if (optionalID != this->labelToIdLookup.end()) {
+        idType id = optionalID->second;
+        updateVector(id, vector_data);
+        return true;
+    }
+
+    return appendVector(vector_data, label);
+}
+
+int BruteForceIndex_Single::deleteVector(size_t label) {
+
+    // Find the id to delete.
+    auto deleted_label_id_pair = this->labelToIdLookup.find(label);
+    if (deleted_label_id_pair == this->labelToIdLookup.end()) {
+        // Nothing to delete.
+        return true;
+    }
+
+    // Get deleted vector id.
+    idType id_to_delete = deleted_label_id_pair->second;
+
+    // Remove the pair of the deleted vector.
+    labelToIdLookup.erase(label);
+
+    return removeVector(id_to_delete);
+}
+
+double BruteForceIndex_Single::getDistanceFrom(size_t label, const void *vector_data) const {
+
+    auto optionalId = this->labelToIdLookup.find(label);
+    if (optionalId == this->labelToIdLookup.end()) {
+        return INVALID_SCORE;
+    }
+    idType id = optionalId->second;
+
+    return this->dist_func(getDataByInternalId(id), vector_data, &this->dim);
+}

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "brute_force.h"
+
+class BruteForceIndex_Single : public BruteForceIndex {
+protected:
+    vecsim_stl::unordered_map<labelType, idType> labelToIdLookup;
+
+public:
+    BruteForceIndex_Single(const BFParams *params, std::shared_ptr<VecSimAllocator> allocator);
+    ~BruteForceIndex_Single();
+
+    virtual int addVector(const void *vector_data, size_t label) override;
+    virtual int deleteVector(size_t id) override;
+    virtual double getDistanceFrom(size_t label, const void *vector_data) const override;
+
+    virtual inline size_t indexLabelCount() const override { return this->count; }
+
+protected:
+    // inline definitions
+
+    inline void updateVector(idType id, const void *vector_data) {
+
+        // Get the vector block
+        VectorBlock *vectorBlock = getVectorVectorBlock(id);
+        size_t index = getVectorRelativeIndex(id);
+
+        // Update vector data in the block.
+        vectorBlock->updateVector(index, vector_data);
+    }
+
+    inline void setVectorId(labelType label, idType id) override {
+        labelToIdLookup.emplace(label, id);
+    }
+
+    inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) override {
+        labelToIdLookup.at(label) = new_id;
+    }
+
+#ifdef BUILD_TESTS
+    // Allow the following tests to access the index private members.
+    friend class BruteForceTest_preferAdHocOptimization_Test;
+    friend class BruteForceTest_test_dynamic_bf_info_iterator_Test;
+    friend class BruteForceTest_resizeNAlignIndex_Test;
+    friend class BruteForceTest_brute_force_vector_update_test_Test;
+    friend class BruteForceTest_brute_force_reindexing_same_vector_Test;
+    friend class BruteForceTest_test_delete_swap_block_Test;
+    friend class BruteForceTest_brute_force_zero_minimal_capacity_Test;
+    friend class BruteForceTest_resizeNAlignIndex_largeInitialCapacity_Test;
+    friend class BruteForceTest_brute_force_empty_index_Test;
+    friend class BM_VecSimBasics_DeleteVectorBF_Benchmark;
+#endif
+};

--- a/src/VecSim/algorithms/brute_force/vector_block.h
+++ b/src/VecSim/algorithms/brute_force/vector_block.h
@@ -5,9 +5,6 @@
 
 #include "VecSim/utils/vec_utils.h"
 
-typedef size_t labelType;
-typedef size_t idType;
-
 struct VectorBlock : public VecsimBaseObject {
 
 public:

--- a/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.cpp
@@ -57,7 +57,7 @@ candidatesMaxHeap HNSW_BatchIterator::scanGraph(candidatesMinHeap &candidates,
         candidates.emplace(dist, entry_point);
     }
     // Checks that we didn't got timeout between iterations.
-    if (__builtin_expect(VecSimIndex::timeoutCallback(this->getTimeoutCtx()), 0)) {
+    if (__builtin_expect(VecSimIndexAbstract::timeoutCallback(this->getTimeoutCtx()), 0)) {
         *rc = VecSim_QueryResult_TimedOut;
         return top_candidates;
     }
@@ -80,7 +80,7 @@ candidatesMaxHeap HNSW_BatchIterator::scanGraph(candidatesMinHeap &candidates,
         if (curr_node_dist > lower_bound && top_candidates.size() >= this->hnsw_index->getEf()) {
             break;
         }
-        if (__builtin_expect(VecSimIndex::timeoutCallback(this->getTimeoutCtx()), 0)) {
+        if (__builtin_expect(VecSimIndexAbstract::timeoutCallback(this->getTimeoutCtx()), 0)) {
             *rc = VecSim_QueryResult_TimedOut;
             return top_candidates;
         }
@@ -142,8 +142,8 @@ HNSW_BatchIterator::HNSW_BatchIterator(void *query_vector, HNSWIndex *index_wrap
       candidates(this->allocator) {
 
     this->hnsw_index = index_wrapper->getHNSWIndex();
-    this->dist_func = hnsw_index->GetDistFunc();
-    this->dim = hnsw_index->GetDim();
+    this->dist_func = index_wrapper->GetDistFunc();
+    this->dim = index_wrapper->GetDim();
     this->entry_point = hnsw_index->getEntryPointId();
     // Use "fresh" tag to mark nodes that were visited along the search in some iteration.
     this->visited_list = hnsw_index->getVisitedList();
@@ -186,7 +186,7 @@ VecSimQueryResult_List HNSW_BatchIterator::getNextResults(size_t n_res,
     batch = this->prepareResults(top_candidates, n_res);
 
     this->updateResultsCount(VecSimQueryResult_Len(batch));
-    if (this->getResultsCount() == this->index_wrapper->indexSize()) {
+    if (this->getResultsCount() == this->index_wrapper->indexLabelCount()) {
         this->depleted = true;
     }
     // By default, results are ordered by score.

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.cpp
@@ -1,8 +1,5 @@
 #include "VecSim/algorithms/hnsw/hnsw_wrapper.h"
 #include "VecSim/utils/arr_cpp.h"
-#include "VecSim/utils/vec_utils.h"
-#include "VecSim/spaces/L2_space.h"
-#include "VecSim/spaces/IP_space.h"
 #include "VecSim/query_result_struct.h"
 #include "VecSim/algorithms/hnsw/hnsw_batch_iterator.h"
 
@@ -16,19 +13,31 @@ using namespace hnswlib;
 /******************** Ctor / Dtor **************/
 
 HNSWIndex::HNSWIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator)
-    : VecSimIndex(allocator), dim(params->dim), vecType(params->type), metric(params->metric),
-      blockSize(params->blockSize ? params->blockSize : DEFAULT_BLOCK_SIZE),
-      hnsw(new (allocator) hnswlib::HierarchicalNSW<float>(params, allocator)),
-      last_mode(EMPTY_MODE) {}
+    : VecSimIndexAbstract(allocator, params->dim, params->type, params->metric, params->blockSize,
+                          params->multi),
+      hnsw(new (allocator) hnswlib::HierarchicalNSW<float>(params, this->dist_func, allocator)) {}
+
+/******************** inheritance factory **************/
+
+HNSWIndex *HNSWIndex::HNSWIndex_New(const HNSWParams *params,
+                                    std::shared_ptr<VecSimAllocator> allocator) {
+    assert(!params->multi);
+    return new (allocator) HNSWIndex(params, allocator);
+}
 
 /******************** Implementation **************/
 size_t HNSWIndex::estimateInitialSize(const HNSWParams *params) {
-    size_t est = sizeof(VecSimAllocator) + sizeof(HNSWIndex) + sizeof(size_t);
+    size_t est = sizeof(VecSimAllocator) + sizeof(size_t);
+    if (params->multi)
+        est += sizeof(HNSWIndex); // change to HNSWIndex_Multi
+    else
+        est += sizeof(HNSWIndex); // change to HNSWIndex_Single
     est += sizeof(*hnsw) + sizeof(size_t);
-    est += sizeof(VisitedNodesHandler) + sizeof(size_t);
     // Used for synchronization only when parallel indexing / searching is enabled.
 #ifdef ENABLE_PARALLELIZATION
-    est += sizeof(VisitedNodesHandlerPool);
+    est += sizeof(VisitedNodesHandlerPool) + sizeof(size_t);
+#else
+    est += sizeof(VisitedNodesHandler) + sizeof(size_t);
 #endif
     est += sizeof(tag_t) * params->initialCapacity + sizeof(size_t); // visited nodes
 
@@ -38,19 +47,19 @@ size_t HNSWIndex::estimateInitialSize(const HNSWParams *params) {
            sizeof(size_t); // Labels lookup hash table buckets.
 
     size_t size_links_level0 =
-        sizeof(linklistsizeint) + params->M * 2 * sizeof(tableint) + sizeof(void *);
+        sizeof(linklistsizeint) + params->M * 2 * sizeof(idType) + sizeof(void *);
     size_t size_total_data_per_element =
-        size_links_level0 + params->dim * sizeof(float) + sizeof(labeltype);
+        size_links_level0 + params->dim * sizeof(float) + sizeof(labelType);
     est += params->initialCapacity * size_total_data_per_element + sizeof(size_t);
 
     return est;
 }
 
 size_t HNSWIndex::estimateElementMemory(const HNSWParams *params) {
-    size_t size_links_level0 = sizeof(linklistsizeint) + params->M * 2 * sizeof(tableint) +
-                               sizeof(void *) + sizeof(vecsim_stl::vector<tableint>);
-    size_t size_links_higher_level = sizeof(linklistsizeint) + params->M * sizeof(tableint) +
-                                     sizeof(void *) + sizeof(vecsim_stl::vector<tableint>);
+    size_t size_links_level0 = sizeof(linklistsizeint) + params->M * 2 * sizeof(idType) +
+                               sizeof(void *) + sizeof(vecsim_stl::vector<idType>);
+    size_t size_links_higher_level = sizeof(linklistsizeint) + params->M * sizeof(idType) +
+                                     sizeof(void *) + sizeof(vecsim_stl::vector<idType>);
     // The Expectancy for the random variable which is the number of levels per element equals
     // 1/ln(M). Since the max_level is rounded to the "floor" integer, the actual average number
     // of levels is lower (intuitively, we "loose" a level every time the random generated number
@@ -60,7 +69,7 @@ size_t HNSWIndex::estimateElementMemory(const HNSWParams *params) {
         ceil((1 / (2 * log(params->M))) * (float)size_links_higher_level);
 
     size_t size_total_data_per_element = size_links_level0 + expected_size_links_higher_levels +
-                                         params->dim * sizeof(float) + sizeof(labeltype);
+                                         params->dim * sizeof(float) + sizeof(labelType);
 
     // For every new vector, a new node of size 24 is allocated in a bucket of the hash table.
     size_t size_label_lookup_node =
@@ -109,7 +118,7 @@ int HNSWIndex::addVector(const void *vector_data, size_t id) {
 
 int HNSWIndex::deleteVector(size_t id) {
 
-    // If id doesnt exist.
+    // If id doesn't exist.
     if (!this->hnsw->isLabelExist(id)) {
         return false;
     }
@@ -133,11 +142,13 @@ int HNSWIndex::deleteVector(size_t id) {
     return true;
 }
 
-double HNSWIndex::getDistanceFrom(size_t label, const void *vector_data) {
+double HNSWIndex::getDistanceFrom(size_t label, const void *vector_data) const {
     return this->hnsw->getDistanceByLabelFromPoint(label, vector_data);
 }
 
 size_t HNSWIndex::indexSize() const { return this->hnsw->getIndexSize(); }
+
+size_t HNSWIndex::indexLabelCount() const { return this->hnsw->getIndexLabelCount(); }
 
 void HNSWIndex::setEf(size_t ef) { this->hnsw->setEf(ef); }
 
@@ -225,6 +236,7 @@ VecSimIndexInfo HNSWIndex::info() const {
     info.algo = VecSimAlgo_HNSWLIB;
     info.hnswInfo.dim = this->dim;
     info.hnswInfo.type = this->vecType;
+    info.hnswInfo.isMulti = this->isMulti;
     info.hnswInfo.metric = this->metric;
     info.hnswInfo.blockSize = this->blockSize;
     info.hnswInfo.M = this->hnsw->getM();
@@ -232,6 +244,7 @@ VecSimIndexInfo HNSWIndex::info() const {
     info.hnswInfo.efRuntime = this->hnsw->getEf();
     info.hnswInfo.epsilon = this->hnsw->getEpsilon();
     info.hnswInfo.indexSize = this->hnsw->getIndexSize();
+    info.hnswInfo.indexLabelCount = this->indexLabelCount();
     info.hnswInfo.max_level = this->hnsw->getMaxLevel();
     info.hnswInfo.entrypoint = this->hnsw->getEntryPointLabel();
     info.hnswInfo.memory = this->allocator->getAllocationSize();
@@ -254,7 +267,7 @@ VecSimBatchIterator *HNSWIndex::newBatchIterator(const void *queryBlob,
         HNSW_BatchIterator(queryBlobCopy, this, queryParams, this->allocator);
 }
 
-VecSimInfoIterator *HNSWIndex::infoIterator() {
+VecSimInfoIterator *HNSWIndex::infoIterator() const {
     VecSimIndexInfo info = this->info();
     // For readability. Update this number when needed.
     size_t numberOfInfoFields = 12;
@@ -274,9 +287,16 @@ VecSimInfoIterator *HNSWIndex::infoIterator() {
         VecSim_InfoField{.fieldName = VecSimCommonStrings::METRIC_STRING,
                          .fieldType = INFOFIELD_STRING,
                          .stringValue = VecSimMetric_ToString(info.hnswInfo.metric)});
+    infoIterator->addInfoField(VecSim_InfoField{.fieldName = VecSimCommonStrings::IS_MULTI_STRING,
+                                                .fieldType = INFOFIELD_UINT64,
+                                                .uintegerValue = info.bfInfo.isMulti});
     infoIterator->addInfoField(VecSim_InfoField{.fieldName = VecSimCommonStrings::INDEX_SIZE_STRING,
                                                 .fieldType = INFOFIELD_UINT64,
                                                 .uintegerValue = info.hnswInfo.indexSize});
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::INDEX_LABEL_COUNT_STRING,
+                         .fieldType = INFOFIELD_UINT64,
+                         .uintegerValue = info.hnswInfo.indexLabelCount});
     infoIterator->addInfoField(VecSim_InfoField{.fieldName = VecSimCommonStrings::HNSW_M_STRING,
                                                 .fieldType = INFOFIELD_UINT64,
                                                 .uintegerValue = info.hnswInfo.M});

--- a/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_wrapper.h
@@ -4,36 +4,31 @@
 #include "VecSim/algorithms/hnsw/hnswlib.h"
 #include <memory>
 
-class HNSWIndex : public VecSimIndex {
-protected:
-    size_t dim;
-    VecSimType vecType;
-    VecSimMetric metric;
-    size_t blockSize;
-
+class HNSWIndex : public VecSimIndexAbstract {
 public:
     HNSWIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator);
+    static HNSWIndex *HNSWIndex_New(const HNSWParams *params,
+                                    std::shared_ptr<VecSimAllocator> allocator);
     static size_t estimateInitialSize(const HNSWParams *params);
     static size_t estimateElementMemory(const HNSWParams *params);
     virtual int addVector(const void *vector_data, size_t label) override;
     virtual int deleteVector(size_t id) override;
-    virtual double getDistanceFrom(size_t label, const void *vector_data) override;
+    virtual double getDistanceFrom(size_t label, const void *vector_data) const override;
     virtual size_t indexSize() const override;
+    virtual size_t indexLabelCount() const override;
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                              VecSimQueryParams *queryParams) override;
     VecSimQueryResult_List rangeQuery(const void *queryBlob, float radius,
                                       VecSimQueryParams *queryParams) override;
     virtual VecSimIndexInfo info() const override;
-    virtual VecSimInfoIterator *infoIterator() override;
+    virtual VecSimInfoIterator *infoIterator() const override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob,
                                                   VecSimQueryParams *queryParams) override;
     bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) override;
 
     void setEf(size_t ef);
     inline std::shared_ptr<hnswlib::HierarchicalNSW<float>> getHNSWIndex() { return hnsw; }
-    inline void setLastSearchMode(VecSearchMode mode) override { this->last_mode = mode; }
 
 private:
     std::shared_ptr<hnswlib::HierarchicalNSW<float>> hnsw;
-    VecSearchMode last_mode;
 };

--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -28,14 +28,12 @@ using spaces::dist_func_t;
 #define HNSW_INVALID_ID    UINT_MAX
 #define HNSW_INVALID_LEVEL SIZE_MAX
 
-typedef size_t labeltype;
-typedef unsigned int tableint;
 typedef unsigned int linklistsizeint;
 
 template <typename dist_t>
-using candidatesMaxHeap = vecsim_stl::max_priority_queue<pair<dist_t, tableint>>;
+using candidatesMaxHeap = vecsim_stl::max_priority_queue<pair<dist_t, idType>>;
 template <typename dist_t>
-using candidatesLabelsMaxHeap = vecsim_stl::max_priority_queue<pair<dist_t, labeltype>>;
+using candidatesLabelsMaxHeap = vecsim_stl::max_priority_queue<pair<dist_t, labelType>>;
 
 template <typename dist_t>
 class HierarchicalNSW : public VecsimBaseObject {
@@ -63,6 +61,9 @@ private:
     size_t incoming_links_offset;
     double mult_;
 
+    // callback for computing distance between two points in the underline space.
+    dist_func_t<dist_t> dist_func_;
+
     // Index level generator of the top level for a new element
     std::default_random_engine level_generator_;
 
@@ -72,15 +73,15 @@ private:
     // internal ids are being kept as a continuous sequence [0, 1, ..,, cur_element_count-1].
     // We can remove this field completely if we change the serialization version, as the decoding
     // relies on this field.
-    tableint max_id;
+    idType max_id;
     size_t maxlevel_;
 
     // Index data structures
-    tableint entrypoint_node_;
+    idType entrypoint_node_;
     char *data_level0_memory_;
     char **linkLists_;
     vecsim_stl::vector<size_t> element_levels_;
-    vecsim_stl::unordered_map<labeltype, tableint> label_lookup_;
+    vecsim_stl::unordered_map<labelType, idType> label_lookup_;
     std::shared_ptr<VisitedNodesHandler> visited_nodes_handler;
 
     // used for synchronization only when parallel indexing / searching is enabled.
@@ -91,9 +92,6 @@ private:
     std::mutex cur_element_count_guard_;
     std::vector<std::mutex> link_list_locks_;
 #endif
-
-    // callback for computing distance between two points in the underline space.
-    dist_func_t<dist_t> fstdistfunc_;
 
 #ifdef BUILD_TESTS
     friend class HNSWIndexSerializer;
@@ -107,51 +105,51 @@ private:
 
     HierarchicalNSW() {}                                // default constructor
     HierarchicalNSW(const HierarchicalNSW &) = default; // default (shallow) copy constructor
-    void setExternalLabel(tableint internal_id, labeltype label);
-    labeltype *getExternalLabelPtr(tableint internal_id) const;
+    void setExternalLabel(idType internal_id, labelType label);
+    labelType *getExternalLabelPtr(idType internal_id) const;
     size_t getRandomLevel(double reverse_size);
-    vecsim_stl::vector<tableint> *getIncomingEdgesPtr(tableint internal_id, size_t level) const;
-    void setIncomingEdgesPtr(tableint internal_id, size_t level, void *set_ptr);
-    inline linklistsizeint *get_linklist0(tableint internal_id) const;
-    inline linklistsizeint *get_linklist(tableint internal_id, size_t level) const;
+    vecsim_stl::vector<idType> *getIncomingEdgesPtr(idType internal_id, size_t level) const;
+    void setIncomingEdgesPtr(idType internal_id, size_t level, void *set_ptr);
+    inline linklistsizeint *get_linklist0(idType internal_id) const;
+    inline linklistsizeint *get_linklist(idType internal_id, size_t level) const;
     void setListCount(linklistsizeint *ptr, unsigned short int size);
     void removeExtraLinks(linklistsizeint *node_ll, candidatesMaxHeap<dist_t> candidates,
-                          size_t Mcurmax, tableint *node_neighbors,
-                          const vecsim_stl::vector<bool> &bitmap, tableint *removed_links,
+                          size_t Mcurmax, idType *node_neighbors,
+                          const vecsim_stl::vector<bool> &bitmap, idType *removed_links,
                           size_t *removed_links_num);
-    inline dist_t processCandidate(tableint curNodeId, const void *data_point, size_t layer,
+    inline dist_t processCandidate(idType curNodeId, const void *data_point, size_t layer,
                                    size_t ef, tag_t visited_tag,
                                    candidatesMaxHeap<dist_t> &top_candidates,
                                    candidatesMaxHeap<dist_t> &candidates_set,
                                    dist_t lowerBound) const;
-    inline void processCandidate_RangeSearch(tableint curNodeId, const void *data_point,
-                                             size_t layer, double epsilon, tag_t visited_tag,
+    inline void processCandidate_RangeSearch(idType curNodeId, const void *data_point, size_t layer,
+                                             double epsilon, tag_t visited_tag,
                                              VecSimQueryResult **top_candidates,
                                              candidatesMaxHeap<dist_t> &candidate_set,
                                              dist_t lowerBound, dist_t radius) const;
-    candidatesMaxHeap<dist_t> searchLayer(tableint ep_id, const void *data_point, size_t layer,
+    candidatesMaxHeap<dist_t> searchLayer(idType ep_id, const void *data_point, size_t layer,
                                           size_t ef) const;
-    candidatesLabelsMaxHeap<dist_t> searchBottomLayer_WithTimeout(tableint ep_id,
+    candidatesLabelsMaxHeap<dist_t> searchBottomLayer_WithTimeout(idType ep_id,
                                                                   const void *data_point, size_t ef,
                                                                   size_t k, void *timeoutCtx,
                                                                   VecSimQueryResult_Code *rc) const;
-    VecSimQueryResult *searchRangeBottomLayer_WithTimeout(tableint ep_id, const void *data_point,
+    VecSimQueryResult *searchRangeBottomLayer_WithTimeout(idType ep_id, const void *data_point,
                                                           double epsilon, dist_t radius,
                                                           void *timeoutCtx,
                                                           VecSimQueryResult_Code *rc) const;
     void getNeighborsByHeuristic2(candidatesMaxHeap<dist_t> &top_candidates, size_t M);
-    tableint mutuallyConnectNewElement(tableint cur_c, candidatesMaxHeap<dist_t> &top_candidates,
-                                       size_t level);
-    void repairConnectionsForDeletion(tableint element_internal_id, tableint neighbour_id,
-                                      tableint *neighbours_list,
-                                      tableint *neighbour_neighbours_list, size_t level,
-                                      vecsim_stl::vector<bool> &neighbours_bitmap);
-    void replaceEntryPoint(tableint element_internal_id);
-    void SwapLastIdWithDeletedId(tableint element_internal_id, tableint last_element_internal_id);
+    idType mutuallyConnectNewElement(idType cur_c, candidatesMaxHeap<dist_t> &top_candidates,
+                                     size_t level);
+    void repairConnectionsForDeletion(idType element_internal_id, idType neighbour_id,
+                                      idType *neighbours_list, idType *neighbour_neighbours_list,
+                                      size_t level, vecsim_stl::vector<bool> &neighbours_bitmap);
+    void replaceEntryPoint(idType element_internal_id);
+    void SwapLastIdWithDeletedId(idType element_internal_id, idType last_element_internal_id);
 
 public:
-    HierarchicalNSW(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator,
-                    size_t random_seed = 100, size_t initial_pool_size = 1);
+    HierarchicalNSW(const HNSWParams *params, dist_func_t<dist_t> func,
+                    std::shared_ptr<VecSimAllocator> allocator, size_t random_seed = 100,
+                    size_t initial_pool_size = 1);
     virtual ~HierarchicalNSW();
 
     void setEf(size_t ef);
@@ -159,30 +157,29 @@ public:
     inline void setEpsilon(double epsilon);
     inline double getEpsilon() const;
     size_t getIndexSize() const;
+    size_t getIndexLabelCount() const;
     size_t getIndexCapacity() const;
     size_t getEfConstruction() const;
     size_t getM() const;
     size_t getMaxLevel() const;
     size_t getEntryPointLabel() const;
-    tableint getEntryPointId() const;
-    labeltype getExternalLabel(tableint internal_id) const;
+    idType getEntryPointId() const;
+    labelType getExternalLabel(idType internal_id) const;
     VisitedNodesHandler *getVisitedList() const;
-    char *getDataByInternalId(tableint internal_id) const;
-    inline linklistsizeint *get_linklist_at_level(tableint internal_id, size_t level) const;
+    char *getDataByInternalId(idType internal_id) const;
+    inline linklistsizeint *get_linklist_at_level(idType internal_id, size_t level) const;
     unsigned short int getListCount(const linklistsizeint *ptr) const;
     void resizeIndex(size_t new_max_elements);
-    void removePoint(labeltype label);
-    void addPoint(const void *data_point, labeltype label);
-    dist_t getDistanceByLabelFromPoint(labeltype label, const void *data_point);
-    tableint searchBottomLayerEP(const void *query_data, void *timeoutCtx,
-                                 VecSimQueryResult_Code *rc) const;
-    vecsim_stl::max_priority_queue<pair<dist_t, labeltype>>
+    void removePoint(labelType label);
+    void addPoint(const void *data_point, labelType label);
+    dist_t getDistanceByLabelFromPoint(labelType label, const void *data_point);
+    idType searchBottomLayerEP(const void *query_data, void *timeoutCtx,
+                               VecSimQueryResult_Code *rc) const;
+    vecsim_stl::max_priority_queue<pair<dist_t, labelType>>
     searchKnn(const void *query_data, size_t k, void *timeoutCtx, VecSimQueryResult_Code *rc) const;
     VecSimQueryResult *searchRange(const void *query_data, dist_t radius, void *timeoutCtx,
                                    VecSimQueryResult_Code *rc) const;
-    bool isLabelExist(labeltype label);
-    dist_func_t<float> GetDistFunc() const { return fstdistfunc_; }
-    size_t GetDim() const { return dim; }
+    bool isLabelExist(labelType label);
 };
 
 /**
@@ -215,6 +212,11 @@ size_t HierarchicalNSW<dist_t>::getIndexSize() const {
 }
 
 template <typename dist_t>
+size_t HierarchicalNSW<dist_t>::getIndexLabelCount() const {
+    return label_lookup_.size();
+}
+
+template <typename dist_t>
 size_t HierarchicalNSW<dist_t>::getIndexCapacity() const {
     return max_elements_;
 }
@@ -242,28 +244,28 @@ size_t HierarchicalNSW<dist_t>::getEntryPointLabel() const {
 }
 
 template <typename dist_t>
-labeltype HierarchicalNSW<dist_t>::getExternalLabel(tableint internal_id) const {
-    labeltype return_label;
+labelType HierarchicalNSW<dist_t>::getExternalLabel(idType internal_id) const {
+    labelType return_label;
     memcpy(&return_label,
            (data_level0_memory_ + internal_id * size_data_per_element_ + label_offset_),
-           sizeof(labeltype));
+           sizeof(labelType));
     return return_label;
 }
 
 template <typename dist_t>
-void HierarchicalNSW<dist_t>::setExternalLabel(tableint internal_id, labeltype label) {
+void HierarchicalNSW<dist_t>::setExternalLabel(idType internal_id, labelType label) {
     memcpy((data_level0_memory_ + internal_id * size_data_per_element_ + label_offset_), &label,
-           sizeof(labeltype));
+           sizeof(labelType));
 }
 
 template <typename dist_t>
-labeltype *HierarchicalNSW<dist_t>::getExternalLabelPtr(tableint internal_id) const {
-    return (labeltype *)(data_level0_memory_ + internal_id * size_data_per_element_ +
+labelType *HierarchicalNSW<dist_t>::getExternalLabelPtr(idType internal_id) const {
+    return (labelType *)(data_level0_memory_ + internal_id * size_data_per_element_ +
                          label_offset_);
 }
 
 template <typename dist_t>
-char *HierarchicalNSW<dist_t>::getDataByInternalId(tableint internal_id) const {
+char *HierarchicalNSW<dist_t>::getDataByInternalId(idType internal_id) const {
     return (data_level0_memory_ + internal_id * size_data_per_element_ + offsetData_);
 }
 
@@ -275,31 +277,30 @@ size_t HierarchicalNSW<dist_t>::getRandomLevel(double reverse_size) {
 }
 
 template <typename dist_t>
-dist_t HierarchicalNSW<dist_t>::getDistanceByLabelFromPoint(labeltype label,
+dist_t HierarchicalNSW<dist_t>::getDistanceByLabelFromPoint(labelType label,
                                                             const void *data_point) {
     if (label_lookup_.find(label) == label_lookup_.end()) {
         return INVALID_SCORE;
     }
-    dist_t t = fstdistfunc_(data_point, getDataByInternalId(label_lookup_[label]), &dim);
+    dist_t t = dist_func_(data_point, getDataByInternalId(label_lookup_[label]), &dim);
     return t;
 }
 
 template <typename dist_t>
-vecsim_stl::vector<tableint> *HierarchicalNSW<dist_t>::getIncomingEdgesPtr(tableint internal_id,
-                                                                           size_t level) const {
+vecsim_stl::vector<idType> *HierarchicalNSW<dist_t>::getIncomingEdgesPtr(idType internal_id,
+                                                                         size_t level) const {
     if (level == 0) {
-        return reinterpret_cast<vecsim_stl::vector<tableint> *>(
+        return reinterpret_cast<vecsim_stl::vector<idType> *>(
             *(void **)(data_level0_memory_ + internal_id * size_data_per_element_ +
                        incoming_links_offset0));
     }
-    return reinterpret_cast<vecsim_stl::vector<tableint> *>(
+    return reinterpret_cast<vecsim_stl::vector<idType> *>(
         *(void **)(linkLists_[internal_id] + (level - 1) * size_links_per_element_ +
                    incoming_links_offset));
 }
 
 template <typename dist_t>
-void HierarchicalNSW<dist_t>::setIncomingEdgesPtr(tableint internal_id, size_t level,
-                                                  void *set_ptr) {
+void HierarchicalNSW<dist_t>::setIncomingEdgesPtr(idType internal_id, size_t level, void *set_ptr) {
     if (level == 0) {
         memcpy(data_level0_memory_ + internal_id * size_data_per_element_ + incoming_links_offset0,
                &set_ptr, sizeof(void *));
@@ -311,18 +312,18 @@ void HierarchicalNSW<dist_t>::setIncomingEdgesPtr(tableint internal_id, size_t l
 }
 
 template <typename dist_t>
-linklistsizeint *HierarchicalNSW<dist_t>::get_linklist0(tableint internal_id) const {
+linklistsizeint *HierarchicalNSW<dist_t>::get_linklist0(idType internal_id) const {
     return (linklistsizeint *)(data_level0_memory_ + internal_id * size_data_per_element_ +
                                offsetLevel0_);
 }
 
 template <typename dist_t>
-linklistsizeint *HierarchicalNSW<dist_t>::get_linklist(tableint internal_id, size_t level) const {
+linklistsizeint *HierarchicalNSW<dist_t>::get_linklist(idType internal_id, size_t level) const {
     return (linklistsizeint *)(linkLists_[internal_id] + (level - 1) * size_links_per_element_);
 }
 
 template <typename dist_t>
-linklistsizeint *HierarchicalNSW<dist_t>::get_linklist_at_level(tableint internal_id,
+linklistsizeint *HierarchicalNSW<dist_t>::get_linklist_at_level(idType internal_id,
                                                                 size_t level) const {
     return level == 0 ? get_linklist0(internal_id) : get_linklist(internal_id, level);
 }
@@ -338,7 +339,7 @@ void HierarchicalNSW<dist_t>::setListCount(linklistsizeint *ptr, unsigned short 
 }
 
 template <typename dist_t>
-tableint HierarchicalNSW<dist_t>::getEntryPointId() const {
+idType HierarchicalNSW<dist_t>::getEntryPointId() const {
     return entrypoint_node_;
 }
 
@@ -348,7 +349,7 @@ VisitedNodesHandler *HierarchicalNSW<dist_t>::getVisitedList() const {
 }
 
 template <typename dist_t>
-bool HierarchicalNSW<dist_t>::isLabelExist(labeltype label) {
+bool HierarchicalNSW<dist_t>::isLabelExist(labelType label) {
     return (label_lookup_.find(label) != label_lookup_.end());
 }
 /**
@@ -357,9 +358,9 @@ bool HierarchicalNSW<dist_t>::isLabelExist(labeltype label) {
 template <typename dist_t>
 void HierarchicalNSW<dist_t>::removeExtraLinks(linklistsizeint *node_ll,
                                                candidatesMaxHeap<dist_t> candidates, size_t Mcurmax,
-                                               tableint *node_neighbors,
+                                               idType *node_neighbors,
                                                const vecsim_stl::vector<bool> &neighbors_bitmap,
-                                               tableint *removed_links, size_t *removed_links_num) {
+                                               idType *removed_links, size_t *removed_links_num) {
 
     auto orig_candidates = candidates;
     // candidates will store the newly selected neighbours (for the relevant node).
@@ -387,7 +388,7 @@ void HierarchicalNSW<dist_t>::removeExtraLinks(linklistsizeint *node_ll,
 }
 
 template <typename dist_t>
-dist_t HierarchicalNSW<dist_t>::processCandidate(tableint curNodeId, const void *data_point,
+dist_t HierarchicalNSW<dist_t>::processCandidate(idType curNodeId, const void *data_point,
                                                  size_t layer, size_t ef, tag_t visited_tag,
                                                  candidatesMaxHeap<dist_t> &top_candidates,
                                                  candidatesMaxHeap<dist_t> &candidate_set,
@@ -398,17 +399,17 @@ dist_t HierarchicalNSW<dist_t>::processCandidate(tableint curNodeId, const void 
 #endif
     linklistsizeint *node_ll = get_linklist_at_level(curNodeId, layer);
     size_t links_num = getListCount(node_ll);
-    auto *node_links = (tableint *)(node_ll + 1);
+    auto *node_links = (idType *)(node_ll + 1);
 
     __builtin_prefetch(visited_nodes_handler->getElementsTags() + *node_links);
     __builtin_prefetch(getDataByInternalId(*node_links));
 
     for (size_t j = 0; j < links_num; j++) {
-        tableint *candidate_pos = node_links + j;
-        tableint candidate_id = *candidate_pos;
+        idType *candidate_pos = node_links + j;
+        idType candidate_id = *candidate_pos;
 
         // Pre-fetch the next candidate data into memory cache, to improve performance.
-        tableint *next_candidate_pos = node_links + j + 1;
+        idType *next_candidate_pos = node_links + j + 1;
         __builtin_prefetch(visited_nodes_handler->getElementsTags() + *next_candidate_pos);
         __builtin_prefetch(getDataByInternalId(*next_candidate_pos));
         if (this->visited_nodes_handler->getNodeTag(candidate_id) == visited_tag)
@@ -416,7 +417,7 @@ dist_t HierarchicalNSW<dist_t>::processCandidate(tableint curNodeId, const void 
         this->visited_nodes_handler->tagNode(candidate_id, visited_tag);
         char *currObj1 = (getDataByInternalId(candidate_id));
 
-        dist_t dist1 = fstdistfunc_(data_point, currObj1, &dim);
+        dist_t dist1 = dist_func_(data_point, currObj1, &dim);
         if (top_candidates.size() < ef || lowerBound > dist1) {
             candidate_set.emplace(-dist1, candidate_id);
 
@@ -437,9 +438,9 @@ dist_t HierarchicalNSW<dist_t>::processCandidate(tableint curNodeId, const void 
 }
 
 template <typename dist_t>
-void HierarchicalNSW<dist_t>::processCandidate_RangeSearch(tableint curNodeId,
-                                                           const void *query_data, size_t layer,
-                                                           double epsilon, tag_t visited_tag,
+void HierarchicalNSW<dist_t>::processCandidate_RangeSearch(idType curNodeId, const void *query_data,
+                                                           size_t layer, double epsilon,
+                                                           tag_t visited_tag,
                                                            VecSimQueryResult **results,
                                                            candidatesMaxHeap<dist_t> &candidate_set,
                                                            dist_t dyn_range, dist_t radius) const {
@@ -449,17 +450,17 @@ void HierarchicalNSW<dist_t>::processCandidate_RangeSearch(tableint curNodeId,
 #endif
     linklistsizeint *node_ll = get_linklist_at_level(curNodeId, layer);
     size_t links_num = getListCount(node_ll);
-    auto *node_links = (tableint *)(node_ll + 1);
+    auto *node_links = (idType *)(node_ll + 1);
 
     __builtin_prefetch(visited_nodes_handler->getElementsTags() + *(node_ll + 1));
     __builtin_prefetch(getDataByInternalId(*node_links));
 
     for (size_t j = 0; j < links_num; j++) {
-        tableint *candidate_pos = node_links + j;
-        tableint candidate_id = *candidate_pos;
+        idType *candidate_pos = node_links + j;
+        idType candidate_id = *candidate_pos;
 
         // Pre-fetch the next candidate data into memory cache, to improve performance.
-        tableint *next_candidate_pos = node_links + j + 1;
+        idType *next_candidate_pos = node_links + j + 1;
         __builtin_prefetch(visited_nodes_handler->getElementsTags() + *next_candidate_pos);
         __builtin_prefetch(getDataByInternalId(*next_candidate_pos));
 
@@ -468,7 +469,7 @@ void HierarchicalNSW<dist_t>::processCandidate_RangeSearch(tableint curNodeId,
         this->visited_nodes_handler->tagNode(candidate_id, visited_tag);
         char *candidate_data = getDataByInternalId(candidate_id);
 
-        dist_t candidate_dist = fstdistfunc_(query_data, candidate_data, &dim);
+        dist_t candidate_dist = dist_func_(query_data, candidate_data, &dim);
         if (candidate_dist < dyn_range) {
             candidate_set.emplace(-candidate_dist, candidate_id);
 
@@ -487,9 +488,8 @@ void HierarchicalNSW<dist_t>::processCandidate_RangeSearch(tableint curNodeId,
 }
 
 template <typename dist_t>
-candidatesMaxHeap<dist_t> HierarchicalNSW<dist_t>::searchLayer(tableint ep_id,
-                                                               const void *data_point, size_t layer,
-                                                               size_t ef) const {
+candidatesMaxHeap<dist_t> HierarchicalNSW<dist_t>::searchLayer(idType ep_id, const void *data_point,
+                                                               size_t layer, size_t ef) const {
 
 #ifdef ENABLE_PARALLELIZATION
     this->visited_nodes_handler =
@@ -501,7 +501,7 @@ candidatesMaxHeap<dist_t> HierarchicalNSW<dist_t>::searchLayer(tableint ep_id,
     candidatesMaxHeap<dist_t> top_candidates(this->allocator);
     candidatesMaxHeap<dist_t> candidate_set(this->allocator);
 
-    dist_t dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), &dim);
+    dist_t dist = dist_func_(data_point, getDataByInternalId(ep_id), &dim);
     dist_t lowerBound = dist;
     top_candidates.emplace(dist, ep_id);
     candidate_set.emplace(-dist, ep_id);
@@ -509,7 +509,7 @@ candidatesMaxHeap<dist_t> HierarchicalNSW<dist_t>::searchLayer(tableint ep_id,
     this->visited_nodes_handler->tagNode(ep_id, visited_tag);
 
     while (!candidate_set.empty()) {
-        std::pair<dist_t, tableint> curr_el_pair = candidate_set.top();
+        std::pair<dist_t, idType> curr_el_pair = candidate_set.top();
         if ((-curr_el_pair.first) > lowerBound) {
             break;
         }
@@ -533,7 +533,7 @@ void HierarchicalNSW<dist_t>::getNeighborsByHeuristic2(candidatesMaxHeap<dist_t>
     }
 
     candidatesMaxHeap<dist_t> queue_closest(this->allocator);
-    vecsim_stl::vector<std::pair<dist_t, tableint>> return_list(this->allocator);
+    vecsim_stl::vector<std::pair<dist_t, idType>> return_list(this->allocator);
     while (top_candidates.size() > 0) {
         // the distance is saved negatively to have the queue ordered such that first is closer
         // (higher).
@@ -544,7 +544,7 @@ void HierarchicalNSW<dist_t>::getNeighborsByHeuristic2(candidatesMaxHeap<dist_t>
     while (queue_closest.size()) {
         if (return_list.size() >= M)
             break;
-        std::pair<dist_t, tableint> current_pair = queue_closest.top();
+        std::pair<dist_t, idType> current_pair = queue_closest.top();
         dist_t dist_to_query = -current_pair.first;
         queue_closest.pop();
         bool good = true;
@@ -552,9 +552,9 @@ void HierarchicalNSW<dist_t>::getNeighborsByHeuristic2(candidatesMaxHeap<dist_t>
         // a candidate is "good" to become a neighbour, unless we find
         // another item that was already selected to the neighbours set which is closer
         // to both q and the candidate than the distance between the candidate and q.
-        for (std::pair<dist_t, tableint> second_pair : return_list) {
-            dist_t curdist = fstdistfunc_(getDataByInternalId(second_pair.second),
-                                          getDataByInternalId(current_pair.second), &dim);
+        for (std::pair<dist_t, idType> second_pair : return_list) {
+            dist_t curdist = dist_func_(getDataByInternalId(second_pair.second),
+                                        getDataByInternalId(current_pair.second), &dim);
             ;
             if (curdist < dist_to_query) {
                 good = false;
@@ -566,35 +566,36 @@ void HierarchicalNSW<dist_t>::getNeighborsByHeuristic2(candidatesMaxHeap<dist_t>
         }
     }
 
-    for (std::pair<dist_t, tableint> current_pair : return_list) {
+    for (std::pair<dist_t, idType> current_pair : return_list) {
         top_candidates.emplace(-current_pair.first, current_pair.second);
     }
 }
 
 template <typename dist_t>
-tableint HierarchicalNSW<dist_t>::mutuallyConnectNewElement(
-    tableint cur_c, candidatesMaxHeap<dist_t> &top_candidates, size_t level) {
+idType HierarchicalNSW<dist_t>::mutuallyConnectNewElement(idType cur_c,
+                                                          candidatesMaxHeap<dist_t> &top_candidates,
+                                                          size_t level) {
     size_t Mcurmax = level ? maxM_ : maxM0_;
     getNeighborsByHeuristic2(top_candidates, M_);
     if (top_candidates.size() > M_)
         throw std::runtime_error(
             "Should be not be more than M_ candidates returned by the heuristic");
 
-    vecsim_stl::vector<tableint> selectedNeighbors(this->allocator);
+    vecsim_stl::vector<idType> selectedNeighbors(this->allocator);
     selectedNeighbors.reserve(M_);
     while (top_candidates.size() > 0) {
         selectedNeighbors.push_back(top_candidates.top().second);
         top_candidates.pop();
     }
 
-    tableint next_closest_entry_point = selectedNeighbors.back();
+    idType next_closest_entry_point = selectedNeighbors.back();
     {
         linklistsizeint *ll_cur = get_linklist_at_level(cur_c, level);
         if (*ll_cur) {
             throw std::runtime_error("The newly inserted element should have blank link list");
         }
         setListCount(ll_cur, selectedNeighbors.size());
-        auto *data = (tableint *)(ll_cur + 1);
+        auto *data = (idType *)(ll_cur + 1);
         for (size_t idx = 0; idx < selectedNeighbors.size(); idx++) {
             if (data[idx])
                 throw std::runtime_error("Possible memory corruption");
@@ -602,13 +603,13 @@ tableint HierarchicalNSW<dist_t>::mutuallyConnectNewElement(
                 throw std::runtime_error("Trying to make a link on a non-existent level");
             data[idx] = selectedNeighbors[idx];
         }
-        auto *incoming_edges = new (this->allocator) vecsim_stl::vector<tableint>(this->allocator);
+        auto *incoming_edges = new (this->allocator) vecsim_stl::vector<idType>(this->allocator);
         setIncomingEdgesPtr(cur_c, level, (void *)incoming_edges);
     }
 
     // go over the selected neighbours - selectedNeighbor is the neighbour id
     vecsim_stl::vector<bool> neighbors_bitmap(allocator);
-    for (tableint selectedNeighbor : selectedNeighbors) {
+    for (idType selectedNeighbor : selectedNeighbors) {
 #ifdef ENABLE_PARALLELIZATION
         std::unique_lock<std::mutex> lock(link_list_locks_[selectedNeighbor]);
 #endif
@@ -623,7 +624,7 @@ tableint HierarchicalNSW<dist_t>::mutuallyConnectNewElement(
             throw std::runtime_error("Trying to make a link on a non-existent level");
 
         // get the array of neighbours - for the current neighbour
-        auto *neighbor_neighbors = (tableint *)(ll_other + 1);
+        auto *neighbor_neighbors = (idType *)(ll_other + 1);
 
         // If the selected neighbor can add another link (hasn't reached the max) - add it.
         if (sz_link_list_other < Mcurmax) {
@@ -635,19 +636,19 @@ tableint HierarchicalNSW<dist_t>::mutuallyConnectNewElement(
             // (re)use the bitmap to represent the set of the original neighbours for the current
             // selected neighbour.
             neighbors_bitmap.assign(max_id + 1, false);
-            dist_t d_max = fstdistfunc_(getDataByInternalId(cur_c),
-                                        getDataByInternalId(selectedNeighbor), &dim);
+            dist_t d_max =
+                dist_func_(getDataByInternalId(cur_c), getDataByInternalId(selectedNeighbor), &dim);
             candidates.emplace(d_max, cur_c);
             // consider cur_c as if it was a link of the selected neighbor
             neighbors_bitmap[cur_c] = true;
             for (size_t j = 0; j < sz_link_list_other; j++) {
-                candidates.emplace(fstdistfunc_(getDataByInternalId(neighbor_neighbors[j]),
-                                                getDataByInternalId(selectedNeighbor), &dim),
+                candidates.emplace(dist_func_(getDataByInternalId(neighbor_neighbors[j]),
+                                              getDataByInternalId(selectedNeighbor), &dim),
                                    neighbor_neighbors[j]);
                 neighbors_bitmap[neighbor_neighbors[j]] = true;
             }
 
-            tableint removed_links[sz_link_list_other + 1];
+            idType removed_links[sz_link_list_other + 1];
             size_t removed_links_num;
             removeExtraLinks(ll_other, candidates, Mcurmax, neighbor_neighbors, neighbors_bitmap,
                              removed_links, &removed_links_num);
@@ -656,7 +657,7 @@ tableint HierarchicalNSW<dist_t>::mutuallyConnectNewElement(
             // neighbours that were chosen to remove (if edge wasn't bidirectional)
             auto *neighbour_incoming_edges = getIncomingEdgesPtr(selectedNeighbor, level);
             for (size_t i = 0; i < removed_links_num; i++) {
-                tableint node_id = removed_links[i];
+                idType node_id = removed_links[i];
                 auto *node_incoming_edges = getIncomingEdgesPtr(node_id, level);
                 // if we removed cur_c (the node just inserted), then it points to the current
                 // neighbour, but not vise versa.
@@ -686,28 +687,27 @@ tableint HierarchicalNSW<dist_t>::mutuallyConnectNewElement(
 
 template <typename dist_t>
 void HierarchicalNSW<dist_t>::repairConnectionsForDeletion(
-    tableint element_internal_id, tableint neighbour_id, tableint *neighbours_list,
-    tableint *neighbour_neighbours_list, size_t level,
-    vecsim_stl::vector<bool> &neighbours_bitmap) {
+    idType element_internal_id, idType neighbour_id, idType *neighbours_list,
+    idType *neighbour_neighbours_list, size_t level, vecsim_stl::vector<bool> &neighbours_bitmap) {
 
     // put the deleted element's neighbours in the candidates.
     candidatesMaxHeap<dist_t> candidates(this->allocator);
     unsigned short neighbours_count = getListCount(neighbours_list);
-    auto *neighbours = (tableint *)(neighbours_list + 1);
+    auto *neighbours = (idType *)(neighbours_list + 1);
     for (size_t j = 0; j < neighbours_count; j++) {
         // Don't put the neighbor itself in his own candidates
         if (neighbours[j] == neighbour_id) {
             continue;
         }
-        candidates.emplace(fstdistfunc_(getDataByInternalId(neighbours[j]),
-                                        getDataByInternalId(neighbour_id), &dim),
-                           neighbours[j]);
+        candidates.emplace(
+            dist_func_(getDataByInternalId(neighbours[j]), getDataByInternalId(neighbour_id), &dim),
+            neighbours[j]);
     }
 
     // add the deleted element's neighbour's original neighbors in the candidates.
     vecsim_stl::vector<bool> neighbour_orig_neighbours_set(max_id + 1, false, this->allocator);
     unsigned short neighbour_neighbours_count = getListCount(neighbour_neighbours_list);
-    auto *neighbour_neighbours = (tableint *)(neighbour_neighbours_list + 1);
+    auto *neighbour_neighbours = (idType *)(neighbour_neighbours_list + 1);
     for (size_t j = 0; j < neighbour_neighbours_count; j++) {
         neighbour_orig_neighbours_set[neighbour_neighbours[j]] = true;
         // Don't add the removed element to the candidates, nor nodes that are already in the
@@ -716,14 +716,14 @@ void HierarchicalNSW<dist_t>::repairConnectionsForDeletion(
             neighbour_neighbours[j] == element_internal_id) {
             continue;
         }
-        candidates.emplace(fstdistfunc_(getDataByInternalId(neighbour_id),
-                                        getDataByInternalId(neighbour_neighbours[j]), &dim),
+        candidates.emplace(dist_func_(getDataByInternalId(neighbour_id),
+                                      getDataByInternalId(neighbour_neighbours[j]), &dim),
                            neighbour_neighbours[j]);
     }
 
     size_t Mcurmax = level ? maxM_ : maxM0_;
     size_t removed_links_num;
-    tableint removed_links[neighbour_neighbours_count];
+    idType removed_links[neighbour_neighbours_count];
     removeExtraLinks(neighbour_neighbours_list, candidates, Mcurmax, neighbour_neighbours,
                      neighbour_orig_neighbours_set, removed_links, &removed_links_num);
 
@@ -732,7 +732,7 @@ void HierarchicalNSW<dist_t>::repairConnectionsForDeletion(
     auto *neighbour_incoming_edges = getIncomingEdgesPtr(neighbour_id, level);
 
     for (size_t i = 0; i < removed_links_num; i++) {
-        tableint node_id = removed_links[i];
+        idType node_id = removed_links[i];
         auto *node_incoming_edges = getIncomingEdgesPtr(node_id, level);
 
         // if the node id (the neighbour's neighbour to be removed)
@@ -751,7 +751,7 @@ void HierarchicalNSW<dist_t>::repairConnectionsForDeletion(
     // updates for the new edges created
     unsigned short updated_links_num = getListCount(neighbour_neighbours_list);
     for (size_t i = 0; i < updated_links_num; i++) {
-        tableint node_id = neighbour_neighbours[i];
+        idType node_id = neighbour_neighbours[i];
         if (!neighbour_orig_neighbours_set[node_id]) {
             auto *node_incoming_edges = getIncomingEdgesPtr(node_id, level);
             // if the node has an edge to the neighbour as well, remove it
@@ -759,7 +759,7 @@ void HierarchicalNSW<dist_t>::repairConnectionsForDeletion(
             // otherwise, need to update the edge as incoming.
             linklistsizeint *node_links_list = get_linklist_at_level(node_id, level);
             unsigned short node_links_size = getListCount(node_links_list);
-            auto *node_links = (tableint *)(node_links_list + 1);
+            auto *node_links = (idType *)(node_links_list + 1);
             bool bidirectional_edge = false;
             for (size_t j = 0; j < node_links_size; j++) {
                 if (node_links[j] == neighbour_id) {
@@ -778,17 +778,17 @@ void HierarchicalNSW<dist_t>::repairConnectionsForDeletion(
 }
 
 template <typename dist_t>
-void HierarchicalNSW<dist_t>::replaceEntryPoint(tableint element_internal_id) {
+void HierarchicalNSW<dist_t>::replaceEntryPoint(idType element_internal_id) {
     // Sets an (arbitrary) new entry point, after deleting the current entry point.
     while (element_internal_id == entrypoint_node_) {
         linklistsizeint *top_level_list = get_linklist_at_level(element_internal_id, maxlevel_);
         if (getListCount(top_level_list) > 0) {
             // Tries to set the (arbitrary) first neighbor as the entry point, if exists.
-            entrypoint_node_ = ((tableint *)(top_level_list + 1))[0];
+            entrypoint_node_ = ((idType *)(top_level_list + 1))[0];
         } else {
             // If there is no neighbors in the current level, check for any vector at
             // this level to be the new entry point.
-            for (tableint cur_id = 0; cur_id < cur_element_count; cur_id++) {
+            for (idType cur_id = 0; cur_id < cur_element_count; cur_id++) {
                 if (element_levels_[cur_id] == maxlevel_ && cur_id != element_internal_id) {
                     entrypoint_node_ = cur_id;
                     break;
@@ -808,10 +808,10 @@ void HierarchicalNSW<dist_t>::replaceEntryPoint(tableint element_internal_id) {
 }
 
 template <typename dist_t>
-void HierarchicalNSW<dist_t>::SwapLastIdWithDeletedId(tableint element_internal_id,
-                                                      tableint last_element_internal_id) {
+void HierarchicalNSW<dist_t>::SwapLastIdWithDeletedId(idType element_internal_id,
+                                                      idType last_element_internal_id) {
     // swap label
-    labeltype last_element_label = getExternalLabel(last_element_internal_id);
+    labelType last_element_label = getExternalLabel(last_element_internal_id);
     label_lookup_[last_element_label] = element_internal_id;
 
     // swap neighbours
@@ -819,16 +819,16 @@ void HierarchicalNSW<dist_t>::SwapLastIdWithDeletedId(tableint element_internal_
     for (size_t level = 0; level <= last_element_top_level; level++) {
         linklistsizeint *neighbours_list = get_linklist_at_level(last_element_internal_id, level);
         unsigned short neighbours_count = getListCount(neighbours_list);
-        auto *neighbours = (tableint *)(neighbours_list + 1);
+        auto *neighbours = (idType *)(neighbours_list + 1);
 
         // go over the neighbours that also points back to the last element whose is going to
         // change, and update the id.
         for (size_t i = 0; i < neighbours_count; i++) {
-            tableint neighbour_id = neighbours[i];
+            idType neighbour_id = neighbours[i];
             linklistsizeint *neighbour_neighbours_list = get_linklist_at_level(neighbour_id, level);
             unsigned short neighbour_neighbours_count = getListCount(neighbour_neighbours_list);
 
-            auto *neighbour_neighbours = (tableint *)(neighbour_neighbours_list + 1);
+            auto *neighbour_neighbours = (idType *)(neighbour_neighbours_list + 1);
             bool bidirectional_edge = false;
             for (size_t j = 0; j < neighbour_neighbours_count; j++) {
                 // if the edge is bidirectional, update for this neighbor
@@ -859,7 +859,7 @@ void HierarchicalNSW<dist_t>::SwapLastIdWithDeletedId(tableint element_internal_
             unsigned short incoming_neighbour_neighbours_count =
                 getListCount(incoming_neighbour_neighbours_list);
             auto *incoming_neighbour_neighbours =
-                (tableint *)(incoming_neighbour_neighbours_list + 1);
+                (idType *)(incoming_neighbour_neighbours_list + 1);
             for (size_t j = 0; j < incoming_neighbour_neighbours_count; j++) {
                 if (incoming_neighbour_neighbours[j] == last_element_internal_id) {
                     incoming_neighbour_neighbours[j] = element_internal_id;
@@ -900,18 +900,18 @@ void HierarchicalNSW<dist_t>::SwapLastIdWithDeletedId(tableint element_internal_
     double epsilon;
 } HNSWParams; */
 template <typename dist_t>
-HierarchicalNSW<dist_t>::HierarchicalNSW(const HNSWParams *params,
+HierarchicalNSW<dist_t>::HierarchicalNSW(const HNSWParams *params, dist_func_t<dist_t> func,
                                          std::shared_ptr<VecSimAllocator> allocator,
                                          size_t random_seed, size_t pool_initial_size)
     : VecsimBaseObject(allocator), max_elements_(params->initialCapacity), dim(params->dim),
-      data_size_(VecSimType_sizeof(params->type) * dim), element_levels_(max_elements_, allocator),
-      label_lookup_(max_elements_, allocator)
+      data_size_(VecSimType_sizeof(params->type) * dim), dist_func_(func),
+      element_levels_(max_elements_, allocator), label_lookup_(max_elements_, allocator)
 
 #ifdef ENABLE_PARALLELIZATION
-          link_list_locks_(max_elements_),
+      ,
+      link_list_locks_(max_elements_)
 #endif
 {
-    spaces::SetDistFunc(params->metric, dim, &fstdistfunc_);
     size_t M = params->M ? params->M : HNSW_DEFAULT_M;
     if (M > SIZE_MAX / 2)
         throw std::runtime_error("HNSW index parameter M is too large: argument overflow");
@@ -948,17 +948,17 @@ HierarchicalNSW<dist_t>::HierarchicalNSW(const HNSWParams *params,
     // data_level0_memory will look like this:
     // -----4------ | -----4*M0----------- | ----8------------------| ------32------- | ----8---- |
     // <links_len>  | <link_1> <link_2>... | <incoming_links_set> |   <data>        |  <label>
-    if (maxM0_ > ((SIZE_MAX - sizeof(void *) - sizeof(linklistsizeint)) / sizeof(tableint)) + 1)
+    if (maxM0_ > ((SIZE_MAX - sizeof(void *) - sizeof(linklistsizeint)) / sizeof(idType)) + 1)
         throw std::runtime_error("HNSW index parameter M is too large: argument overflow");
-    size_links_level0_ = sizeof(linklistsizeint) + maxM0_ * sizeof(tableint) + sizeof(void *);
+    size_links_level0_ = sizeof(linklistsizeint) + maxM0_ * sizeof(idType) + sizeof(void *);
 
-    if (size_links_level0_ > SIZE_MAX - data_size_ - sizeof(labeltype))
+    if (size_links_level0_ > SIZE_MAX - data_size_ - sizeof(labelType))
         throw std::runtime_error("HNSW index parameter M is too large: argument overflow");
-    size_data_per_element_ = size_links_level0_ + data_size_ + sizeof(labeltype);
+    size_data_per_element_ = size_links_level0_ + data_size_ + sizeof(labelType);
 
     // No need to test for overflow because we passed the test for size_links_level0_ and this is
     // less.
-    incoming_links_offset0 = maxM0_ * sizeof(tableint) + sizeof(linklistsizeint);
+    incoming_links_offset0 = maxM0_ * sizeof(idType) + sizeof(linklistsizeint);
     offsetData_ = size_links_level0_;
     label_offset_ = size_links_level0_ + data_size_;
     offsetLevel0_ = 0;
@@ -976,16 +976,16 @@ HierarchicalNSW<dist_t>::HierarchicalNSW(const HNSWParams *params,
     // chunks of memory, each one will look like this:
     // -----4------ | -----4*M-------------- | ----8------------------|
     // <links_len>  | <link_1> <link_2> ...  | <incoming_links_set>
-    size_links_per_element_ = sizeof(linklistsizeint) + maxM_ * sizeof(tableint) + sizeof(void *);
+    size_links_per_element_ = sizeof(linklistsizeint) + maxM_ * sizeof(idType) + sizeof(void *);
     // No need to test for overflow because we passed the test for incoming_links_offset0 and this
     // is less.
-    incoming_links_offset = maxM_ * sizeof(tableint) + sizeof(linklistsizeint);
+    incoming_links_offset = maxM_ * sizeof(idType) + sizeof(linklistsizeint);
 }
 
 template <typename dist_t>
 HierarchicalNSW<dist_t>::~HierarchicalNSW() {
     if (max_id != HNSW_INVALID_ID) {
-        for (tableint id = 0; id <= max_id; id++) {
+        for (idType id = 0; id <= max_id; id++) {
             for (size_t level = 0; level <= element_levels_[id]; level++) {
                 delete getIncomingEdgesPtr(id, level);
             }
@@ -1033,9 +1033,9 @@ void HierarchicalNSW<dist_t>::resizeIndex(size_t new_max_elements) {
 }
 
 template <typename dist_t>
-void HierarchicalNSW<dist_t>::removePoint(const labeltype label) {
+void HierarchicalNSW<dist_t>::removePoint(const labelType label) {
 
-    tableint element_internal_id = label_lookup_[label];
+    idType element_internal_id = label_lookup_[label];
     vecsim_stl::vector<bool> neighbours_bitmap(allocator);
 
     // go over levels and repair connections
@@ -1043,7 +1043,7 @@ void HierarchicalNSW<dist_t>::removePoint(const labeltype label) {
     for (size_t level = 0; level <= element_top_level; level++) {
         linklistsizeint *neighbours_list = get_linklist_at_level(element_internal_id, level);
         unsigned short neighbours_count = getListCount(neighbours_list);
-        auto *neighbours = (tableint *)(neighbours_list + 1);
+        auto *neighbours = (idType *)(neighbours_list + 1);
         // reset the neighbours' bitmap for the current level.
         neighbours_bitmap.assign(max_id + 1, false);
         // store the deleted element's neighbours set in a bitmap for fast access.
@@ -1053,11 +1053,11 @@ void HierarchicalNSW<dist_t>::removePoint(const labeltype label) {
         // go over the neighbours that also points back to the removed point and make a local
         // repair.
         for (size_t i = 0; i < neighbours_count; i++) {
-            tableint neighbour_id = neighbours[i];
+            idType neighbour_id = neighbours[i];
             linklistsizeint *neighbour_neighbours_list = get_linklist_at_level(neighbour_id, level);
             unsigned short neighbour_neighbours_count = getListCount(neighbour_neighbours_list);
 
-            auto *neighbour_neighbours = (tableint *)(neighbour_neighbours_list + 1);
+            auto *neighbour_neighbours = (idType *)(neighbour_neighbours_list + 1);
             bool bidirectional_edge = false;
             for (size_t j = 0; j < neighbour_neighbours_count; j++) {
                 // if the edge is bidirectional, do repair for this neighbor
@@ -1099,7 +1099,7 @@ void HierarchicalNSW<dist_t>::removePoint(const labeltype label) {
     }
 
     // Swap the last id with the deleted one, and invalidate the last id data.
-    tableint last_element_internal_id = --cur_element_count;
+    idType last_element_internal_id = --cur_element_count;
     --max_id;
     label_lookup_.erase(label);
     if (element_levels_[element_internal_id] > 0) {
@@ -1117,9 +1117,9 @@ void HierarchicalNSW<dist_t>::removePoint(const labeltype label) {
 }
 
 template <typename dist_t>
-void HierarchicalNSW<dist_t>::addPoint(const void *data_point, const labeltype label) {
+void HierarchicalNSW<dist_t>::addPoint(const void *data_point, const labelType label) {
 
-    tableint cur_c;
+    idType cur_c;
 
     {
 #ifdef ENABLE_PARALLELIZATION
@@ -1151,7 +1151,7 @@ void HierarchicalNSW<dist_t>::addPoint(const void *data_point, const labeltype l
            size_data_per_element_);
 
     // Initialisation of the data and label
-    memcpy(getExternalLabelPtr(cur_c), &label, sizeof(labeltype));
+    memcpy(getExternalLabelPtr(cur_c), &label, sizeof(labelType));
     memcpy(getDataByInternalId(cur_c), data_point, data_size_);
 
     if (element_max_level > 0) {
@@ -1165,7 +1165,7 @@ void HierarchicalNSW<dist_t>::addPoint(const void *data_point, const labeltype l
     // this condition only means that we are not inserting the first element.
     if (entrypoint_node_ != HNSW_INVALID_ID) {
         if (element_max_level < maxlevelcopy) {
-            dist_t cur_dist = fstdistfunc_(data_point, getDataByInternalId(currObj), &dim);
+            dist_t cur_dist = dist_func_(data_point, getDataByInternalId(currObj), &dim);
             for (size_t level = maxlevelcopy; level > element_max_level; level--) {
                 // this is done for the levels which are above the max level
                 // to which we are going to insert the new element. We do
@@ -1182,14 +1182,14 @@ void HierarchicalNSW<dist_t>::addPoint(const void *data_point, const labeltype l
                     data = get_linklist(currObj, level);
                     int size = getListCount(data);
 
-                    auto *datal = (tableint *)(data + 1);
+                    auto *datal = (idType *)(data + 1);
                     for (int i = 0; i < size; i++) {
-                        tableint cand = datal[i];
+                        idType cand = datal[i];
                         if (cand < 0 || cand > max_elements_)
                             throw std::runtime_error(
                                 "candidate error: candidate id is out of index range");
 
-                        dist_t d = fstdistfunc_(data_point, getDataByInternalId(cand), &dim);
+                        dist_t d = dist_func_(data_point, getDataByInternalId(cand), &dim);
                         if (d < cur_dist) {
                             cur_dist = d;
                             currObj = cand;
@@ -1216,7 +1216,7 @@ void HierarchicalNSW<dist_t>::addPoint(const void *data_point, const labeltype l
             // create the incoming edges set for the new levels.
             for (size_t level_idx = maxlevelcopy + 1; level_idx <= element_max_level; level_idx++) {
                 auto *incoming_edges =
-                    new (this->allocator) vecsim_stl::vector<tableint>(this->allocator);
+                    new (this->allocator) vecsim_stl::vector<idType>(this->allocator);
                 setIncomingEdgesPtr(cur_c, level_idx, incoming_edges);
             }
         }
@@ -1225,7 +1225,7 @@ void HierarchicalNSW<dist_t>::addPoint(const void *data_point, const labeltype l
         entrypoint_node_ = 0;
         for (size_t level_idx = maxlevel_ + 1; level_idx <= element_max_level; level_idx++) {
             auto *incoming_edges =
-                new (this->allocator) vecsim_stl::vector<tableint>(this->allocator);
+                new (this->allocator) vecsim_stl::vector<idType>(this->allocator);
             setIncomingEdgesPtr(cur_c, level_idx, incoming_edges);
         }
         maxlevel_ = element_max_level;
@@ -1233,31 +1233,31 @@ void HierarchicalNSW<dist_t>::addPoint(const void *data_point, const labeltype l
 }
 
 template <typename dist_t>
-tableint HierarchicalNSW<dist_t>::searchBottomLayerEP(const void *query_data, void *timeoutCtx,
-                                                      VecSimQueryResult_Code *rc) const {
+idType HierarchicalNSW<dist_t>::searchBottomLayerEP(const void *query_data, void *timeoutCtx,
+                                                    VecSimQueryResult_Code *rc) const {
 
     if (cur_element_count == 0) {
         return entrypoint_node_;
     }
-    tableint currObj = entrypoint_node_;
-    dist_t cur_dist = fstdistfunc_(query_data, getDataByInternalId(entrypoint_node_), &dim);
+    idType currObj = entrypoint_node_;
+    dist_t cur_dist = dist_func_(query_data, getDataByInternalId(entrypoint_node_), &dim);
     for (size_t level = maxlevel_; level > 0; level--) {
         bool changed = true;
         while (changed) {
-            if (__builtin_expect(VecSimIndex::timeoutCallback(timeoutCtx), 0)) {
+            if (__builtin_expect(VecSimIndexAbstract::timeoutCallback(timeoutCtx), 0)) {
                 *rc = VecSim_QueryResult_TimedOut;
                 return HNSW_INVALID_ID;
             }
             changed = false;
             linklistsizeint *node_ll = get_linklist(currObj, level);
             unsigned short links_count = getListCount(node_ll);
-            auto *node_links = (tableint *)(node_ll + 1);
+            auto *node_links = (idType *)(node_ll + 1);
             for (int i = 0; i < links_count; i++) {
-                tableint candidate = node_links[i];
+                idType candidate = node_links[i];
                 if (candidate > max_elements_)
                     throw std::runtime_error("candidate error: out of index range");
 
-                dist_t d = fstdistfunc_(query_data, getDataByInternalId(candidate), &dim);
+                dist_t d = dist_func_(query_data, getDataByInternalId(candidate), &dim);
                 if (d < cur_dist) {
                     cur_dist = d;
                     currObj = candidate;
@@ -1272,7 +1272,7 @@ tableint HierarchicalNSW<dist_t>::searchBottomLayerEP(const void *query_data, vo
 
 template <typename dist_t>
 candidatesLabelsMaxHeap<dist_t>
-HierarchicalNSW<dist_t>::searchBottomLayer_WithTimeout(tableint ep_id, const void *data_point,
+HierarchicalNSW<dist_t>::searchBottomLayer_WithTimeout(idType ep_id, const void *data_point,
                                                        size_t ef, size_t k, void *timeoutCtx,
                                                        VecSimQueryResult_Code *rc) const {
     candidatesLabelsMaxHeap<dist_t> results(this->allocator);
@@ -1287,7 +1287,7 @@ HierarchicalNSW<dist_t>::searchBottomLayer_WithTimeout(tableint ep_id, const voi
     candidatesMaxHeap<dist_t> top_candidates(this->allocator);
     candidatesMaxHeap<dist_t> candidate_set(this->allocator);
 
-    dist_t dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), &dim);
+    dist_t dist = dist_func_(data_point, getDataByInternalId(ep_id), &dim);
     dist_t lowerBound = dist;
     top_candidates.emplace(dist, ep_id);
     candidate_set.emplace(-dist, ep_id);
@@ -1295,11 +1295,11 @@ HierarchicalNSW<dist_t>::searchBottomLayer_WithTimeout(tableint ep_id, const voi
     this->visited_nodes_handler->tagNode(ep_id, visited_tag);
 
     while (!candidate_set.empty()) {
-        std::pair<dist_t, tableint> curr_el_pair = candidate_set.top();
+        std::pair<dist_t, idType> curr_el_pair = candidate_set.top();
         if ((-curr_el_pair.first) > lowerBound) {
             break;
         }
-        if (__builtin_expect(VecSimIndex::timeoutCallback(timeoutCtx), 0)) {
+        if (__builtin_expect(VecSimIndexAbstract::timeoutCallback(timeoutCtx), 0)) {
             *rc = VecSim_QueryResult_TimedOut;
             return results;
         }
@@ -1333,7 +1333,7 @@ HierarchicalNSW<dist_t>::searchKnn(const void *query_data, size_t k, void *timeo
         return candidatesLabelsMaxHeap<dist_t>(this->allocator);
     }
 
-    tableint bottom_layer_ep = searchBottomLayerEP(query_data, timeoutCtx, rc);
+    idType bottom_layer_ep = searchBottomLayerEP(query_data, timeoutCtx, rc);
     if (VecSim_OK != *rc) {
         return candidatesLabelsMaxHeap<dist_t>(this->allocator);
     }
@@ -1345,7 +1345,7 @@ HierarchicalNSW<dist_t>::searchKnn(const void *query_data, size_t k, void *timeo
 
 template <typename dist_t>
 VecSimQueryResult *HierarchicalNSW<dist_t>::searchRangeBottomLayer_WithTimeout(
-    tableint ep_id, const void *data_point, double epsilon, dist_t radius, void *timeoutCtx,
+    idType ep_id, const void *data_point, double epsilon, dist_t radius, void *timeoutCtx,
     VecSimQueryResult_Code *rc) const {
     auto *results = array_new<VecSimQueryResult>(10); // arbitrary initial cap.
 
@@ -1358,7 +1358,7 @@ VecSimQueryResult *HierarchicalNSW<dist_t>::searchRangeBottomLayer_WithTimeout(
     candidatesMaxHeap<dist_t> candidate_set(this->allocator);
 
     // Set the initial effective-range to be at least the distance from the entry-point.
-    dist_t ep_dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), &dim);
+    dist_t ep_dist = dist_func_(data_point, getDataByInternalId(ep_id), &dim);
     dist_t dynamic_range = ep_dist;
     if (ep_dist <= radius) {
         // Entry-point is within the radius - add it to the results.
@@ -1374,13 +1374,13 @@ VecSimQueryResult *HierarchicalNSW<dist_t>::searchRangeBottomLayer_WithTimeout(
     this->visited_nodes_handler->tagNode(ep_id, visited_tag);
 
     while (!candidate_set.empty()) {
-        std::pair<dist_t, tableint> curr_el_pair = candidate_set.top();
+        std::pair<dist_t, idType> curr_el_pair = candidate_set.top();
         // If the best candidate is outside the dynamic range in more than epsilon (relatively) - we
         // finish the search.
         if ((-curr_el_pair.first) > dynamic_range_search_boundaries) {
             break;
         }
-        if (__builtin_expect(VecSimIndex::timeoutCallback(timeoutCtx), 0)) {
+        if (__builtin_expect(VecSimIndexAbstract::timeoutCallback(timeoutCtx), 0)) {
             *rc = VecSim_QueryResult_TimedOut;
             return results;
         }
@@ -1417,7 +1417,7 @@ VecSimQueryResult *HierarchicalNSW<dist_t>::searchRange(const void *query_data, 
         return array_new<VecSimQueryResult>(0);
     }
 
-    tableint bottom_layer_ep = searchBottomLayerEP(query_data, timeoutCtx, rc);
+    idType bottom_layer_ep = searchBottomLayerEP(query_data, timeoutCtx, rc);
     if (VecSim_OK != *rc) {
         return array_new<VecSimQueryResult>(0);
     }

--- a/src/VecSim/algorithms/hnsw/serialization.cpp
+++ b/src/VecSim/algorithms/hnsw/serialization.cpp
@@ -141,11 +141,11 @@ void HNSWIndexSerializer::restoreGraph(std::ifstream &input) {
     }
     for (size_t i = 0; i <= hnsw_index->max_id; i++) {
         auto *incoming_edges =
-            new (hnsw_index->allocator) vecsim_stl::vector<tableint>(hnsw_index->allocator);
+            new (hnsw_index->allocator) vecsim_stl::vector<idType>(hnsw_index->allocator);
         unsigned int incoming_edges_len;
         readBinaryPOD(input, incoming_edges_len);
         for (size_t j = 0; j < incoming_edges_len; j++) {
-            tableint next_edge;
+            idType next_edge;
             readBinaryPOD(input, next_edge);
             incoming_edges->push_back(next_edge);
         }
@@ -186,11 +186,11 @@ void HNSWIndexSerializer::restoreGraph(std::ifstream &input) {
             input.read(hnsw_index->linkLists_[i], linkListSize);
             for (size_t j = 1; j <= hnsw_index->element_levels_[i]; j++) {
                 auto *incoming_edges =
-                    new (hnsw_index->allocator) vecsim_stl::vector<tableint>(hnsw_index->allocator);
+                    new (hnsw_index->allocator) vecsim_stl::vector<idType>(hnsw_index->allocator);
                 unsigned int vector_len;
                 readBinaryPOD(input, vector_len);
                 for (size_t k = 0; k < vector_len; k++) {
-                    tableint next_edge;
+                    idType next_edge;
                     readBinaryPOD(input, next_edge);
                     incoming_edges->push_back(next_edge);
                 }
@@ -260,8 +260,8 @@ HNSWIndexMetaData HNSWIndexSerializer::checkIntegrity() {
             for (size_t l = 0; l <= hnsw_index->element_levels_[i]; l++) {
                 linklistsizeint *ll_cur = hnsw_index->get_linklist_at_level(i, l);
                 unsigned int size = hnsw_index->getListCount(ll_cur);
-                auto *data = (tableint *)(ll_cur + 1);
-                std::set<tableint> s;
+                auto *data = (idType *)(ll_cur + 1);
+                std::set<idType> s;
                 for (unsigned int j = 0; j < size; j++) {
                     // Check if we found an invalid neighbor.
                     if (data[j] > hnsw_index->max_id || data[j] == i) {
@@ -275,9 +275,9 @@ HNSWIndexMetaData HNSWIndexSerializer::checkIntegrity() {
                     // Check if this connection is bidirectional.
                     linklistsizeint *ll_other = hnsw_index->get_linklist_at_level(data[j], l);
                     int size_other = hnsw_index->getListCount(ll_other);
-                    auto *data_other = (tableint *)(ll_other + 1);
+                    auto *data_other = (idType *)(ll_other + 1);
                     for (int r = 0; r < size_other; r++) {
-                        if (data_other[r] == (tableint)i) {
+                        if (data_other[r] == (idType)i) {
                             double_connections++;
                             break;
                         }

--- a/src/VecSim/info_iterator.h
+++ b/src/VecSim/info_iterator.h
@@ -20,7 +20,7 @@ typedef enum {
 
 /**
  * @brief A struct to hold field information. This struct contains three members:
- *  fieldType - Enum describing the contenet of the value.
+ *  fieldType - Enum describing the content of the value.
  *  fieldName - Field name.
  *  fieldValue - A union of string/integer/float values.
  */

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -27,6 +27,8 @@ const char *VecSimCommonStrings::L2_STRING = "L2";
 
 const char *VecSimCommonStrings::DIMENSION_STRING = "DIMENSION";
 const char *VecSimCommonStrings::INDEX_SIZE_STRING = "INDEX_SIZE";
+const char *VecSimCommonStrings::INDEX_LABEL_COUNT_STRING = "INDEX_LABEL_COUNT";
+const char *VecSimCommonStrings::IS_MULTI_STRING = "IS_MULTI_VALUE";
 const char *VecSimCommonStrings::MEMORY_STRING = "MEMORY";
 
 const char *VecSimCommonStrings::HNSW_EF_RUNTIME_STRING = "EF_RUNTIME";

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -32,6 +32,8 @@ public:
 
     static const char *DIMENSION_STRING;
     static const char *INDEX_SIZE_STRING;
+    static const char *INDEX_LABEL_COUNT_STRING;
+    static const char *IS_MULTI_STRING;
     static const char *MEMORY_STRING;
 
     static const char *HNSW_EF_RUNTIME_STRING;

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -9,7 +9,7 @@
 #include "memory.h"
 
 extern "C" void VecSim_SetTimeoutCallbackFunction(timeoutCallbackFunction callback) {
-    VecSimIndex::setTimeoutCallbackFunction(callback);
+    VecSimIndexAbstract::setTimeoutCallbackFunction(callback);
 }
 
 static VecSimResolveCode _ResolveParams_EFRuntime(VecSimAlgo index_type, VecSimRawParam rparam,
@@ -70,10 +70,10 @@ extern "C" VecSimIndex *VecSimIndex_New(const VecSimParams *params) {
     try {
         switch (params->algo) {
         case VecSimAlgo_HNSWLIB:
-            index = new (allocator) HNSWIndex(&params->hnswParams, allocator);
+            index = HNSWIndex::HNSWIndex_New(&params->hnswParams, allocator);
             break;
         case VecSimAlgo_BF:
-            index = new (allocator) BruteForceIndex(&params->bfParams, allocator);
+            index = BruteForceIndex::BruteForceIndex_New(&params->bfParams, allocator);
             break;
         default:
             break;

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -9,7 +9,7 @@ extern "C" {
 #include "vec_sim_common.h"
 #include "info_iterator.h"
 
-typedef struct VecSimIndex VecSimIndex;
+typedef struct VecSimIndexInterface VecSimIndex;
 
 /**
  * @brief Create a new VecSim index based on the given params.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -27,6 +27,9 @@ typedef enum { VecSimAlgo_BF, VecSimAlgo_HNSWLIB } VecSimAlgo;
 // Distance metric
 typedef enum { VecSimMetric_L2, VecSimMetric_IP, VecSimMetric_Cosine } VecSimMetric;
 
+typedef size_t labelType;
+typedef unsigned int idType;
+
 /**
  * @brief Query Runtime raw parameters.
  * Use VecSimIndex_ResolveParams to generate VecSimQueryParams from array of VecSimRawParams.
@@ -61,6 +64,7 @@ typedef struct {
     VecSimType type;     // Datatype to index.
     size_t dim;          // Vector's dimension.
     VecSimMetric metric; // Distance metric to use in the index.
+    bool multi;          // Determines if the index should multi-index or not.
     size_t initialCapacity;
     size_t blockSize;
     size_t M;
@@ -73,6 +77,7 @@ typedef struct {
     VecSimType type;     // Datatype to index.
     size_t dim;          // Vector's dimension.
     VecSimMetric metric; // Distance metric to use in the index.
+    bool multi;          // Determines if the index should multi-index or not.
     size_t initialCapacity;
     size_t blockSize;
 } BFParams;
@@ -117,7 +122,7 @@ typedef struct {
     size_t batchSize;
     VecSearchMode searchMode;
     void *timeoutCtx; // This parameter is not exposed directly to the user, and we shouldn't expect
-                      // to get it from the parameters reslove function.
+                      // to get it from the parameters resolve function.
 } VecSimQueryParams;
 
 /**
@@ -127,26 +132,30 @@ typedef struct {
 typedef struct {
     union {
         struct {
-            size_t indexSize;      // Current count of vectors.
-            size_t blockSize;      // Sets the amount to grow when resizing
-            size_t M;              // Number of allowed edges per node in graph.
-            size_t efConstruction; // EF parameter for HNSW graph accuracy/latency for indexing.
-            size_t efRuntime;      // EF parameter for HNSW graph accuracy/latency for search.
+            size_t indexSize;       // Current count of vectors.
+            size_t indexLabelCount; // Current unique count of labels.
+            size_t blockSize;       // Sets the amount to grow when resizing
+            size_t M;               // Number of allowed edges per node in graph.
+            size_t efConstruction;  // EF parameter for HNSW graph accuracy/latency for indexing.
+            size_t efRuntime;       // EF parameter for HNSW graph accuracy/latency for search.
             double epsilon;   // Epsilon parameter for HNSW graph accuracy/latency for range search.
             size_t max_level; // Number of graph levels.
             size_t entrypoint;       // Entrypoint vector label.
             VecSimMetric metric;     // Index distance metric
             uint64_t memory;         // Index memory consumption.
             VecSimType type;         // Datatype the index holds.
+            bool isMulti;            // Determines if the index should multi-index or not.
             size_t dim;              // Vector size (dimension).
             VecSearchMode last_mode; // The mode in which the last query ran.
         } hnswInfo;
         struct {
             size_t indexSize;        // Current count of vectors.
+            size_t indexLabelCount;  // Current unique count of labels.
             size_t blockSize;        // Brute force algorithm vector block (mini matrix) size
             VecSimMetric metric;     // Index distance metric
             uint64_t memory;         // Index memory consumption.
             VecSimType type;         // Datatype the index holds.
+            bool isMulti;            // Determines if the index should multi-index or not.
             size_t dim;              // Vector size (dimension).
             VecSearchMode last_mode; // The mode in which the last query ran.
         } bfInfo;

--- a/src/VecSim/vec_sim_index.cpp
+++ b/src/VecSim/vec_sim_index.cpp
@@ -1,7 +1,7 @@
 #include "vec_sim_index.h"
 
-timeoutCallbackFunction VecSimIndex::timeoutCallback = [](void *ctx) { return 0; };
+timeoutCallbackFunction VecSimIndexAbstract::timeoutCallback = [](void *ctx) { return 0; };
 
-void VecSimIndex::setTimeoutCallbackFunction(timeoutCallbackFunction callback) {
-    VecSimIndex::timeoutCallback = callback;
+void VecSimIndexAbstract::setTimeoutCallbackFunction(timeoutCallbackFunction callback) {
+    VecSimIndexAbstract::timeoutCallback = callback;
 }

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -1,0 +1,147 @@
+#pragma once
+#include "vec_sim_common.h"
+#include "query_results.h"
+#include <stddef.h>
+#include "VecSim/memory/vecsim_base.h"
+#include "info_iterator_struct.h"
+
+/**
+ * @brief Abstract C++ class for vector index, delete and lookup
+ *
+ */
+struct VecSimIndexInterface : public VecsimBaseObject {
+
+public:
+    /**
+     * @brief Construct a new Vec Sim Index object
+     *
+     */
+    VecSimIndexInterface(std::shared_ptr<VecSimAllocator> allocator)
+        : VecsimBaseObject(allocator) {}
+
+    /**
+     * @brief Destroy the Vec Sim Index object
+     *
+     */
+    virtual ~VecSimIndexInterface() {}
+
+    /**
+     * @brief Add a vector blob and its id to the index.
+     *
+     * @param blob binary representation of the vector. Blob size should match the index data type
+     * and dimension.
+     * @param id the id of the added vector
+     * @return always returns true
+     */
+    virtual int addVector(const void *blob, size_t id) = 0;
+
+    /**
+     * @brief Remove a vector from an index.
+     *
+     * @param id the id of the removed vector
+     * @return always returns true
+     */
+    virtual int deleteVector(size_t id) = 0;
+
+    /**
+     * @brief Calculate the distance of a vector from an index to a vector.
+     * @param index the index from which the first vector is located, and that defines the distance
+     * metric.
+     * @param id the id of the vector in the index.
+     * @param blob binary representation of the second vector. Blob size should match the index data
+     * type and dimension, and pre-normalized if needed.
+     * @return The distance (according to the index's distance metric) between `blob` and the vector
+     * with id `id`.
+     */
+    virtual double getDistanceFrom(size_t id, const void *blob) const = 0;
+
+    /**
+     * @brief Return the number of vectors in the index using its SizeFn.
+     *
+     * @return index size.
+     */
+    virtual size_t indexSize() const = 0;
+
+    /**
+     * @brief Return the number of unique labels in the index using its SizeFn.
+     *
+     * @return index label count.
+     */
+    virtual size_t indexLabelCount() const = 0;
+
+    /**
+     * @brief Search for the k closest vectors to a given vector in the index.
+     *
+     * @param queryBlob binary representation of the query vector. Blob size should match the index
+     * data type and dimension.
+     * @param k the number of "nearest neighbours" to return (upper bound).
+     * @param queryParams run time params for the search, which are algorithm-specific.
+     * @return An opaque object the represents a list of results. User can access the id and score
+     * (which is the distance according to the index metric) of every result through
+     * VecSimQueryResult_Iterator.
+     */
+    virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
+                                             VecSimQueryParams *queryParams) = 0;
+
+    /**
+     * @brief Search for the vectors that are in a given range in the index with respect to a given
+     * vector. The results can be ordered by their score or id.
+     * @param queryBlob binary representation of the query vector. Blob size should match the index
+     * data type and dimension.
+     * @param radius the radius around the query vector to search vectors within it.
+     * @param queryParams run time params for the search, which are algorithm-specific.
+     * @param order the criterion to sort the results list by it. Options are by score, or by id.
+     * @return An opaque object the represents a list of results. User can access the id and score
+     * (which is the distance according to the index metric) of every result through
+     * VecSimQueryResult_Iterator.
+     */
+    virtual VecSimQueryResult_List rangeQuery(const void *queryBlob, float radius,
+                                              VecSimQueryParams *queryParams) = 0;
+
+    /**
+     * @brief Return index information.
+     *
+     * @return Index general and specific meta-data.
+     */
+    virtual VecSimIndexInfo info() const = 0;
+
+    /**
+     * @brief Returns an index information in an iterable structure.
+     *
+     * @return VecSimInfoIterator Index general and specific meta-data.
+     */
+    virtual VecSimInfoIterator *infoIterator() const = 0;
+
+    /**
+     * @brief Create a new batch iterator for a specific index, for a specific query vector,
+     * using the Index_BatchIteratorNew method of the index. Should be released with
+     * VecSimBatchIterator_Free call.
+     *
+     * @param queryBlob binary representation of the vector. Blob size should match the index data
+     * type and dimension.
+     * @return Fresh batch iterator
+     */
+    virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob,
+                                                  VecSimQueryParams *queryParams) = 0;
+
+    /**
+     * @brief Return True if heuristics says that it is better to use ad-hoc brute-force
+     * search over the index instead of using batch iterator.
+     *
+     * @param subsetSize the estimated number of vectors in the index that pass the filter
+     * (that is, query results can be only from a subset of vector of this size).
+     *
+     * @param k the number of required results to return from the query.
+     *
+     * @param initial_check flag to indicate if this check is performed for the first time (upon
+     * creating the hybrid iterator), or after running batches.
+     */
+
+    virtual bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) = 0;
+
+    /**
+     * @brief Set the latest search mode in the index data (for info/debugging).
+     * @param mode The search mode.
+     */
+    virtual inline void setLastSearchMode(VecSearchMode mode) = 0;
+};

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -173,6 +173,7 @@ PYBIND11_MODULE(VecSim, m) {
         .def_readwrite("type", &HNSWParams::type)
         .def_readwrite("dim", &HNSWParams::dim)
         .def_readwrite("metric", &HNSWParams::metric)
+        .def_readwrite("multi", &HNSWParams::multi)
         .def_readwrite("initialCapacity", &HNSWParams::initialCapacity)
         .def_readwrite("M", &HNSWParams::M)
         .def_readwrite("efConstruction", &HNSWParams::efConstruction)
@@ -184,6 +185,7 @@ PYBIND11_MODULE(VecSim, m) {
         .def_readwrite("type", &BFParams::type)
         .def_readwrite("dim", &BFParams::dim)
         .def_readwrite("metric", &BFParams::metric)
+        .def_readwrite("multi", &BFParams::multi)
         .def_readwrite("initialCapacity", &BFParams::initialCapacity)
         .def_readwrite("blockSize", &BFParams::blockSize);
 

--- a/tests/benchmark/bm_basics.cpp
+++ b/tests/benchmark/bm_basics.cpp
@@ -5,7 +5,7 @@
 #include "VecSim/query_results.h"
 #include "VecSim/utils/arr_cpp.h"
 #include "VecSim/algorithms/hnsw/serialization.h"
-#include "VecSim/algorithms/brute_force/brute_force.h"
+#include "VecSim/algorithms/brute_force/brute_force_single.h"
 #include "bm_utils.h"
 
 // Global benchmark data
@@ -101,11 +101,8 @@ BENCHMARK_DEFINE_F(BM_VecSimBasics, DeleteVectorBF)(benchmark::State &st) {
     for (auto _ : st) {
         st.PauseTiming();
         auto removed_vec = std::vector<float>(dim);
-        auto *vector_block =
-            reinterpret_cast<BruteForceIndex *>(bf_index)->getVectorVectorBlock(id_to_remove);
-        size_t index =
-            reinterpret_cast<BruteForceIndex *>(bf_index)->getVectorRelativeIndex(id_to_remove);
-        float *destination = vector_block->getVector(index);
+        float *destination =
+            reinterpret_cast<BruteForceIndex_Single *>(bf_index)->getDataByInternalId(id_to_remove);
         memcpy(removed_vec.data(), destination, dim * sizeof(float));
         blobs.push_back(removed_vec);
         iter++;

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -2,7 +2,7 @@
 #include "VecSim/vec_sim.h"
 #include "VecSim/memory/vecsim_malloc.h"
 #include "VecSim/memory/vecsim_base.h"
-#include "VecSim/algorithms/brute_force/brute_force.h"
+#include "VecSim/algorithms/brute_force/brute_force_single.h"
 #include "VecSim/algorithms/hnsw/hnsw_wrapper.h"
 #include "test_utils.h"
 #include "VecSim/algorithms/hnsw/serialization.h"
@@ -102,8 +102,8 @@ TEST_F(AllocatorTest, test_bf_index_block_size_1) {
                        .blockSize = 1};
 
     float vec[128] = {};
-    BruteForceIndex *bfIndex = new (allocator) BruteForceIndex(&params, allocator);
-    expectedAllocationSize += sizeof(BruteForceIndex) + vecsimAllocationOverhead;
+    BruteForceIndex_Single *bfIndex = new (allocator) BruteForceIndex_Single(&params, allocator);
+    expectedAllocationSize += sizeof(BruteForceIndex_Single) + vecsimAllocationOverhead;
     ASSERT_EQ(allocator->getAllocationSize(), expectedAllocationSize);
     VecSimIndexInfo info = bfIndex->info();
     ASSERT_EQ(allocator->getAllocationSize(), info.bfInfo.memory);
@@ -272,7 +272,7 @@ TEST_F(AllocatorTest, testIncomingEdgesSet) {
     // overhead), and a single node in the labels' lookup hash table.
     size_t expected_allocation_delta =
         (vec_max_level + 1) *
-        (sizeof(vecsim_stl::vector<hnswlib::tableint>) + AllocatorTest::vecsimAllocationOverhead);
+        (sizeof(vecsim_stl::vector<idType>) + AllocatorTest::vecsimAllocationOverhead);
     expected_allocation_delta += AllocatorTest::hashTableNodeSize;
 
     // Account for allocating link lists for levels higher than 0, if exists.
@@ -313,10 +313,9 @@ TEST_F(AllocatorTest, testIncomingEdgesSet) {
      * 4. Finally, expect an allocation of the data buffer in the incoming edges vector of vec1 due
      * to the insertion, and the fact that vec1 will re-select its neighbours.
      */
-    expected_allocation_delta =
-        (vec_max_level + 1) * (sizeof(vecsim_stl::vector<hnswlib::tableint>) +
-                               AllocatorTest::vecsimAllocationOverhead) +
-        AllocatorTest::hashTableNodeSize;
+    expected_allocation_delta = (vec_max_level + 1) * (sizeof(vecsim_stl::vector<idType>) +
+                                                       AllocatorTest::vecsimAllocationOverhead) +
+                                AllocatorTest::hashTableNodeSize;
     size_t buckets_diff =
         hnswIndex->getHNSWIndex()->label_lookup_.bucket_count() - buckets_num_before;
     expected_allocation_delta += buckets_diff * sizeof(size_t);
@@ -328,9 +327,9 @@ TEST_F(AllocatorTest, testIncomingEdgesSet) {
 
     // Expect that the first element is pushed to the incoming edges vector of element 1 in level 0.
     // Then, we account for the capacity of the buffer that is allocated for the vector data.
-    expected_allocation_delta += hnswIndex->getHNSWIndex()->getIncomingEdgesPtr(1, 0)->capacity() *
-                                     sizeof(hnswlib::tableint) +
-                                 AllocatorTest::vecsimAllocationOverhead;
+    expected_allocation_delta +=
+        hnswIndex->getHNSWIndex()->getIncomingEdgesPtr(1, 0)->capacity() * sizeof(idType) +
+        AllocatorTest::vecsimAllocationOverhead;
     ASSERT_EQ(allocation_delta, expected_allocation_delta);
 
     VecSimIndex_Free(hnswIndex);
@@ -386,10 +385,9 @@ TEST_F(AllocatorTest, test_hnsw_reclaim_memory) {
 
     // Compute the expected memory allocation due to the last vector insertion.
     size_t vec_max_level = hnswIndex->getHNSWIndex()->element_levels_[block_size];
-    size_t expected_mem_delta =
-        (vec_max_level + 1) * (sizeof(vecsim_stl::vector<hnswlib::tableint>) +
-                               AllocatorTest::vecsimAllocationOverhead) +
-        AllocatorTest::hashTableNodeSize;
+    size_t expected_mem_delta = (vec_max_level + 1) * (sizeof(vecsim_stl::vector<idType>) +
+                                                       AllocatorTest::vecsimAllocationOverhead) +
+                                AllocatorTest::hashTableNodeSize;
     if (vec_max_level > 0) {
         expected_mem_delta += hnswIndex->getHNSWIndex()->size_links_per_element_ * vec_max_level +
                               1 + AllocatorTest::vecsimAllocationOverhead;

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -3,6 +3,7 @@
 #include "test_utils.h"
 #include "VecSim/utils/arr_cpp.h"
 #include "VecSim/algorithms/brute_force/brute_force.h"
+#include "VecSim/algorithms/brute_force/brute_force_single.h"
 #include <cmath>
 
 class BruteForceTest : public ::testing::Test {
@@ -62,16 +63,15 @@ TEST_F(BruteForceTest, brute_force_vector_update_test) {
     // Call addVEctor with the same id, different data.
     VecSimIndex_AddVector(index, (const void *)a, 1);
 
-    // Index size shouldn't cahnge.
+    // Index size shouldn't change.
     ASSERT_EQ(VecSimIndex_IndexSize(index), 1);
 
     // id2label size should remain the same, although we seemingly tried to exceed
-    // initialcapacity.
+    // initial capacity.
     ASSERT_EQ(reinterpret_cast<BruteForceIndex *>(index)->idToLabelMapping.size(), n);
 
     // Check update.
-    VectorBlock *block = reinterpret_cast<BruteForceIndex *>(index)->getVectorVectorBlock(0);
-    float *vector_data = block->getVector(0);
+    float *vector_data = reinterpret_cast<BruteForceIndex *>(index)->getDataByInternalId(0);
     for (size_t i = 0; i < dim; ++i) {
         ASSERT_EQ(*vector_data, 2);
         ++vector_data;
@@ -91,8 +91,8 @@ TEST_F(BruteForceTest, brute_force_vector_update_test) {
     ASSERT_EQ(reinterpret_cast<BruteForceIndex *>(index)->idToLabelMapping.size(), n);
 
     // Label2id of the last vector doesn't exist.
-    ASSERT_EQ(reinterpret_cast<BruteForceIndex *>(index)->labelToIdLookup.find(1),
-              reinterpret_cast<BruteForceIndex *>(index)->labelToIdLookup.end());
+    ASSERT_EQ(reinterpret_cast<BruteForceIndex_Single *>(index)->labelToIdLookup.find(1),
+              reinterpret_cast<BruteForceIndex_Single *>(index)->labelToIdLookup.end());
 
     VecSimIndex_Free(index);
 }
@@ -553,15 +553,17 @@ TEST_F(BruteForceTest, test_delete_swap_block) {
     ASSERT_EQ(bf_index->getVectorLabel(1), id5_prev_label);
 
     // label2id value at label5 should be 1
-    ASSERT_EQ(bf_index->getVectorId(id5_prev_label), 1);
+    ASSERT_EQ(reinterpret_cast<BruteForceIndex_Single *>(bf_index)->labelToIdLookup[id5_prev_label],
+              1);
 
-    // The label of what initiailly was in id1 should be removed.
-    auto deleted_label_id_pair = bf_index->labelToIdLookup.find(id1_prev_label);
-    ASSERT_EQ(deleted_label_id_pair, bf_index->labelToIdLookup.end());
+    // The label of what initially was in id1 should be removed.
+    auto deleted_label_id_pair =
+        reinterpret_cast<BruteForceIndex_Single *>(bf_index)->labelToIdLookup.find(id1_prev_label);
+    ASSERT_EQ(deleted_label_id_pair,
+              reinterpret_cast<BruteForceIndex_Single *>(bf_index)->labelToIdLookup.end());
 
     // The vector in index1 should hold id5 data.
-    VectorBlock *block = bf_index->getVectorVectorBlock(1);
-    float *vector_data = block->getVector(1);
+    float *vector_data = bf_index->getDataByInternalId(1);
     for (size_t i = 0; i < dim; ++i) {
         ASSERT_EQ(*vector_data, 5);
         ++vector_data;

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -126,7 +126,7 @@ TEST_F(HNSWLibTest, resizeNAlignIndex) {
     // The size and the capacity should be equal.
     ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(),
               VecSimIndex_IndexSize(index));
-    // The capcity shouldnt be changed.
+    // The capacity shouldn't be changed.
     ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(), n);
 
     // Add another vector to exceed the initial capacity.
@@ -134,13 +134,13 @@ TEST_F(HNSWLibTest, resizeNAlignIndex) {
 
     // The capacity should be now aligned with the block size.
     // bs = 3, size = 11 -> capacity = 12
-    // New capacity = intiailcapacity + blockSize - intiailcapacity % blockSize.
+    // New capacity = initial capacity + blockSize - initial capacity % blockSize.
     ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(),
               n + bs - n % bs);
     VecSimIndex_Free(index);
 }
 
-// Case 1: initial cpapcity is larger than block size, and it is not aligned.
+// Case 1: initial capacity is larger than block size, and it is not aligned.
 TEST_F(HNSWLibTest, resizeNAlignIndex_largeInitialCapacity) {
     size_t dim = 4;
     size_t n = 10;
@@ -164,7 +164,7 @@ TEST_F(HNSWLibTest, resizeNAlignIndex_largeInitialCapacity) {
         VecSimIndex_AddVector(index, (const void *)a, i);
     }
 
-    // The capcity shouldnt change, should remain n.
+    // The capacity shouldn't change, should remain n.
     ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(), n);
 
     // Delete last vector, to get size % block_size == 0. size = 3
@@ -173,7 +173,7 @@ TEST_F(HNSWLibTest, resizeNAlignIndex_largeInitialCapacity) {
     // Index size = bs = 3.
     ASSERT_EQ(VecSimIndex_IndexSize(index), bs);
 
-    // New capacity = intiailcapacity - block_size - number_of_vectors_to_align =
+    // New capacity = initial capacity - block_size - number_of_vectors_to_align =
     // 10  - 3 - 10 % 3 (1) = 6
     size_t curr_capacity = reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity();
     ASSERT_EQ(curr_capacity, n - bs - n % bs);
@@ -185,7 +185,7 @@ TEST_F(HNSWLibTest, resizeNAlignIndex_largeInitialCapacity) {
         ++i;
     }
     ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(), bs);
-    // Add and delete a vector to acheive:
+    // Add and delete a vector to achieve:
     // size % block_size == 0 && size + bs <= capacity(3).
     // the capacity should be resized to zero
     VecSimIndex_AddVector(index, (const void *)a, 0);
@@ -202,7 +202,7 @@ TEST_F(HNSWLibTest, resizeNAlignIndex_largeInitialCapacity) {
     VecSimIndex_Free(index);
 }
 
-// Case 2: initial cpapcity is smaller than block_size.
+// Case 2: initial capacity is smaller than block_size.
 TEST_F(HNSWLibTest, resizeNAlignIndex_largerBlockSize) {
     size_t dim = 4;
     size_t n = 4;
@@ -226,7 +226,7 @@ TEST_F(HNSWLibTest, resizeNAlignIndex_largerBlockSize) {
         VecSimIndex_AddVector(index, (const void *)a, i);
     }
 
-    // The capcity shouldnt change.
+    // The capacity shouldn't change.
     ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(), n);
 
     // Size equals capacity.
@@ -262,7 +262,7 @@ TEST_F(HNSWLibTest, emptyIndex) {
     VecSimIndex *index = VecSimIndex_New(&params);
     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
 
-    // Try to remove from an empty index - should fail because label doesnt exist.
+    // Try to remove from an empty index - should fail because label doesn't exist.
     VecSimIndex_DeleteVector(index, 0);
 
     // Add one vector.
@@ -276,17 +276,17 @@ TEST_F(HNSWLibTest, emptyIndex) {
     VecSimIndex_DeleteVector(index, 1);
     // The capacity should change to be aligned with the vector size.
 
-    size_t new_capcaity = reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity();
-    ASSERT_EQ(new_capcaity, n - n % bs - bs);
+    size_t new_capacity = reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity();
+    ASSERT_EQ(new_capacity, n - n % bs - bs);
 
     // Size equals 0.
     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
 
     // Try to remove it again.
-    // The capacity should remain unchanged, as we are trying to delete a label that doesnt exist.
+    // The capacity should remain unchanged, as we are trying to delete a label that doesn't exist.
     VecSimIndex_DeleteVector(index, 1);
     ASSERT_EQ(reinterpret_cast<HNSWIndex *>(index)->getHNSWIndex()->getIndexCapacity(),
-              new_capcaity);
+              new_capacity);
     // Nor the size.
     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
 
@@ -491,7 +491,7 @@ TEST_F(HNSWLibTest, hnswlib_reindexing_same_vector_different_id) {
     VecSimIndex_Free(index);
 }
 
-TEST_F(HNSWLibTest, sanity_rinsert_1280) {
+TEST_F(HNSWLibTest, sanity_reinsert_1280) {
     size_t n = 5;
     size_t d = 1280;
     size_t k = 5;
@@ -925,7 +925,7 @@ TEST_F(HNSWLibTest, hnsw_bad_params) {
         SIZE_MAX,  // Will fail on M * 2 overflow.
         SIZE_MAX / 2, // Will fail on M * 2 overflow.
         SIZE_MAX / 4  // Will fail on size_links_level0_ calculation:
-                      // sizeof(linklistsizeint) + M * 2 * sizeof(tableint) + sizeof(void *)
+                      // sizeof(linklistsizeint) + M * 2 * sizeof(idType) + sizeof(void *)
     };
     unsigned long len = sizeof(bad_M) / sizeof(size_t);
 
@@ -1700,8 +1700,8 @@ TEST_F(HNSWLibTest, testSizeEstimation) {
         }
         actual += VecSimIndex_AddVector(index, vec, n + i);
     }
-    ASSERT_GE(estimation * 1.02, actual);
-    ASSERT_LE(estimation * 0.98, actual);
+    ASSERT_GE(estimation * 1.01, actual);
+    ASSERT_LE(estimation * 0.99, actual);
 
     VecSimIndex_Free(index);
 }

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -52,7 +52,7 @@ void runBatchIteratorSearchTest(VecSimBatchIterator *batch_iterator, size_t n_re
 }
 
 void compareFlatIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *infoIter) {
-    ASSERT_EQ(8, VecSimInfoIterator_NumberOfFields(infoIter));
+    ASSERT_EQ(10, VecSimInfoIterator_NumberOfFields(infoIter));
     while (VecSimInfoIterator_HasNextField(infoIter)) {
         VecSim_InfoField *infoFiled = VecSimInfoIterator_NextField(infoIter);
         if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
@@ -79,6 +79,14 @@ void compareFlatIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
             // Index size.
             ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);
             ASSERT_EQ(infoFiled->uintegerValue, info.bfInfo.indexSize);
+        } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::INDEX_LABEL_COUNT_STRING)) {
+            // Index label count.
+            ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoFiled->uintegerValue, info.bfInfo.indexLabelCount);
+        } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::IS_MULTI_STRING)) {
+            // Is the index multi value.
+            ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoFiled->uintegerValue, info.bfInfo.isMulti);
         } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::BLOCK_SIZE_STRING)) {
             // Block size.
             ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);
@@ -94,7 +102,7 @@ void compareFlatIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
 }
 
 void compareHNSWIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *infoIter) {
-    ASSERT_EQ(13, VecSimInfoIterator_NumberOfFields(infoIter));
+    ASSERT_EQ(15, VecSimInfoIterator_NumberOfFields(infoIter));
     while (VecSimInfoIterator_HasNextField(infoIter)) {
         VecSim_InfoField *infoFiled = VecSimInfoIterator_NextField(infoIter);
         if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
@@ -122,6 +130,14 @@ void compareHNSWIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
             // Index size.
             ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);
             ASSERT_EQ(infoFiled->uintegerValue, info.hnswInfo.indexSize);
+        } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::INDEX_LABEL_COUNT_STRING)) {
+            // Index label count.
+            ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoFiled->uintegerValue, info.hnswInfo.indexLabelCount);
+        } else if (!strcmp(infoFiled->fieldName, VecSimCommonStrings::IS_MULTI_STRING)) {
+            // Is the index multi value.
+            ASSERT_EQ(infoFiled->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoFiled->uintegerValue, info.hnswInfo.isMulti);
         } else if (!strcmp(infoFiled->fieldName,
                            VecSimCommonStrings::HNSW_EF_CONSTRUCTION_STRING)) {
             // EF construction.


### PR DESCRIPTION
* unified types, moved common members to VecSimIndex

* added multi param to vecsimparams and used it
to determine what constructor to call

* generalized brute_force.cpp and moved specifics

* prepared bf batch iterator to support multi

* fixed tests (using only BruteForceIndex_Single)

* update bindings

* changed index creation flow to use factors

* added vecsim interface
to support the coming up templates

* preparing bf_batch_itr for inheritance

* rebase after deleting space interface

* moving `GetDistFunc` to vecsim abstract class

* moves `GetDim` & `setLastSearchMode` to base class

* added `multi` flag to vecsim base

* added label count and is multi to info fields

* review fixes

* generalizing hnsw batch flow

* review improvements