### PR TITLE
multivalue hnsw - derive hnsw single and multi from base hnsw

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -233,8 +233,12 @@ BruteForceIndex<DataType, DistType>::topKQuery(const void *queryBlob, size_t k,
 
     VecSimQueryResult_List rl = {0};
     void *timeoutCtx = queryParams ? queryParams->timeoutCtx : NULL;
-
     this->last_mode = STANDARD_KNN;
+
+    if (0 == k) {
+        rl.results = array_new<VecSimQueryResult>(0);
+        return rl;
+    }
 
     DataType normalized_blob[this->dim]; // This will be use only if metric == VecSimMetric_Cosine.
     if (this->metric == VecSimMetric_Cosine) {

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -65,7 +65,7 @@ protected:
     }
     // inline priority queue getter that need to be implemented by derived class
     virtual inline vecsim_stl::abstract_priority_queue<DistType, labelType> *
-    getNewPriorityQueue() = 0;
+    getNewMaxPriorityQueue() = 0;
 
     // inline label to id setters that need to be implemented by derived class
     virtual inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) = 0;
@@ -245,7 +245,8 @@ BruteForceIndex<DataType, DistType>::topKQuery(const void *queryBlob, size_t k,
     }
 
     DistType upperBound = std::numeric_limits<DistType>::lowest();
-    vecsim_stl::abstract_priority_queue<DistType, labelType> *TopCandidates = getNewPriorityQueue();
+    vecsim_stl::abstract_priority_queue<DistType, labelType> *TopCandidates =
+        getNewMaxPriorityQueue();
     // For every block, compute its vectors scores and update the Top candidates max heap
     idType curr_id = 0;
     for (auto vectorBlock : this->vectorBlocks) {

--- a/src/VecSim/algorithms/brute_force/brute_force_multi.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_multi.h
@@ -30,7 +30,7 @@ private:
     inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) override;
 
     inline vecsim_stl::abstract_priority_queue<DistType, labelType> *
-    getNewPriorityQueue() override {
+    getNewMaxPriorityQueue() override {
         return new (this->allocator)
             vecsim_stl::updatable_max_heap<DistType, labelType>(this->allocator);
     }

--- a/src/VecSim/algorithms/brute_force/brute_force_multi.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_multi.h
@@ -47,7 +47,7 @@ private:
     friend class BruteForceMultiTest_empty_index_Test;
     friend class BruteForceMultiTest_test_delete_swap_block_Test;
     friend class BruteForceMultiTest_remove_vector_after_replacing_block_Test;
-    friend class BruteForceMultiTest_search_more_then_there_is_Test;
+    friend class BruteForceMultiTest_search_more_than_there_is_Test;
     friend class BruteForceMultiTest_indexing_same_vector_Test;
     friend class BruteForceMultiTest_test_dynamic_bf_info_iterator_Test;
 #endif

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -42,7 +42,7 @@ protected:
     }
 
     inline vecsim_stl::abstract_priority_queue<DistType, labelType> *
-    getNewPriorityQueue() override {
+    getNewMaxPriorityQueue() override {
         return new (this->allocator)
             vecsim_stl::max_priority_queue<DistType, labelType>(this->allocator);
     }

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -1199,10 +1199,10 @@ int HNSWIndex<DataType, DistType>::appendVector(const void *vector_data, const l
 
     if (element_max_level > 0) {
         linkLists_[cur_c] =
-            (char *)this->allocator->allocate(size_links_per_element_ * element_max_level + 1);
+            (char *)this->allocator->allocate(size_links_per_element_ * element_max_level);
         if (linkLists_[cur_c] == nullptr)
             throw std::runtime_error("Not enough memory: addPoint failed to allocate linklist");
-        memset(linkLists_[cur_c], 0, size_links_per_element_ * element_max_level + 1);
+        memset(linkLists_[cur_c], 0, size_links_per_element_ * element_max_level);
     }
 
     // this condition only means that we are not inserting the first element.

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -1657,7 +1657,7 @@ bool HNSWIndex<DataType, DistType>::preferAdHocSearch(size_t subsetSize, size_t 
     }
     size_t d = this->dim;
     size_t M = this->getM();
-    float r = (index_size == 0) ? 0.0f : (float)(subsetSize) / (float)index_size;
+    float r = (index_size == 0) ? 0.0f : (float)(subsetSize) / (float)this->indexLabelCount();
     bool res;
 
     // node 0

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -427,12 +427,14 @@ DistType HNSWIndex<DataType, DistType>::processCandidate(
         idType *candidate_pos = node_links + j;
         idType candidate_id = *candidate_pos;
 
+        if (this->visited_nodes_handler->getNodeTag(candidate_id) == visited_tag)
+            continue;
+
         // Pre-fetch the next candidate data into memory cache, to improve performance.
         idType *next_candidate_pos = node_links + j + 1;
         __builtin_prefetch(visited_nodes_handler->getElementsTags() + *next_candidate_pos);
         __builtin_prefetch(getDataByInternalId(*next_candidate_pos));
-        if (this->visited_nodes_handler->getNodeTag(candidate_id) == visited_tag)
-            continue;
+
         this->visited_nodes_handler->tagNode(candidate_id, visited_tag);
         char *currObj1 = (getDataByInternalId(candidate_id));
 

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -120,7 +120,7 @@ protected:
                                  size_t Mcurmax, idType *node_neighbors,
                                  const vecsim_stl::vector<bool> &bitmap, idType *removed_links,
                                  size_t *removed_links_num);
-    template <typename Identifier>
+    template <typename Identifier> // Either idType or labelType
     inline DistType
     processCandidate(idType curNodeId, const void *data_point, size_t layer, size_t ef,
                      tag_t visited_tag,
@@ -151,19 +151,10 @@ protected:
     inline void resizeIndex(size_t new_max_elements);
     inline void SwapLastIdWithDeletedId(idType element_internal_id);
 
-    // inline label to id setters that need to be implemented by derived class
-    virtual inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) = 0;
-    virtual inline void setVectorId(labelType label, idType id) = 0;
-    virtual inline void resizeLabelLookup(size_t new_max_elements) = 0;
-
-    // inline priority queue getter that need to be implemented by derived class
-    virtual inline vecsim_stl::abstract_priority_queue<DistType, labelType> *
-    getNewMaxPriorityQueue() const = 0;
-
-    // Private internal function that implements generic single vector insertion.
+    // Protected internal function that implements generic single vector insertion.
     int appendVector(const void *vector_data, labelType label);
 
-    // Private internal function that implements generic single vector deletion.
+    // Protected internal function that implements generic single vector deletion.
     int removeVector(idType id);
 
     inline void emplaceToHeap(vecsim_stl::abstract_priority_queue<DistType, idType> &heap,
@@ -204,6 +195,16 @@ public:
                                      VecSimQueryParams *queryParams) override;
     VecSimQueryResult_List rangeQuery(const void *query_data, double radius,
                                       VecSimQueryParams *queryParams) override;
+
+protected:
+    // inline label to id setters that need to be implemented by derived class
+    virtual inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) = 0;
+    virtual inline void setVectorId(labelType label, idType id) = 0;
+    virtual inline void resizeLabelLookup(size_t new_max_elements) = 0;
+
+    // inline priority queue getter that need to be implemented by derived class
+    virtual inline vecsim_stl::abstract_priority_queue<DistType, labelType> *
+    getNewMaxPriorityQueue() const = 0;
 };
 
 /**
@@ -1403,6 +1404,7 @@ VecSimQueryResult_List HNSWIndex<DataType, DistType>::topKQuery(const void *quer
         return rl;
     }
 
+    // We now oun the results heap, we need to free (delete) it when we done
     candidatesLabelsMaxHeap<DistType> *results = searchBottomLayer_WithTimeout(
         bottom_layer_ep, query_data, std::max(ef, k), k, timeoutCtx, &rl.code);
 

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -10,7 +10,6 @@
 #include "VecSim/vec_sim_common.h"
 #include "VecSim/vec_sim_index.h"
 #include "VecSim/algorithms/hnsw/hnsw_factory.h" //newBatchIterator
-#include "VecSim/algorithms/hnsw/hnsw_single.h"
 
 #include <deque>
 #include <memory>
@@ -103,7 +102,6 @@ protected:
     friend class HNSWTest_test_dynamic_hnsw_info_iterator_Test;
     friend class AllocatorTest_testIncomingEdgesSet_Test;
     friend class AllocatorTest_test_hnsw_reclaim_memory_Test;
-    friend class HNSWTest_testSizeEstimation_Test;
 #endif
 
     HNSWIndex() = delete;                  // default constructor is disabled.
@@ -199,6 +197,7 @@ public:
     inline unsigned short int getListCount(const linklistsizeint *ptr) const;
     inline idType searchBottomLayerEP(const void *query_data, void *timeoutCtx,
                                       VecSimQueryResult_Code *rc) const;
+
     VecSimQueryResult_List topKQuery(const void *query_data, size_t k,
                                      VecSimQueryParams *queryParams) override;
     VecSimQueryResult_List rangeQuery(const void *query_data, double radius,
@@ -1599,7 +1598,7 @@ VecSimInfoIterator *HNSWIndex<DataType, DistType>::infoIterator() const {
     infoIterator->addInfoField(
         VecSim_InfoField{.fieldName = VecSimCommonStrings::IS_MULTI_STRING,
                          .fieldType = INFOFIELD_UINT64,
-                         .fieldValue = {FieldValue{.uintegerValue = info.bfInfo.isMulti}}});
+                         .fieldValue = {FieldValue{.uintegerValue = info.hnswInfo.isMulti}}});
     infoIterator->addInfoField(
         VecSim_InfoField{.fieldName = VecSimCommonStrings::INDEX_SIZE_STRING,
                          .fieldType = INFOFIELD_UINT64,

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -120,9 +120,10 @@ protected:
                                  size_t Mcurmax, idType *node_neighbors,
                                  const vecsim_stl::vector<bool> &bitmap, idType *removed_links,
                                  size_t *removed_links_num);
+    template<typename Value>
     inline DistType processCandidate(idType curNodeId, const void *data_point, size_t layer,
                                      size_t ef, tag_t visited_tag,
-                                     candidatesMaxHeap<DistType> &top_candidates,
+                                     vecsim_stl::max_priority_queue<DistType, Value> &top_candidates,
                                      candidatesMaxHeap<DistType> &candidates_set,
                                      DistType lowerBound) const;
     inline void processCandidate_RangeSearch(idType curNodeId, const void *data_point, size_t layer,
@@ -160,6 +161,9 @@ protected:
 
     // Private internal function that implements generic single vector deletion.
     int removeVector(idType id);
+
+    inline void emplaceToHeap(candidatesMaxHeap<DistType> &heap, DistType dist, idType id) const;
+    inline void emplaceToHeap(candidatesLabelsMaxHeap<DistType> &heap, DistType dist, idType id) const;
 
 public:
     HNSWIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator,
@@ -383,9 +387,20 @@ void HNSWIndex<DataType, DistType>::removeExtraLinks(
 }
 
 template <typename DataType, typename DistType>
+void HNSWIndex<DataType, DistType>::emplaceToHeap(candidatesMaxHeap<DistType> &heap, DistType dist, idType id) const {
+    heap.emplace(dist, id);
+}
+
+template <typename DataType, typename DistType>
+void HNSWIndex<DataType, DistType>::emplaceToHeap(candidatesLabelsMaxHeap<DistType> &heap, DistType dist, idType id) const {
+    heap.emplace(dist, getExternalLabel(id));
+}
+
+template <typename DataType, typename DistType>
+template <typename Value>
 DistType HNSWIndex<DataType, DistType>::processCandidate(
     idType curNodeId, const void *data_point, size_t layer, size_t ef, tag_t visited_tag,
-    candidatesMaxHeap<DistType> &top_candidates, candidatesMaxHeap<DistType> &candidate_set,
+    vecsim_stl::max_priority_queue<DistType, Value> &top_candidates, candidatesMaxHeap<DistType> &candidate_set,
     DistType lowerBound) const {
 
 #ifdef ENABLE_PARALLELIZATION
@@ -415,7 +430,7 @@ DistType HNSWIndex<DataType, DistType>::processCandidate(
         if (top_candidates.size() < ef || lowerBound > dist1) {
             candidate_set.emplace(-dist1, candidate_id);
 
-            top_candidates.emplace(dist1, candidate_id);
+            emplaceToHeap(top_candidates , dist1, candidate_id);
 
             if (top_candidates.size() > ef)
                 top_candidates.pop();
@@ -1297,7 +1312,6 @@ candidatesLabelsMaxHeap<DistType>
 HNSWIndex<DataType, DistType>::searchBottomLayer_WithTimeout(idType ep_id, const void *data_point,
                                                              size_t ef, size_t k, void *timeoutCtx,
                                                              VecSimQueryResult_Code *rc) const {
-    candidatesLabelsMaxHeap<DistType> results(this->allocator);
 
 #ifdef ENABLE_PARALLELIZATION
     this->visited_nodes_handler =
@@ -1306,12 +1320,12 @@ HNSWIndex<DataType, DistType>::searchBottomLayer_WithTimeout(idType ep_id, const
 
     tag_t visited_tag = this->visited_nodes_handler->getFreshTag();
 
-    candidatesMaxHeap<DistType> top_candidates(this->allocator);
+    candidatesLabelsMaxHeap<DistType> top_candidates(this->allocator); // change to get heap
     candidatesMaxHeap<DistType> candidate_set(this->allocator);
 
     DistType dist = this->dist_func(data_point, getDataByInternalId(ep_id), this->dim);
     DistType lowerBound = dist;
-    top_candidates.emplace(dist, ep_id);
+    top_candidates.emplace(dist, getExternalLabel(ep_id));
     candidate_set.emplace(-dist, ep_id);
 
     this->visited_nodes_handler->tagNode(ep_id, visited_tag);
@@ -1323,7 +1337,7 @@ HNSWIndex<DataType, DistType>::searchBottomLayer_WithTimeout(idType ep_id, const
         }
         if (__builtin_expect(VecSimIndexAbstract<DistType>::timeoutCallback(timeoutCtx), 0)) {
             *rc = VecSim_QueryResult_TimedOut;
-            return results;
+            return top_candidates;
         }
         candidate_set.pop();
 
@@ -1336,13 +1350,8 @@ HNSWIndex<DataType, DistType>::searchBottomLayer_WithTimeout(idType ep_id, const
     while (top_candidates.size() > k) {
         top_candidates.pop();
     }
-    while (top_candidates.size() > 0) {
-        auto &res = top_candidates.top();
-        results.emplace(res.first, getExternalLabel(res.second));
-        top_candidates.pop();
-    }
     *rc = VecSim_QueryResult_OK;
-    return results;
+    return top_candidates;
 }
 
 template <typename DataType, typename DistType>
@@ -1388,15 +1397,13 @@ VecSimQueryResult_List HNSWIndex<DataType, DistType>::topKQuery(const void *quer
     // Restore efRuntime.
     ef_ = originalEF;
 
-    if (VecSim_OK != rl.code) {
-        return rl;
-    }
-
-    rl.results = array_new_len<VecSimQueryResult>(results.size(), results.size());
-    for (int i = (int)results.size() - 1; i >= 0; --i) {
-        VecSimQueryResult_SetId(rl.results[i], results.top().second);
-        VecSimQueryResult_SetScore(rl.results[i], results.top().first);
-        results.pop();
+    if (VecSim_OK == rl.code) {
+        rl.results = array_new_len<VecSimQueryResult>(results.size(), results.size());
+        for (int i = (int)results.size() - 1; i >= 0; --i) {
+            VecSimQueryResult_SetId(rl.results[i], results.top().second);
+            VecSimQueryResult_SetScore(rl.results[i], results.top().first);
+            results.pop();
+        }
     }
     return rl;
 }

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -10,6 +10,7 @@
 #include "VecSim/vec_sim_common.h"
 #include "VecSim/vec_sim_index.h"
 #include "VecSim/algorithms/hnsw/hnsw_factory.h" //newBatchIterator
+#include "VecSim/algorithms/hnsw/hnsw_single.h"
 
 #include <deque>
 #include <memory>
@@ -23,7 +24,6 @@
 #include <sys/resource.h>
 #include <fstream>
 
-using spaces::dist_func_t;
 using std::pair;
 
 #define HNSW_INVALID_ID    UINT_MAX
@@ -45,7 +45,7 @@ using candidatesLabelsMaxHeap = vecsim_stl::max_priority_queue<DistType, labelTy
 
 template <typename DataType, typename DistType>
 class HNSWIndex : public VecSimIndexAbstract<DistType> {
-private:
+protected:
     // Index build parameters
     size_t max_elements_;
     size_t M_;
@@ -85,7 +85,6 @@ private:
     char *data_level0_memory_;
     char **linkLists_;
     vecsim_stl::vector<size_t> element_levels_;
-    vecsim_stl::unordered_map<labelType, idType> label_lookup_;
     std::shared_ptr<VisitedNodesHandler> visited_nodes_handler;
 
     // used for synchronization only when parallel indexing / searching is enabled.
@@ -148,8 +147,19 @@ private:
                                       idType *neighbours_list, idType *neighbour_neighbours_list,
                                       size_t level, vecsim_stl::vector<bool> &neighbours_bitmap);
     inline void replaceEntryPoint();
-    inline void SwapLastIdWithDeletedId(idType element_internal_id,
-                                        idType last_element_internal_id);
+    inline void resizeIndex(size_t new_max_elements);
+    inline void SwapLastIdWithDeletedId(idType element_internal_id);
+
+    // inline label to id setters that need to be implemented by derived class
+    virtual inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) = 0;
+    virtual inline void setVectorId(labelType label, idType id) = 0;
+    virtual inline void resizeLabelLookup(size_t new_max_elements) = 0;
+
+    // Private internal function that implements generic single vector insertion.
+    int appendVector(const void *vector_data, labelType label);
+
+    // Private internal function that implements generic single vector deletion.
+    int removeVector(idType id);
 
 public:
     HNSWIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator,
@@ -161,13 +171,12 @@ public:
     inline void setEpsilon(double epsilon);
     inline double getEpsilon() const;
     inline size_t indexSize() const override;
-    inline size_t indexLabelCount() const override;
     inline size_t getIndexCapacity() const;
     inline size_t getEfConstruction() const;
     inline size_t getM() const;
     inline size_t getMaxLevel() const;
-    inline size_t getEntryPointLabel() const;
     inline idType getEntryPointId() const;
+    inline labelType getEntryPointLabel() const;
     inline labelType getExternalLabel(idType internal_id) const;
     inline VisitedNodesHandler *getVisitedList() const;
     VecSimIndexInfo info() const override;
@@ -178,10 +187,6 @@ public:
     char *getDataByInternalId(idType internal_id) const;
     inline linklistsizeint *get_linklist_at_level(idType internal_id, size_t level) const;
     inline unsigned short int getListCount(const linklistsizeint *ptr) const;
-    inline void resizeIndex(size_t new_max_elements);
-    int deleteVector(labelType label) override;
-    int addVector(const void *vector_data, labelType label) override;
-    double getDistanceFrom(labelType label, const void *vector_data) const override;
     inline idType searchBottomLayerEP(const void *query_data, void *timeoutCtx,
                                       VecSimQueryResult_Code *rc) const;
     VecSimQueryResult_List topKQuery(const void *query_data, size_t k,
@@ -220,11 +225,6 @@ size_t HNSWIndex<DataType, DistType>::indexSize() const {
 }
 
 template <typename DataType, typename DistType>
-size_t HNSWIndex<DataType, DistType>::indexLabelCount() const {
-    return label_lookup_.size();
-}
-
-template <typename DataType, typename DistType>
 size_t HNSWIndex<DataType, DistType>::getIndexCapacity() const {
     return max_elements_;
 }
@@ -245,9 +245,9 @@ size_t HNSWIndex<DataType, DistType>::getMaxLevel() const {
 }
 
 template <typename DataType, typename DistType>
-size_t HNSWIndex<DataType, DistType>::getEntryPointLabel() const {
+labelType HNSWIndex<DataType, DistType>::getEntryPointLabel() const {
     if (entrypoint_node_ != HNSW_INVALID_ID)
-        return (size_t)getExternalLabel(entrypoint_node_);
+        return getExternalLabel(entrypoint_node_);
     return SIZE_MAX;
 }
 
@@ -282,16 +282,6 @@ size_t HNSWIndex<DataType, DistType>::getRandomLevel(double reverse_size) {
     std::uniform_real_distribution<double> distribution(0.0, 1.0);
     double r = -log(distribution(level_generator_)) * reverse_size;
     return (size_t)r;
-}
-
-template <typename DataType, typename DistType>
-double HNSWIndex<DataType, DistType>::getDistanceFrom(labelType label,
-                                                      const void *vector_data) const {
-    auto id = label_lookup_.find(label);
-    if (id == label_lookup_.end()) {
-        return INVALID_SCORE;
-    }
-    return this->dist_func(vector_data, getDataByInternalId(id->second), this->dim);
 }
 
 template <typename DataType, typename DistType>
@@ -814,16 +804,14 @@ void HNSWIndex<DataType, DistType>::replaceEntryPoint() {
 }
 
 template <typename DataType, typename DistType>
-void HNSWIndex<DataType, DistType>::SwapLastIdWithDeletedId(idType element_internal_id,
-                                                            idType last_element_internal_id) {
+void HNSWIndex<DataType, DistType>::SwapLastIdWithDeletedId(idType element_internal_id) {
     // swap label
-    labelType last_element_label = getExternalLabel(last_element_internal_id);
-    label_lookup_[last_element_label] = element_internal_id;
+    replaceIdOfLabel(getExternalLabel(max_id), element_internal_id, max_id);
 
     // swap neighbours
-    size_t last_element_top_level = element_levels_[last_element_internal_id];
+    size_t last_element_top_level = element_levels_[max_id];
     for (size_t level = 0; level <= last_element_top_level; level++) {
-        linklistsizeint *neighbours_list = get_linklist_at_level(last_element_internal_id, level);
+        linklistsizeint *neighbours_list = get_linklist_at_level(max_id, level);
         unsigned short neighbours_count = getListCount(neighbours_list);
         auto *neighbours = (idType *)(neighbours_list + 1);
 
@@ -838,7 +826,7 @@ void HNSWIndex<DataType, DistType>::SwapLastIdWithDeletedId(idType element_inter
             bool bidirectional_edge = false;
             for (size_t j = 0; j < neighbour_neighbours_count; j++) {
                 // if the edge is bidirectional, update for this neighbor
-                if (neighbour_neighbours[j] == last_element_internal_id) {
+                if (neighbour_neighbours[j] == max_id) {
                     bidirectional_edge = true;
                     neighbour_neighbours[j] = element_internal_id;
                     break;
@@ -850,7 +838,7 @@ void HNSWIndex<DataType, DistType>::SwapLastIdWithDeletedId(idType element_inter
             if (!bidirectional_edge) {
                 auto *neighbour_incoming_edges = getIncomingEdgesPtr(neighbour_id, level);
                 auto it = std::find(neighbour_incoming_edges->begin(),
-                                    neighbour_incoming_edges->end(), last_element_internal_id);
+                                    neighbour_incoming_edges->end(), max_id);
                 neighbour_incoming_edges->erase(it);
                 neighbour_incoming_edges->push_back(element_internal_id);
             }
@@ -858,7 +846,7 @@ void HNSWIndex<DataType, DistType>::SwapLastIdWithDeletedId(idType element_inter
 
         // next, go over the rest of incoming edges (the ones that are not bidirectional) and make
         // updates.
-        auto *incoming_edges = getIncomingEdgesPtr(last_element_internal_id, level);
+        auto *incoming_edges = getIncomingEdgesPtr(max_id, level);
         for (auto incoming_edge : *incoming_edges) {
             linklistsizeint *incoming_neighbour_neighbours_list =
                 get_linklist_at_level(incoming_edge, level);
@@ -867,7 +855,7 @@ void HNSWIndex<DataType, DistType>::SwapLastIdWithDeletedId(idType element_inter
             auto *incoming_neighbour_neighbours =
                 (idType *)(incoming_neighbour_neighbours_list + 1);
             for (size_t j = 0; j < incoming_neighbour_neighbours_count; j++) {
-                if (incoming_neighbour_neighbours[j] == last_element_internal_id) {
+                if (incoming_neighbour_neighbours[j] == max_id) {
                     incoming_neighbour_neighbours[j] = element_internal_id;
                     break;
                 }
@@ -877,23 +865,24 @@ void HNSWIndex<DataType, DistType>::SwapLastIdWithDeletedId(idType element_inter
 
     // swap the last_id level 0 data, and invalidate the deleted id's data
     memcpy(data_level0_memory_ + element_internal_id * size_data_per_element_ + offsetLevel0_,
-           data_level0_memory_ + last_element_internal_id * size_data_per_element_ + offsetLevel0_,
+           data_level0_memory_ + max_id * size_data_per_element_ + offsetLevel0_,
            size_data_per_element_);
-    memset(data_level0_memory_ + last_element_internal_id * size_data_per_element_ + offsetLevel0_,
-           0, size_data_per_element_);
+    memset(data_level0_memory_ + max_id * size_data_per_element_ + offsetLevel0_, 0,
+           size_data_per_element_);
 
     // swap pointer of higher levels links
-    linkLists_[element_internal_id] = linkLists_[last_element_internal_id];
-    linkLists_[last_element_internal_id] = nullptr;
+    linkLists_[element_internal_id] = linkLists_[max_id];
+    linkLists_[max_id] = nullptr;
 
     // swap top element level
-    element_levels_[element_internal_id] = element_levels_[last_element_internal_id];
-    element_levels_[last_element_internal_id] = HNSW_INVALID_LEVEL;
+    element_levels_[element_internal_id] = element_levels_[max_id];
+    element_levels_[max_id] = HNSW_INVALID_LEVEL;
 
-    if (last_element_internal_id == this->entrypoint_node_) {
+    if (max_id == this->entrypoint_node_) {
         this->entrypoint_node_ = element_internal_id;
     }
 }
+
 /* typedef struct {
     VecSimType type;     // Datatype to index.
     size_t dim;          // Vector's dimension.
@@ -913,7 +902,7 @@ HNSWIndex<DataType, DistType>::HNSWIndex(const HNSWParams *params,
                                     params->blockSize, params->multi),
       max_elements_(params->initialCapacity),
       data_size_(VecSimType_sizeof(params->type) * this->dim),
-      element_levels_(max_elements_, allocator), label_lookup_(max_elements_, allocator)
+      element_levels_(max_elements_, allocator)
 
 #ifdef ENABLE_PARALLELIZATION
       ,
@@ -954,8 +943,8 @@ HNSWIndex<DataType, DistType>::HNSWIndex(const HNSWParams *params,
     level_generator_.seed(random_seed);
 
     // data_level0_memory will look like this:
-    // -----4------ | -----4*M0----------- | ----8------------------| ------32------- | ----8---- |
-    // <links_len>  | <link_1> <link_2>... | <incoming_links_set> |   <data>        |  <label>
+    // | -----4------ | -----4*M0----------- | ----------8----------| --data_size_-- | ----8---- |
+    // | <links_len>  | <link_1> <link_2>... | <incoming_links_ptr> |     <data>     |  <label>  |
     if (maxM0_ > ((SIZE_MAX - sizeof(void *) - sizeof(linklistsizeint)) / sizeof(idType)) + 1)
         throw std::runtime_error("HNSW index parameter M is too large: argument overflow");
     size_links_level0_ = sizeof(linklistsizeint) + maxM0_ * sizeof(idType) + sizeof(void *);
@@ -982,8 +971,8 @@ HNSWIndex<DataType, DistType>::HNSWIndex(const HNSWParams *params,
 
     // The i-th entry in linkLists array points to max_level[i] (continuous)
     // chunks of memory, each one will look like this:
-    // -----4------ | -----4*M-------------- | ----8------------------|
-    // <links_len>  | <link_1> <link_2> ...  | <incoming_links_set>
+    // | -----4----- | -----4*M-------------- | ----------8--------- |
+    // | <links_len> | <link_1> <link_2> ...  | <incoming_links_ptr> |
     size_links_per_element_ = sizeof(linklistsizeint) + maxM_ * sizeof(idType) + sizeof(void *);
     // No need to test for overflow because we passed the test for incoming_links_offset0 and this
     // is less.
@@ -1013,7 +1002,7 @@ template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::resizeIndex(size_t new_max_elements) {
     element_levels_.resize(new_max_elements);
     element_levels_.shrink_to_fit();
-    label_lookup_.reserve(new_max_elements);
+    resizeLabelLookup(new_max_elements);
 #ifdef ENABLE_PARALLELIZATION
     visited_nodes_handler_pool = std::unique_ptr<VisitedNodesHandlerPool>(
         new (this->allocator)
@@ -1041,12 +1030,8 @@ void HNSWIndex<DataType, DistType>::resizeIndex(size_t new_max_elements) {
 }
 
 template <typename DataType, typename DistType>
-int HNSWIndex<DataType, DistType>::deleteVector(const labelType label) {
-    // check that the label actually exists in the graph, and update the number of elements.
-    if (label_lookup_.find(label) == label_lookup_.end()) {
-        return false;
-    }
-    idType element_internal_id = label_lookup_[label];
+int HNSWIndex<DataType, DistType>::removeVector(const idType element_internal_id) {
+
     vecsim_stl::vector<bool> neighbours_bitmap(this->allocator);
 
     // go over levels and repair connections
@@ -1110,21 +1095,19 @@ int HNSWIndex<DataType, DistType>::deleteVector(const labelType label) {
     }
 
     // Swap the last id with the deleted one, and invalidate the last id data.
-    idType last_element_internal_id = --cur_element_count;
-    --max_id;
-    label_lookup_.erase(label);
     if (element_levels_[element_internal_id] > 0) {
         this->allocator->free_allocation(linkLists_[element_internal_id]);
         linkLists_[element_internal_id] = nullptr;
     }
-    if (last_element_internal_id == element_internal_id) {
+    if (max_id == element_internal_id) {
         // we're deleting the last internal id, just invalidate data without swapping.
-        memset(data_level0_memory_ + last_element_internal_id * size_data_per_element_ +
-                   offsetLevel0_,
-               0, size_data_per_element_);
+        memset(data_level0_memory_ + max_id * size_data_per_element_ + offsetLevel0_, 0,
+               size_data_per_element_);
     } else {
-        SwapLastIdWithDeletedId(element_internal_id, last_element_internal_id);
+        SwapLastIdWithDeletedId(element_internal_id);
     }
+    --cur_element_count;
+    --max_id;
 
     // If we need to free a complete block & there is a least one block between the
     // capacity and the size.
@@ -1141,7 +1124,7 @@ int HNSWIndex<DataType, DistType>::deleteVector(const labelType label) {
 }
 
 template <typename DataType, typename DistType>
-int HNSWIndex<DataType, DistType>::addVector(const void *vector_data, const labelType label) {
+int HNSWIndex<DataType, DistType>::appendVector(const void *vector_data, const labelType label) {
 
     idType cur_c;
 
@@ -1157,16 +1140,12 @@ int HNSWIndex<DataType, DistType>::addVector(const void *vector_data, const labe
         std::unique_lock<std::mutex> templock_curr(cur_element_count_guard_);
 #endif
 
-        // Checking if an element with the given label already exists. if so, remove it.
-        if (label_lookup_.find(label) != label_lookup_.end()) {
-            deleteVector(label);
-        }
         if (cur_element_count >= max_elements_) {
             size_t vectors_to_add = this->blockSize - max_elements_ % this->blockSize;
             resizeIndex(max_elements_ + vectors_to_add);
         }
         cur_c = max_id = cur_element_count++;
-        label_lookup_[label] = cur_c;
+        setVectorId(label, cur_c);
     }
 #ifdef ENABLE_PARALLELIZATION
     std::unique_lock<std::mutex> lock_el(link_list_locks_[cur_c]);
@@ -1190,7 +1169,7 @@ int HNSWIndex<DataType, DistType>::addVector(const void *vector_data, const labe
            size_data_per_element_);
 
     // Initialisation of the data and label
-    memcpy(getExternalLabelPtr(cur_c), &label, sizeof(labelType));
+    setExternalLabel(cur_c, label);
     memcpy(getDataByInternalId(cur_c), vector_data, data_size_);
 
     if (element_max_level > 0) {

--- a/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
@@ -15,6 +15,7 @@ VecSimIndex *NewIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator>
 }
 
 size_t EstimateInitialSize(const HNSWParams *params) {
+    size_t M = (params->M) ? params->M : HNSW_DEFAULT_M;
 
     size_t est = sizeof(VecSimAllocator) + sizeof(size_t);
     if (params->multi) {
@@ -22,21 +23,26 @@ size_t EstimateInitialSize(const HNSWParams *params) {
     } else {
         est += sizeof(HNSWIndex_Single<float, float>);
     }
-    // Used for synchronization only when parallel indexing / searching is enabled.
+
 #ifdef ENABLE_PARALLELIZATION
+    // Used for synchronization only when parallel indexing / searching is enabled.
     est += sizeof(VisitedNodesHandlerPool) + sizeof(size_t);
 #else
     est += sizeof(VisitedNodesHandler) + sizeof(size_t);
 #endif
-    est += sizeof(tag_t) * params->initialCapacity + sizeof(size_t); // visited nodes
 
+    // Implicit allocation calls - allocates memory + a header only with positive capacity.
+    if (params->initialCapacity) {
+        est += sizeof(tag_t) * params->initialCapacity + sizeof(size_t);  // visited nodes
+        est += sizeof(size_t) * params->initialCapacity + sizeof(size_t); // element level
+        est += sizeof(size_t) * params->initialCapacity +
+               sizeof(size_t); // Labels lookup hash table buckets.
+    }
+
+    // Explicit allocation calls - always allocate a header.
     est += sizeof(void *) * params->initialCapacity + sizeof(size_t); // link lists (for levels > 0)
-    est += sizeof(size_t) * params->initialCapacity + sizeof(size_t); // element level
-    est += sizeof(size_t) * params->initialCapacity +
-           sizeof(size_t); // Labels lookup hash table buckets.
 
-    size_t size_links_level0 =
-        sizeof(linklistsizeint) + params->M * 2 * sizeof(idType) + sizeof(void *);
+    size_t size_links_level0 = sizeof(linklistsizeint) + M * 2 * sizeof(idType) + sizeof(void *);
     size_t size_total_data_per_element =
         size_links_level0 + params->dim * VecSimType_sizeof(params->type) + sizeof(labelType);
     est += params->initialCapacity * size_total_data_per_element + sizeof(size_t);
@@ -45,25 +51,38 @@ size_t EstimateInitialSize(const HNSWParams *params) {
 }
 
 size_t EstimateElementSize(const HNSWParams *params) {
-    size_t size_links_level0 = sizeof(linklistsizeint) + params->M * 2 * sizeof(idType) +
-                               sizeof(void *) + sizeof(vecsim_stl::vector<idType>);
-    size_t size_links_higher_level = sizeof(linklistsizeint) + params->M * sizeof(idType) +
-                                     sizeof(void *) + sizeof(vecsim_stl::vector<idType>);
+    size_t M = (params->M) ? params->M : HNSW_DEFAULT_M;
+    size_t size_links_level0 = sizeof(linklistsizeint) + M * 2 * sizeof(idType) + sizeof(void *) +
+                               sizeof(vecsim_stl::vector<idType>);
+    size_t size_links_higher_level = sizeof(linklistsizeint) + M * sizeof(idType) + sizeof(void *) +
+                                     sizeof(vecsim_stl::vector<idType>);
     // The Expectancy for the random variable which is the number of levels per element equals
     // 1/ln(M). Since the max_level is rounded to the "floor" integer, the actual average number
     // of levels is lower (intuitively, we "loose" a level every time the random generated number
     // should have been rounded up to the larger integer). So, we "fix" the expectancy and take
     // 1/2*ln(M) instead as an approximation.
     size_t expected_size_links_higher_levels =
-        ceil((1 / (2 * log(params->M))) * (float)size_links_higher_level);
+        ceil((1 / (2 * log(M))) * (float)size_links_higher_level);
 
     size_t size_total_data_per_element = size_links_level0 + expected_size_links_higher_levels +
                                          params->dim * VecSimType_sizeof(params->type) +
                                          sizeof(labelType);
 
-    // For every new vector, a new node of size 24 is allocated in a bucket of the hash table.
-    size_t size_label_lookup_node =
-        24 + sizeof(size_t); // 24 + VecSimAllocator::allocation_header_size
+    size_t size_label_lookup_node;
+    if (params->multi) {
+        // For each new insertion (of a new label), we add a new node to the label_lookup_ map,
+        // and a new element to the vector in the map. These two allocations both results in a new
+        // allocation and therefore another VecSimAllocator::allocation_header_size.
+        size_label_lookup_node =
+            sizeof(vecsim_stl::unordered_map<labelType, vecsim_stl::vector<idType>>::value_type) +
+            sizeof(size_t) + sizeof(vecsim_stl::vector<idType>::value_type) + sizeof(size_t);
+    } else {
+        // For each new insertion (of a new label), we add a new node to the label_lookup_ map. This
+        // results in a new allocation and therefore another VecSimAllocator::allocation_header_size
+        size_label_lookup_node =
+            sizeof(vecsim_stl::unordered_map<labelType, idType>::value_type) + sizeof(size_t);
+    }
+
     // 1 entry in visited nodes + 1 entry in element levels + (approximately) 1 bucket in labels
     // lookup hash map.
     size_t size_meta_data =

--- a/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
@@ -17,10 +17,11 @@ VecSimIndex *NewIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator>
 size_t EstimateInitialSize(const HNSWParams *params) {
 
     size_t est = sizeof(VecSimAllocator) + sizeof(size_t);
-    if (params->multi)
+    if (params->multi) {
         est += sizeof(HNSWIndex_Multi<float, float>);
-    else
+    } else {
         est += sizeof(HNSWIndex_Single<float, float>);
+    }
     // Used for synchronization only when parallel indexing / searching is enabled.
 #ifdef ENABLE_PARALLELIZATION
     est += sizeof(VisitedNodesHandlerPool) + sizeof(size_t);

--- a/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
@@ -7,13 +7,14 @@ namespace HNSWFactory {
 VecSimIndex *NewIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator) {
     // check if single and return new bf_index
     assert(!params->multi);
-    return new (allocator) HNSWIndex<float, float>(params, allocator);
+    return new (allocator) HNSWIndex_Single<float, float>(params, allocator);
 }
 
 size_t EstimateInitialSize(const HNSWParams *params) {
 
     size_t est = sizeof(VecSimAllocator) + sizeof(size_t);
-    est += sizeof(HNSWIndex<float, float>);
+    assert(!params->multi);
+    est += sizeof(HNSWIndex_Single<float, float>);
     // Used for synchronization only when parallel indexing / searching is enabled.
 #ifdef ENABLE_PARALLELIZATION
     est += sizeof(VisitedNodesHandlerPool) + sizeof(size_t);

--- a/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
@@ -79,8 +79,9 @@ size_t EstimateElementSize(const HNSWParams *params) {
     } else {
         // For each new insertion (of a new label), we add a new node to the label_lookup_ map. This
         // results in a new allocation and therefore another VecSimAllocator::allocation_header_size
-        size_label_lookup_node =
-            sizeof(vecsim_stl::unordered_map<labelType, idType>::value_type) + sizeof(size_t);
+        // plus an internal pointer
+        size_label_lookup_node = sizeof(vecsim_stl::unordered_map<labelType, idType>::value_type) +
+                                 sizeof(size_t) + sizeof(size_t);
     }
 
     // 1 entry in visited nodes + 1 entry in element levels + (approximately) 1 bucket in labels

--- a/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
@@ -1,3 +1,5 @@
+#include "VecSim/algorithms/hnsw/hnsw_single.h"
+#include "VecSim/algorithms/hnsw/hnsw_multi.h"
 #include "VecSim/algorithms/hnsw/hnsw_factory.h"
 #include "VecSim/algorithms/hnsw/hnsw.h"
 #include "VecSim/algorithms/hnsw/hnsw_batch_iterator.h"
@@ -6,15 +8,19 @@ namespace HNSWFactory {
 
 VecSimIndex *NewIndex(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator) {
     // check if single and return new bf_index
-    assert(!params->multi);
-    return new (allocator) HNSWIndex_Single<float, float>(params, allocator);
+    if (params->multi)
+        return new (allocator) HNSWIndex_Multi<float, float>(params, allocator);
+    else
+        return new (allocator) HNSWIndex_Single<float, float>(params, allocator);
 }
 
 size_t EstimateInitialSize(const HNSWParams *params) {
 
     size_t est = sizeof(VecSimAllocator) + sizeof(size_t);
-    assert(!params->multi);
-    est += sizeof(HNSWIndex_Single<float, float>);
+    if (params->multi)
+        est += sizeof(HNSWIndex_Multi<float, float>);
+    else
+        est += sizeof(HNSWIndex_Single<float, float>);
     // Used for synchronization only when parallel indexing / searching is enabled.
 #ifdef ENABLE_PARALLELIZATION
     est += sizeof(VisitedNodesHandlerPool) + sizeof(size_t);

--- a/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_factory.cpp
@@ -29,11 +29,11 @@ size_t EstimateInitialSize(const HNSWParams *params) {
     est += sizeof(VisitedNodesHandlerPool) + sizeof(size_t);
 #else
     est += sizeof(VisitedNodesHandler) + sizeof(size_t);
+    est += sizeof(tag_t) * params->initialCapacity + sizeof(size_t); // visited nodes
 #endif
 
     // Implicit allocation calls - allocates memory + a header only with positive capacity.
     if (params->initialCapacity) {
-        est += sizeof(tag_t) * params->initialCapacity + sizeof(size_t);  // visited nodes
         est += sizeof(size_t) * params->initialCapacity + sizeof(size_t); // element level
         est += sizeof(size_t) * params->initialCapacity +
                sizeof(size_t); // Labels lookup hash table buckets.

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -45,7 +45,7 @@ public:
     int deleteVector(labelType label) override;
     int addVector(const void *vector_data, labelType label) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
-    VecSimQueryResult_List rangeQuery(const void *query_data, DistType radius,
+    VecSimQueryResult_List rangeQuery(const void *query_data, double radius,
                                       VecSimQueryParams *queryParams) override;
 };
 
@@ -132,7 +132,7 @@ int HNSWIndex_Multi<DataType, DistType>::addVector(const void *vector_data, cons
 // TODO: support range queries
 template <typename DataType, typename DistType>
 VecSimQueryResult_List
-HNSWIndex_Multi<DataType, DistType>::rangeQuery(const void *query_data, DistType radius,
+HNSWIndex_Multi<DataType, DistType>::rangeQuery(const void *query_data, double radius,
                                                 VecSimQueryParams *queryParams) {
     this->last_mode = RANGE_QUERY;
     return {array_new<VecSimQueryResult>(0), VecSim_QueryResult_OK};

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -40,7 +40,7 @@ public:
         : HNSWIndex<DataType, DistType>(params, allocator, random_seed, initial_pool_size),
           label_lookup_(this->max_elements_, allocator) {}
 
-    ~HNSWIndex_Multi(){};
+    ~HNSWIndex_Multi() {}
 
     inline size_t indexLabelCount() const override;
 

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -12,6 +12,7 @@ private:
     friend class HNSWIndexSerializer;
     // Allow the following test to access the index size private member.
     friend class HNSWMultiTest_testSizeEstimation_Test;
+    friend class HNSWMultiTest_testInitialSizeEstimation_No_InitialCapacity_Test;
     friend class HNSWMultiTest_empty_index_Test;
     friend class HNSWMultiTest_indexing_same_vector_Test;
     friend class HNSWMultiTest_search_more_then_there_is_Test;

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -16,6 +16,9 @@ private:
     friend class HNSWMultiTest_empty_index_Test;
     friend class HNSWMultiTest_indexing_same_vector_Test;
     friend class HNSWMultiTest_search_more_then_there_is_Test;
+    friend class HNSWMultiTest_preferAdHocOptimization_Test;
+    friend class HNSWMultiTest_test_dynamic_hnsw_info_iterator_Test;
+
 #endif
 
     // VecSimQueryResult *searchRangeBottomLayer_WithTimeout(idType ep_id, const void *data_point,

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -15,16 +15,11 @@ private:
     friend class HNSWMultiTest_testInitialSizeEstimation_No_InitialCapacity_Test;
     friend class HNSWMultiTest_empty_index_Test;
     friend class HNSWMultiTest_indexing_same_vector_Test;
-    friend class HNSWMultiTest_search_more_then_there_is_Test;
+    friend class HNSWMultiTest_search_more_than_there_is_Test;
     friend class HNSWMultiTest_preferAdHocOptimization_Test;
     friend class HNSWMultiTest_test_dynamic_hnsw_info_iterator_Test;
 
 #endif
-
-    // VecSimQueryResult *searchRangeBottomLayer_WithTimeout(idType ep_id, const void *data_point,
-    //                                                       double epsilon, DistType radius,
-    //                                                       void *timeoutCtx,
-    //                                                       VecSimQueryResult_Code *rc) const;
 
     inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) override;
     inline void setVectorId(labelType label, idType id) override {
@@ -50,8 +45,8 @@ public:
     int deleteVector(labelType label) override;
     int addVector(const void *vector_data, labelType label) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
-    // VecSimQueryResult_List rangeQuery(const void *query_data, DistType radius,
-    //                                   VecSimQueryParams *queryParams) override;
+    VecSimQueryResult_List rangeQuery(const void *query_data, DistType radius,
+                                      VecSimQueryParams *queryParams) override;
 };
 
 /**
@@ -134,116 +129,11 @@ int HNSWIndex_Multi<DataType, DistType>::addVector(const void *vector_data, cons
     return this->appendVector(vector_data, label);
 }
 
-// template <typename DataType, typename DistType>
-// VecSimQueryResult *HNSWIndex_Multi<DataType, DistType>::searchRangeBottomLayer_WithTimeout(
-//     idType ep_id, const void *data_point, double epsilon, DistType radius, void *timeoutCtx,
-//     VecSimQueryResult_Code *rc) const {
-//     auto *results = array_new<VecSimQueryResult>(10); // arbitrary initial cap.
-
-// #ifdef ENABLE_PARALLELIZATION
-//     this->visited_nodes_handler =
-//         this->visited_nodes_handler_pool->getAvailableVisitedNodesHandler();
-// #endif
-
-//     tag_t visited_tag = this->visited_nodes_handler->getFreshTag();
-//     candidatesMaxHeap<DistType> candidate_set(this->allocator);
-
-//     // Set the initial effective-range to be at least the distance from the entry-point.
-//     DistType ep_dist = this->dist_func(data_point, getDataByInternalId(ep_id), this->dim);
-//     DistType dynamic_range = ep_dist;
-//     if (ep_dist <= radius) {
-//         // Entry-point is within the radius - add it to the results.
-//         auto new_result = VecSimQueryResult{};
-//         VecSimQueryResult_SetId(new_result, getExternalLabel(ep_id));
-//         VecSimQueryResult_SetScore(new_result, ep_dist);
-//         results = array_append(results, new_result);
-//         dynamic_range = radius; // to ensure that dyn_range >= radius.
-//     }
-
-//     DistType dynamic_range_search_boundaries = dynamic_range * (1.0 + epsilon);
-//     candidate_set.emplace(-ep_dist, ep_id);
-//     this->visited_nodes_handler->tagNode(ep_id, visited_tag);
-
-//     while (!candidate_set.empty()) {
-//         std::pair<DistType, idType> curr_el_pair = candidate_set.top();
-//         // If the best candidate is outside the dynamic range in more than epsilon (relatively) -
-//         we
-//         // finish the search.
-//         if ((-curr_el_pair.first) > dynamic_range_search_boundaries) {
-//             break;
-//         }
-//         if (__builtin_expect(VecSimIndexAbstract<DistType>::timeoutCallback(timeoutCtx), 0)) {
-//             *rc = VecSim_QueryResult_TimedOut;
-//             return results;
-//         }
-//         candidate_set.pop();
-
-//         // Decrease the effective range, but keep dyn_range >= radius.
-//         if (-curr_el_pair.first < dynamic_range && -curr_el_pair.first >= radius) {
-//             dynamic_range = -curr_el_pair.first;
-//             dynamic_range_search_boundaries = dynamic_range * (1.0 + epsilon);
-//         }
-
-//         // Go over the candidate neighbours, add them to the candidates list if they are within
-//         the
-//         // epsilon environment of the dynamic range, and add them to the results if they are in
-//         the
-//         // requested radius.
-//         processCandidate_RangeSearch(curr_el_pair.second, data_point, 0, epsilon, visited_tag,
-//                                      &results, candidate_set, dynamic_range_search_boundaries,
-//                                      radius);
-//     }
-// #ifdef ENABLE_PARALLELIZATION
-//     visited_nodes_handler_pool->returnVisitedNodesHandlerToPool(this->visited_nodes_handler);
-// #endif
-
-//     *rc = VecSim_QueryResult_OK;
-//     return results;
-// }
-
-// template <typename DataType, typename DistType>
-// VecSimQueryResult_List
-// HNSWIndex_Multi<DataType, DistType>::rangeQuery(const void *query_data, DistType radius,
-//                                                  VecSimQueryParams *queryParams) {
-
-//     VecSimQueryResult_List rl = {0};
-//     this->last_mode = RANGE_QUERY;
-
-//     if (cur_element_count == 0) {
-//         rl.code = VecSim_QueryResult_OK;
-//         rl.results = array_new<VecSimQueryResult>(0);
-//         return rl;
-//     }
-//     void *timeoutCtx = nullptr;
-
-//     DataType normalized_blob[this->dim]; // This will be use only if metric ==
-//     VecSimMetric_Cosine if (this->metric == VecSimMetric_Cosine) {
-//         // TODO: need more generic when other types will be supported.
-//         memcpy(normalized_blob, query_data, this->dim * sizeof(DataType));
-//         float_vector_normalize(normalized_blob, this->dim);
-//         query_data = normalized_blob;
-//     }
-
-//     double originalEpsilon = epsilon_;
-//     if (queryParams) {
-//         timeoutCtx = queryParams->timeoutCtx;
-//         if (queryParams->hnswRuntimeParams.epsilon != 0.0) {
-//             epsilon_ = queryParams->hnswRuntimeParams.epsilon;
-//         }
-//     }
-
-//     idType bottom_layer_ep = searchBottomLayerEP(query_data, timeoutCtx, &rl.code);
-//     if (VecSim_OK != rl.code) {
-//         epsilon_ = originalEpsilon;
-//         rl.results = array_new<VecSimQueryResult>(0);
-//         return rl;
-//     }
-
-//     // search bottom layer
-//     rl.results = searchRangeBottomLayer_WithTimeout(bottom_layer_ep, query_data, this->epsilon_,
-//                                                     radius, timeoutCtx, &rl.code);
-
-//     // Restore the default epsilon.
-//     epsilon_ = originalEpsilon;
-//     return rl;
-// }
+// TODO: support range queries
+template <typename DataType, typename DistType>
+VecSimQueryResult_List
+HNSWIndex_Multi<DataType, DistType>::rangeQuery(const void *query_data, DistType radius,
+                                                VecSimQueryParams *queryParams) {
+    this->last_mode = RANGE_QUERY;
+    return {array_new<VecSimQueryResult>(0), VecSim_QueryResult_OK};
+}

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -17,11 +17,6 @@ private:
     friend class HNSWTest_preferAdHocOptimization_Test;
 #endif
 
-    // VecSimQueryResult *searchRangeBottomLayer_WithTimeout(idType ep_id, const void *data_point,
-    //                                                       double epsilon, DistType radius,
-    //                                                       void *timeoutCtx,
-    //                                                       VecSimQueryResult_Code *rc) const;
-
     inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) override;
     inline void setVectorId(labelType label, idType id) override { label_lookup_[label] = id; }
     inline void resizeLabelLookup(size_t new_max_elements) override;
@@ -44,8 +39,6 @@ public:
     int deleteVector(labelType label) override;
     int addVector(const void *vector_data, labelType label) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
-    // VecSimQueryResult_List rangeQuery(const void *query_data, DistType radius,
-    //                                   VecSimQueryParams *queryParams) override;
 };
 
 /**
@@ -108,117 +101,3 @@ int HNSWIndex_Single<DataType, DistType>::addVector(const void *vector_data,
 
     return this->appendVector(vector_data, label);
 }
-
-// template <typename DataType, typename DistType>
-// VecSimQueryResult *HNSWIndex_Single<DataType, DistType>::searchRangeBottomLayer_WithTimeout(
-//     idType ep_id, const void *data_point, double epsilon, DistType radius, void *timeoutCtx,
-//     VecSimQueryResult_Code *rc) const {
-//     auto *results = array_new<VecSimQueryResult>(10); // arbitrary initial cap.
-
-// #ifdef ENABLE_PARALLELIZATION
-//     this->visited_nodes_handler =
-//         this->visited_nodes_handler_pool->getAvailableVisitedNodesHandler();
-// #endif
-
-//     tag_t visited_tag = this->visited_nodes_handler->getFreshTag();
-//     candidatesMaxHeap<DistType> candidate_set(this->allocator);
-
-//     // Set the initial effective-range to be at least the distance from the entry-point.
-//     DistType ep_dist = this->dist_func(data_point, getDataByInternalId(ep_id), this->dim);
-//     DistType dynamic_range = ep_dist;
-//     if (ep_dist <= radius) {
-//         // Entry-point is within the radius - add it to the results.
-//         auto new_result = VecSimQueryResult{};
-//         VecSimQueryResult_SetId(new_result, getExternalLabel(ep_id));
-//         VecSimQueryResult_SetScore(new_result, ep_dist);
-//         results = array_append(results, new_result);
-//         dynamic_range = radius; // to ensure that dyn_range >= radius.
-//     }
-
-//     DistType dynamic_range_search_boundaries = dynamic_range * (1.0 + epsilon);
-//     candidate_set.emplace(-ep_dist, ep_id);
-//     this->visited_nodes_handler->tagNode(ep_id, visited_tag);
-
-//     while (!candidate_set.empty()) {
-//         std::pair<DistType, idType> curr_el_pair = candidate_set.top();
-//         // If the best candidate is outside the dynamic range in more than epsilon (relatively) -
-//         we
-//         // finish the search.
-//         if ((-curr_el_pair.first) > dynamic_range_search_boundaries) {
-//             break;
-//         }
-//         if (__builtin_expect(VecSimIndexAbstract<DistType>::timeoutCallback(timeoutCtx), 0)) {
-//             *rc = VecSim_QueryResult_TimedOut;
-//             return results;
-//         }
-//         candidate_set.pop();
-
-//         // Decrease the effective range, but keep dyn_range >= radius.
-//         if (-curr_el_pair.first < dynamic_range && -curr_el_pair.first >= radius) {
-//             dynamic_range = -curr_el_pair.first;
-//             dynamic_range_search_boundaries = dynamic_range * (1.0 + epsilon);
-//         }
-
-//         // Go over the candidate neighbours, add them to the candidates list if they are within
-//         the
-//         // epsilon environment of the dynamic range, and add them to the results if they are in
-//         the
-//         // requested radius.
-//         processCandidate_RangeSearch(curr_el_pair.second, data_point, 0, epsilon, visited_tag,
-//                                      &results, candidate_set, dynamic_range_search_boundaries,
-//                                      radius);
-//     }
-// #ifdef ENABLE_PARALLELIZATION
-//     visited_nodes_handler_pool->returnVisitedNodesHandlerToPool(this->visited_nodes_handler);
-// #endif
-
-//     *rc = VecSim_QueryResult_OK;
-//     return results;
-// }
-
-// template <typename DataType, typename DistType>
-// VecSimQueryResult_List
-// HNSWIndex_Single<DataType, DistType>::rangeQuery(const void *query_data, DistType radius,
-//                                                  VecSimQueryParams *queryParams) {
-
-//     VecSimQueryResult_List rl = {0};
-//     this->last_mode = RANGE_QUERY;
-
-//     if (cur_element_count == 0) {
-//         rl.code = VecSim_QueryResult_OK;
-//         rl.results = array_new<VecSimQueryResult>(0);
-//         return rl;
-//     }
-//     void *timeoutCtx = nullptr;
-
-//     DataType normalized_blob[this->dim]; // This will be use only if metric ==
-//     VecSimMetric_Cosine if (this->metric == VecSimMetric_Cosine) {
-//         // TODO: need more generic when other types will be supported.
-//         memcpy(normalized_blob, query_data, this->dim * sizeof(DataType));
-//         float_vector_normalize(normalized_blob, this->dim);
-//         query_data = normalized_blob;
-//     }
-
-//     double originalEpsilon = epsilon_;
-//     if (queryParams) {
-//         timeoutCtx = queryParams->timeoutCtx;
-//         if (queryParams->hnswRuntimeParams.epsilon != 0.0) {
-//             epsilon_ = queryParams->hnswRuntimeParams.epsilon;
-//         }
-//     }
-
-//     idType bottom_layer_ep = searchBottomLayerEP(query_data, timeoutCtx, &rl.code);
-//     if (VecSim_OK != rl.code) {
-//         epsilon_ = originalEpsilon;
-//         rl.results = array_new<VecSimQueryResult>(0);
-//         return rl;
-//     }
-
-//     // search bottom layer
-//     rl.results = searchRangeBottomLayer_WithTimeout(bottom_layer_ep, query_data, this->epsilon_,
-//                                                     radius, timeoutCtx, &rl.code);
-
-//     // Restore the default epsilon.
-//     epsilon_ = originalEpsilon;
-//     return rl;
-// }

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -1,0 +1,335 @@
+#pragma once
+
+#include "hnsw.h"
+
+template <typename DataType, typename DistType>
+class HNSWIndex_Single : public HNSWIndex<DataType, DistType> {
+private:
+    vecsim_stl::unordered_map<labelType, idType> label_lookup_;
+
+#ifdef BUILD_TESTS
+    friend class HNSWIndexSerializer;
+    // Allow the following test to access the index size private member.
+    friend class HNSWTest_preferAdHocOptimization_Test;
+    friend class HNSWTest_test_dynamic_hnsw_info_iterator_Test;
+    friend class AllocatorTest_testIncomingEdgesSet_Test;
+    friend class AllocatorTest_test_hnsw_reclaim_memory_Test;
+    friend class HNSWTest_testSizeEstimation_Test;
+#endif
+
+    // candidatesLabelsMaxHeap<DistType>
+    // searchBottomLayer_WithTimeout(idType ep_id, const void *data_point, size_t ef, size_t k,
+    //                               void *timeoutCtx, VecSimQueryResult_Code *rc) const;
+    // VecSimQueryResult *searchRangeBottomLayer_WithTimeout(idType ep_id, const void *data_point,
+    //                                                       double epsilon, DistType radius,
+    //                                                       void *timeoutCtx,
+    //                                                       VecSimQueryResult_Code *rc) const;
+
+    inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) override;
+    inline void setVectorId(labelType label, idType id) override { label_lookup_[label] = id; }
+    inline void resizeLabelLookup(size_t new_max_elements) override;
+
+public:
+    HNSWIndex_Single(const HNSWParams *params, std::shared_ptr<VecSimAllocator> allocator,
+                     size_t random_seed = 100, size_t initial_pool_size = 1)
+        : HNSWIndex<DataType, DistType>(params, allocator, random_seed, initial_pool_size),
+          label_lookup_(this->max_elements_, allocator) {}
+
+    ~HNSWIndex_Single(){};
+
+    inline size_t indexLabelCount() const override;
+
+    int deleteVector(labelType label) override;
+    int addVector(const void *vector_data, labelType label) override;
+    double getDistanceFrom(labelType label, const void *vector_data) const override;
+    // VecSimQueryResult_List topKQuery(const void *query_data, size_t k,
+    //                                  VecSimQueryParams *queryParams) override;
+    // VecSimQueryResult_List rangeQuery(const void *query_data, DistType radius,
+    //                                   VecSimQueryParams *queryParams) override;
+};
+
+/**
+ * getters and setters of index data
+ */
+
+template <typename DataType, typename DistType>
+size_t HNSWIndex_Single<DataType, DistType>::indexLabelCount() const {
+    return label_lookup_.size();
+}
+
+template <typename DataType, typename DistType>
+double HNSWIndex_Single<DataType, DistType>::getDistanceFrom(labelType label,
+                                                             const void *vector_data) const {
+    auto id = label_lookup_.find(label);
+    if (id == label_lookup_.end()) {
+        return INVALID_SCORE;
+    }
+    return this->dist_func(vector_data, this->getDataByInternalId(id->second), this->dim);
+}
+
+/**
+ * helper functions
+ */
+
+template <typename DataType, typename DistType>
+void HNSWIndex_Single<DataType, DistType>::replaceIdOfLabel(labelType label, idType new_id,
+                                                            idType old_id) {
+    label_lookup_[label] = new_id;
+}
+
+template <typename DataType, typename DistType>
+void HNSWIndex_Single<DataType, DistType>::resizeLabelLookup(size_t new_max_elements) {
+    label_lookup_.reserve(new_max_elements);
+}
+
+/**
+ * Index API functions
+ */
+
+template <typename DataType, typename DistType>
+int HNSWIndex_Single<DataType, DistType>::deleteVector(const labelType label) {
+    // check that the label actually exists in the graph, and update the number of elements.
+    if (label_lookup_.find(label) == label_lookup_.end()) {
+        return false;
+    }
+    idType element_internal_id = label_lookup_[label];
+    label_lookup_.erase(label);
+    return this->removeVector(element_internal_id);
+}
+
+template <typename DataType, typename DistType>
+int HNSWIndex_Single<DataType, DistType>::addVector(const void *vector_data,
+                                                    const labelType label) {
+
+    // Checking if an element with the given label already exists. if so, remove it.
+    if (label_lookup_.find(label) != label_lookup_.end()) {
+        deleteVector(label);
+    }
+
+    return this->appendVector(vector_data, label);
+}
+
+// template <typename DataType, typename DistType>
+// candidatesLabelsMaxHeap<DistType>
+// HNSWIndex_Single<DataType, DistType>::searchBottomLayer_WithTimeout(
+//     idType ep_id, const void *data_point, size_t ef, size_t k, void *timeoutCtx,
+//     VecSimQueryResult_Code *rc) const {
+//     candidatesLabelsMaxHeap<DistType> results(this->allocator);
+
+// #ifdef ENABLE_PARALLELIZATION
+//     this->visited_nodes_handler =
+//         this->visited_nodes_handler_pool->getAvailableVisitedNodesHandler();
+// #endif
+
+//     tag_t visited_tag = this->visited_nodes_handler->getFreshTag();
+
+//     candidatesMaxHeap<DistType> top_candidates(this->allocator);
+//     candidatesMaxHeap<DistType> candidate_set(this->allocator);
+
+//     DistType dist = this->dist_func(data_point, getDataByInternalId(ep_id), this->dim);
+//     DistType lowerBound = dist;
+//     top_candidates.emplace(dist, ep_id);
+//     candidate_set.emplace(-dist, ep_id);
+
+//     this->visited_nodes_handler->tagNode(ep_id, visited_tag);
+
+//     while (!candidate_set.empty()) {
+//         std::pair<DistType, idType> curr_el_pair = candidate_set.top();
+//         if ((-curr_el_pair.first) > lowerBound) {
+//             break;
+//         }
+//         if (__builtin_expect(VecSimIndexAbstract<DistType>::timeoutCallback(timeoutCtx), 0)) {
+//             *rc = VecSim_QueryResult_TimedOut;
+//             return results;
+//         }
+//         candidate_set.pop();
+
+//         lowerBound = processCandidate(curr_el_pair.second, data_point, 0, ef, visited_tag,
+//                                       top_candidates, candidate_set, lowerBound);
+//     }
+// #ifdef ENABLE_PARALLELIZATION
+//     visited_nodes_handler_pool->returnVisitedNodesHandlerToPool(this->visited_nodes_handler);
+// #endif
+//     while (top_candidates.size() > k) {
+//         top_candidates.pop();
+//     }
+//     while (top_candidates.size() > 0) {
+//         auto &res = top_candidates.top();
+//         results.emplace(res.first, getExternalLabel(res.second));
+//         top_candidates.pop();
+//     }
+//     *rc = VecSim_QueryResult_OK;
+//     return results;
+// }
+
+// template <typename DataType, typename DistType>
+// VecSimQueryResult_List
+// HNSWIndex_Single<DataType, DistType>::topKQuery(const void *query_data, size_t k,
+//                                                 VecSimQueryParams *queryParams) {
+
+//     VecSimQueryResult_List rl = {0};
+//     this->last_mode = STANDARD_KNN;
+
+//     if (cur_element_count == 0) {
+//         rl.code = VecSim_QueryResult_OK;
+//         rl.results = array_new<VecSimQueryResult>(0);
+//         return rl;
+//     }
+
+//     void *timeoutCtx = nullptr;
+
+//     DataType normalized_data[this->dim]; // This will be use only if metric ==
+//     VecSimMetric_Cosine. if (this->metric == VecSimMetric_Cosine) {
+//         // TODO: need more generic
+//         memcpy(normalized_data, query_data, this->dim * sizeof(DataType));
+//         float_vector_normalize(normalized_data, this->dim);
+//         query_data = normalized_data;
+//     }
+//     // Get original efRuntime and store it.
+//     size_t originalEF = ef_;
+
+//     if (queryParams) {
+//         timeoutCtx = queryParams->timeoutCtx;
+//         if (queryParams->hnswRuntimeParams.efRuntime != 0) {
+//             ef_ = queryParams->hnswRuntimeParams.efRuntime;
+//         }
+//     }
+
+//     idType bottom_layer_ep = searchBottomLayerEP(query_data, timeoutCtx, &rl.code);
+//     if (VecSim_OK != rl.code) {
+//         ef_ = originalEF;
+//         return rl;
+//     }
+
+//     candidatesLabelsMaxHeap<DistType> results = searchBottomLayer_WithTimeout(
+//         bottom_layer_ep, query_data, std::max(ef_, k), k, timeoutCtx, &rl.code);
+
+//     // Restore efRuntime.
+//     ef_ = originalEF;
+
+//     if (VecSim_OK != rl.code) {
+//         return rl;
+//     }
+
+//     rl.results = array_new_len<VecSimQueryResult>(results.size(), results.size());
+//     for (int i = (int)results.size() - 1; i >= 0; --i) {
+//         VecSimQueryResult_SetId(rl.results[i], results.top().second);
+//         VecSimQueryResult_SetScore(rl.results[i], results.top().first);
+//         results.pop();
+//     }
+//     return rl;
+// }
+
+// template <typename DataType, typename DistType>
+// VecSimQueryResult *HNSWIndex_Single<DataType, DistType>::searchRangeBottomLayer_WithTimeout(
+//     idType ep_id, const void *data_point, double epsilon, DistType radius, void *timeoutCtx,
+//     VecSimQueryResult_Code *rc) const {
+//     auto *results = array_new<VecSimQueryResult>(10); // arbitrary initial cap.
+
+// #ifdef ENABLE_PARALLELIZATION
+//     this->visited_nodes_handler =
+//         this->visited_nodes_handler_pool->getAvailableVisitedNodesHandler();
+// #endif
+
+//     tag_t visited_tag = this->visited_nodes_handler->getFreshTag();
+//     candidatesMaxHeap<DistType> candidate_set(this->allocator);
+
+//     // Set the initial effective-range to be at least the distance from the entry-point.
+//     DistType ep_dist = this->dist_func(data_point, getDataByInternalId(ep_id), this->dim);
+//     DistType dynamic_range = ep_dist;
+//     if (ep_dist <= radius) {
+//         // Entry-point is within the radius - add it to the results.
+//         auto new_result = VecSimQueryResult{};
+//         VecSimQueryResult_SetId(new_result, getExternalLabel(ep_id));
+//         VecSimQueryResult_SetScore(new_result, ep_dist);
+//         results = array_append(results, new_result);
+//         dynamic_range = radius; // to ensure that dyn_range >= radius.
+//     }
+
+//     DistType dynamic_range_search_boundaries = dynamic_range * (1.0 + epsilon);
+//     candidate_set.emplace(-ep_dist, ep_id);
+//     this->visited_nodes_handler->tagNode(ep_id, visited_tag);
+
+//     while (!candidate_set.empty()) {
+//         std::pair<DistType, idType> curr_el_pair = candidate_set.top();
+//         // If the best candidate is outside the dynamic range in more than epsilon (relatively) -
+//         we
+//         // finish the search.
+//         if ((-curr_el_pair.first) > dynamic_range_search_boundaries) {
+//             break;
+//         }
+//         if (__builtin_expect(VecSimIndexAbstract<DistType>::timeoutCallback(timeoutCtx), 0)) {
+//             *rc = VecSim_QueryResult_TimedOut;
+//             return results;
+//         }
+//         candidate_set.pop();
+
+//         // Decrease the effective range, but keep dyn_range >= radius.
+//         if (-curr_el_pair.first < dynamic_range && -curr_el_pair.first >= radius) {
+//             dynamic_range = -curr_el_pair.first;
+//             dynamic_range_search_boundaries = dynamic_range * (1.0 + epsilon);
+//         }
+
+//         // Go over the candidate neighbours, add them to the candidates list if they are within
+//         the
+//         // epsilon environment of the dynamic range, and add them to the results if they are in
+//         the
+//         // requested radius.
+//         processCandidate_RangeSearch(curr_el_pair.second, data_point, 0, epsilon, visited_tag,
+//                                      &results, candidate_set, dynamic_range_search_boundaries,
+//                                      radius);
+//     }
+// #ifdef ENABLE_PARALLELIZATION
+//     visited_nodes_handler_pool->returnVisitedNodesHandlerToPool(this->visited_nodes_handler);
+// #endif
+
+//     *rc = VecSim_QueryResult_OK;
+//     return results;
+// }
+
+// template <typename DataType, typename DistType>
+// VecSimQueryResult_List
+// HNSWIndex_Single<DataType, DistType>::rangeQuery(const void *query_data, DistType radius,
+//                                                  VecSimQueryParams *queryParams) {
+
+//     VecSimQueryResult_List rl = {0};
+//     this->last_mode = RANGE_QUERY;
+
+//     if (cur_element_count == 0) {
+//         rl.code = VecSim_QueryResult_OK;
+//         rl.results = array_new<VecSimQueryResult>(0);
+//         return rl;
+//     }
+//     void *timeoutCtx = nullptr;
+
+//     DataType normalized_blob[this->dim]; // This will be use only if metric ==
+//     VecSimMetric_Cosine if (this->metric == VecSimMetric_Cosine) {
+//         // TODO: need more generic when other types will be supported.
+//         memcpy(normalized_blob, query_data, this->dim * sizeof(DataType));
+//         float_vector_normalize(normalized_blob, this->dim);
+//         query_data = normalized_blob;
+//     }
+
+//     double originalEpsilon = epsilon_;
+//     if (queryParams) {
+//         timeoutCtx = queryParams->timeoutCtx;
+//         if (queryParams->hnswRuntimeParams.epsilon != 0.0) {
+//             epsilon_ = queryParams->hnswRuntimeParams.epsilon;
+//         }
+//     }
+
+//     idType bottom_layer_ep = searchBottomLayerEP(query_data, timeoutCtx, &rl.code);
+//     if (VecSim_OK != rl.code) {
+//         epsilon_ = originalEpsilon;
+//         rl.results = array_new<VecSimQueryResult>(0);
+//         return rl;
+//     }
+
+//     // search bottom layer
+//     rl.results = searchRangeBottomLayer_WithTimeout(bottom_layer_ep, query_data, this->epsilon_,
+//                                                     radius, timeoutCtx, &rl.code);
+
+//     // Restore the default epsilon.
+//     epsilon_ = originalEpsilon;
+//     return rl;
+// }

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -13,6 +13,8 @@ private:
     friend class AllocatorTest_testIncomingEdgesSet_Test;
     friend class AllocatorTest_test_hnsw_reclaim_memory_Test;
     friend class HNSWTest_testSizeEstimation_Test;
+    friend class HNSWTest_test_dynamic_hnsw_info_iterator_Test;
+    friend class HNSWTest_preferAdHocOptimization_Test;
 #endif
 
     // VecSimQueryResult *searchRangeBottomLayer_WithTimeout(idType ep_id, const void *data_point,

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -10,8 +10,6 @@ private:
 #ifdef BUILD_TESTS
     friend class HNSWIndexSerializer;
     // Allow the following test to access the index size private member.
-    friend class HNSWTest_preferAdHocOptimization_Test;
-    friend class HNSWTest_test_dynamic_hnsw_info_iterator_Test;
     friend class AllocatorTest_testIncomingEdgesSet_Test;
     friend class AllocatorTest_test_hnsw_reclaim_memory_Test;
     friend class HNSWTest_testSizeEstimation_Test;

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -35,7 +35,7 @@ public:
         : HNSWIndex<DataType, DistType>(params, allocator, random_seed, initial_pool_size),
           label_lookup_(this->max_elements_, allocator) {}
 
-    ~HNSWIndex_Single(){};
+    ~HNSWIndex_Single() {}
 
     inline size_t indexLabelCount() const override;
 

--- a/src/VecSim/algorithms/hnsw/serialization.cpp
+++ b/src/VecSim/algorithms/hnsw/serialization.cpp
@@ -166,10 +166,11 @@ void HNSWIndexSerializer::restoreGraph(std::ifstream &input) {
         hnsw_index->linkLists_, sizeof(void *) * hnsw_index->max_elements_);
     hnsw_index->element_levels_ =
         vecsim_stl::vector<size_t>(hnsw_index->max_elements_, hnsw_index->allocator);
-    hnsw_index->label_lookup_.clear();
+    reinterpret_cast<HNSWIndex_Single<float, float> *>(hnsw_index)->label_lookup_.clear();
 
     for (size_t i = 0; i <= hnsw_index->max_id; i++) {
-        hnsw_index->label_lookup_[hnsw_index->getExternalLabel(i)] = i;
+        reinterpret_cast<HNSWIndex_Single<float, float> *>(hnsw_index)
+            ->label_lookup_[hnsw_index->getExternalLabel(i)] = i;
         unsigned int linkListSize;
         readBinaryPOD(input, linkListSize);
         if (linkListSize == 0) {

--- a/src/VecSim/algorithms/hnsw/serialization.cpp
+++ b/src/VecSim/algorithms/hnsw/serialization.cpp
@@ -3,7 +3,7 @@
 #include <utility>
 #include "serialization.h"
 #include "VecSim/utils/vecsim_stl.h"
-#include "hnsw.h"
+#include "hnsw_single.h"
 #define HNSW_INVALID_META_DATA SIZE_MAX
 
 // Helper functions for serializing the index.

--- a/src/VecSim/algorithms/hnsw/serialization.h
+++ b/src/VecSim/algorithms/hnsw/serialization.h
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <string>
-#include "VecSim/algorithms/hnsw/hnsw.h"
 #include "VecSim/algorithms/hnsw/hnsw_single.h"
 
 // This struct is the return value of "checkIntegrity" methods (used for debugging).

--- a/src/VecSim/algorithms/hnsw/serialization.h
+++ b/src/VecSim/algorithms/hnsw/serialization.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <string>
 #include "VecSim/algorithms/hnsw/hnsw.h"
+#include "VecSim/algorithms/hnsw/hnsw_single.h"
 
 // This struct is the return value of "checkIntegrity" methods (used for debugging).
 typedef struct HNSWIndexMetaData {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${LLVM_LD_FLAGS}")
 
 enable_testing()
 
-add_executable(test_hnsw test_hnsw.cpp test_utils.cpp)
+add_executable(test_hnsw test_hnsw.cpp test_hnsw_multi.cpp test_utils.cpp)
 add_executable(test_bruteforce test_bruteforce.cpp test_bruteforce_multi.cpp test_utils.cpp)
 add_executable(test_allocator test_allocator.cpp test_utils.cpp)
 add_executable(test_spaces test_spaces.cpp)

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -279,7 +279,7 @@ TEST_F(AllocatorTest, testIncomingEdgesSet) {
 
     // Account for allocating link lists for levels higher than 0, if exists.
     if (vec_max_level > 0) {
-        expected_allocation_delta += hnswIndex->size_links_per_element_ * vec_max_level + 1 +
+        expected_allocation_delta += hnswIndex->size_links_per_element_ * vec_max_level +
                                      AllocatorTest::vecsimAllocationOverhead;
     }
     ASSERT_EQ(allocation_delta, expected_allocation_delta);
@@ -320,7 +320,7 @@ TEST_F(AllocatorTest, testIncomingEdgesSet) {
     size_t buckets_diff = hnswIndex->label_lookup_.bucket_count() - buckets_num_before;
     expected_allocation_delta += buckets_diff * sizeof(size_t);
     if (vec_max_level > 0) {
-        expected_allocation_delta += hnswIndex->size_links_per_element_ * vec_max_level + 1 +
+        expected_allocation_delta += hnswIndex->size_links_per_element_ * vec_max_level +
                                      AllocatorTest::vecsimAllocationOverhead;
     }
 
@@ -348,9 +348,9 @@ TEST_F(AllocatorTest, test_hnsw_reclaim_memory) {
     // when initial capacity is zero, while in other platforms labels_lookup is allocated with a
     // single bucket. This, we get the following range in which we expect the initial memory to be
     // in.
-    ASSERT_LE(initial_memory_size, HNSWFactory::EstimateInitialSize(&params) + sizeof(size_t));
-    ASSERT_GE(initial_memory_size,
-              HNSWFactory::EstimateInitialSize(&params) - 2 * vecsimAllocationOverhead);
+    ASSERT_GE(initial_memory_size, HNSWFactory::EstimateInitialSize(&params));
+    ASSERT_LE(initial_memory_size, HNSWFactory::EstimateInitialSize(&params) + sizeof(size_t) +
+                                       2 * vecsimAllocationOverhead);
 
     // Add vectors up to the size of a whole block, and calculate the total memory delta.
     size_t block_size = hnswIndex->info().hnswInfo.blockSize;
@@ -425,6 +425,6 @@ TEST_F(AllocatorTest, test_hnsw_reclaim_memory) {
     ASSERT_LE(allocator->getAllocationSize(), HNSWFactory::EstimateInitialSize(&params) +
                                                   hash_table_memory + 2 * vecsimAllocationOverhead);
     ASSERT_GE(allocator->getAllocationSize(), HNSWFactory::EstimateInitialSize(&params) +
-                                                  hash_table_memory + vecsimAllocationOverhead);
+                                                  hash_table_memory);
     VecSimIndex_Free(hnswIndex);
 }

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -424,7 +424,7 @@ TEST_F(AllocatorTest, test_hnsw_reclaim_memory) {
     // zero, while in others the entire capacity reduced to zero (including the header).
     ASSERT_LE(allocator->getAllocationSize(), HNSWFactory::EstimateInitialSize(&params) +
                                                   hash_table_memory + 2 * vecsimAllocationOverhead);
-    ASSERT_GE(allocator->getAllocationSize(), HNSWFactory::EstimateInitialSize(&params) +
-                                                  hash_table_memory);
+    ASSERT_GE(allocator->getAllocationSize(),
+              HNSWFactory::EstimateInitialSize(&params) + hash_table_memory);
     VecSimIndex_Free(hnswIndex);
 }

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -422,11 +422,9 @@ TEST_F(AllocatorTest, test_hnsw_reclaim_memory) {
     // Current memory should be back as it was initially. The label_lookup hash table is an
     // exception, since in some platforms, empty buckets remain even when the capacity is set to
     // zero, while in others the entire capacity reduced to zero (including the header).
-    // Also, the element_levels vector capacity should become zero, so we should reduce its header
-    // that always counted in the initial size estimation.
     ASSERT_LE(allocator->getAllocationSize(), HNSWFactory::EstimateInitialSize(&params) +
-                                                  hash_table_memory - vecsimAllocationOverhead);
+                                                  hash_table_memory + 2 * vecsimAllocationOverhead);
     ASSERT_GE(allocator->getAllocationSize(), HNSWFactory::EstimateInitialSize(&params) +
-                                                  hash_table_memory - 2 * vecsimAllocationOverhead);
+                                                  hash_table_memory + vecsimAllocationOverhead);
     VecSimIndex_Free(hnswIndex);
 }

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -213,9 +213,9 @@ TEST_F(AllocatorTest, test_hnsw) {
         .type = VecSimType_FLOAT32, .dim = d, .metric = VecSimMetric_L2, .initialCapacity = 0};
 
     float vec[128] = {};
-    HNSWIndex<float, float> *hnswIndex =
-        new (allocator) HNSWIndex<float, float>(&params, allocator);
-    expectedAllocationSize += sizeof(HNSWIndex<float, float>) + vecsimAllocationOverhead;
+    HNSWIndex_Single<float, float> *hnswIndex =
+        new (allocator) HNSWIndex_Single<float, float>(&params, allocator);
+    expectedAllocationSize += sizeof(HNSWIndex_Single<float, float>) + vecsimAllocationOverhead;
     ASSERT_GE(allocator->getAllocationSize(), expectedAllocationSize);
     VecSimIndexInfo info = hnswIndex->info();
     ASSERT_EQ(allocator->getAllocationSize(), info.hnswInfo.memory);
@@ -259,7 +259,7 @@ TEST_F(AllocatorTest, testIncomingEdgesSet) {
                          .metric = VecSimMetric_L2,
                          .initialCapacity = 10,
                          .M = 2};
-    auto *hnswIndex = new (allocator) HNSWIndex<float, float>(&params, allocator);
+    auto *hnswIndex = new (allocator) HNSWIndex_Single<float, float>(&params, allocator);
 
     // Add a "dummy" vector - labels_lookup hash table will allocate initial size of buckets here.
     float vec0[] = {0.0f, 0.0f};
@@ -340,7 +340,7 @@ TEST_F(AllocatorTest, test_hnsw_reclaim_memory) {
     // Build HNSW index with default args and initial capacity of zero.
     HNSWParams params = {
         .type = VecSimType_FLOAT32, .dim = d, .metric = VecSimMetric_L2, .initialCapacity = 0};
-    auto *hnswIndex = new (allocator) HNSWIndex<float, float>(&params, allocator);
+    auto *hnswIndex = new (allocator) HNSWIndex_Single<float, float>(&params, allocator);
 
     ASSERT_EQ(hnswIndex->getIndexCapacity(), 0);
     size_t initial_memory_size = allocator->getAllocationSize();

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -339,6 +339,7 @@ TEST_F(BruteForceTest, brute_force_vector_search_test_l2) {
     };
     float query[] = {50, 50, 50, 50};
     runTopKSearchTest(index, query, k, verify_res);
+    runTopKSearchTest(index, query, 0, verify_res); // For sanity, search for nothing
 
     VecSimIndex_Free(index);
 }
@@ -366,34 +367,6 @@ TEST_F(BruteForceTest, brute_force_vector_search_by_id_test) {
 
     float query[] = {50, 50, 50, 50};
     auto verify_res = [&](size_t id, float score, size_t index) { ASSERT_EQ(id, (index + 45)); };
-    runTopKSearchTest(index, query, k, verify_res, nullptr, BY_ID);
-
-    VecSimIndex_Free(index);
-}
-
-TEST_F(BruteForceTest, search_for_nothing) {
-    size_t n = 100;
-    size_t k = 0;
-    size_t dim = 4;
-
-    VecSimParams params{.algo = VecSimAlgo_BF,
-                        .bfParams = BFParams{.type = VecSimType_FLOAT32,
-                                             .dim = dim,
-                                             .metric = VecSimMetric_L2,
-                                             .initialCapacity = n}};
-    VecSimIndex *index = VecSimIndex_New(&params);
-
-    for (size_t i = 0; i < n; i++) {
-        float f[dim];
-        for (size_t j = 0; j < dim; j++) {
-            f[j] = (float)i;
-        }
-        VecSimIndex_AddVector(index, (const void *)f, (int)i);
-    }
-    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
-
-    float query[] = {50, 50, 50, 50};
-    auto verify_res = [&](size_t id, float score, size_t index) { return; };
     runTopKSearchTest(index, query, k, verify_res, nullptr, BY_ID);
 
     VecSimIndex_Free(index);

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -371,6 +371,34 @@ TEST_F(BruteForceTest, brute_force_vector_search_by_id_test) {
     VecSimIndex_Free(index);
 }
 
+TEST_F(BruteForceTest, search_for_nothing) {
+    size_t n = 100;
+    size_t k = 0;
+    size_t dim = 4;
+
+    VecSimParams params{.algo = VecSimAlgo_BF,
+                        .bfParams = BFParams{.type = VecSimType_FLOAT32,
+                                             .dim = dim,
+                                             .metric = VecSimMetric_L2,
+                                             .initialCapacity = n}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)i;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, (int)i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    float query[] = {50, 50, 50, 50};
+    auto verify_res = [&](size_t id, float score, size_t index) { return; };
+    runTopKSearchTest(index, query, k, verify_res, nullptr, BY_ID);
+
+    VecSimIndex_Free(index);
+}
+
 TEST_F(BruteForceTest, brute_force_indexing_same_vector) {
     size_t n = 100;
     size_t k = 10;

--- a/tests/unit/test_bruteforce_multi.cpp
+++ b/tests/unit/test_bruteforce_multi.cpp
@@ -220,7 +220,7 @@ TEST_F(BruteForceMultiTest, vector_search_test) {
     VecSimIndex_Free(index);
 }
 
-TEST_F(BruteForceMultiTest, search_more_then_there_is) {
+TEST_F(BruteForceMultiTest, search_more_than_there_is) {
     size_t dim = 4;
     size_t n = 5;
     size_t perLabel = 3;

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -97,34 +97,6 @@ TEST_F(HNSWTest, hnsw_blob_sanity_test) {
     VecSimIndex_Free(index);
 }
 
-TEST_F(HNSWTest, search_for_nothing) {
-    size_t n = 100;
-    size_t k = 0;
-    size_t dim = 4;
-
-    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-                                                 .dim = dim,
-                                                 .metric = VecSimMetric_L2,
-                                                 .initialCapacity = n}};
-    VecSimIndex *index = VecSimIndex_New(&params);
-
-    for (size_t i = 0; i < n; i++) {
-        float f[dim];
-        for (size_t j = 0; j < dim; j++) {
-            f[j] = (float)i;
-        }
-        VecSimIndex_AddVector(index, (const void *)f, (int)i);
-    }
-    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
-
-    float query[] = {50, 50, 50, 50};
-    auto verify_res = [&](size_t id, float score, size_t index) { return; };
-    runTopKSearchTest(index, query, k, verify_res, nullptr, BY_ID);
-
-    VecSimIndex_Free(index);
-}
-
 /**** resizing cases ****/
 
 // Add up to capacity.
@@ -350,6 +322,7 @@ TEST_F(HNSWTest, hnsw_vector_search_test) {
         ASSERT_EQ(score, (4 * ((index + 1) / 2) * ((index + 1) / 2)));
     };
     runTopKSearchTest(index, query, k, verify_res);
+    runTopKSearchTest(index, query, 0, verify_res); // For sanity, search for nothing
     VecSimIndex_Free(index);
 }
 

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -20,9 +20,9 @@ protected:
 TEST_F(HNSWTest, TEST_TEST_TEST) {
     auto al = VecSimAllocator::newVecsimAllocator();
     auto s = al->getAllocationSize();
-    vecsim_stl::vector<idType>vec(0, al);
+    vecsim_stl::vector<idType> vec(0, al);
     auto e = al->getAllocationSize();
-    ASSERT_EQ(e-s, 0);
+    ASSERT_EQ(e - s, 0);
 }
 
 TEST_F(HNSWTest, hnsw_vector_add_test) {

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -1679,7 +1679,7 @@ TEST_F(HNSWTest, testSizeEstimation) {
     // labels_lookup hash table has additional memory, since STL implementation chooses "an
     // appropriate prime number" higher than n as the number of allocated buckets (for n=1000, 1031
     // buckets are created)
-    estimation += (reinterpret_cast<HNSWIndex<float, float> *>(index)
+    estimation += (reinterpret_cast<HNSWIndex_Single<float, float> *>(index)
 
                        ->label_lookup_.bucket_count() -
                    n) *

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -17,14 +17,6 @@ protected:
     void TearDown() override {}
 };
 
-TEST_F(HNSWTest, TEST_TEST_TEST) {
-    auto al = VecSimAllocator::newVecsimAllocator();
-    auto s = al->getAllocationSize();
-    vecsim_stl::vector<idType> vec(0, al);
-    auto e = al->getAllocationSize();
-    ASSERT_EQ(e - s, 0);
-}
-
 TEST_F(HNSWTest, hnsw_vector_add_test) {
     size_t dim = 4;
     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -1661,8 +1661,8 @@ TEST_F(HNSWTest, testCosine) {
 
 TEST_F(HNSWTest, testSizeEstimation) {
     size_t dim = 128;
-    size_t n = 1000;
-    size_t bs = DEFAULT_BLOCK_SIZE;
+    size_t n = 10000;
+    size_t bs = 1000;
     size_t M = 32;
 
     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
@@ -1697,7 +1697,7 @@ TEST_F(HNSWTest, testSizeEstimation) {
     }
 
     // Estimate the memory delta of adding a full new block.
-    estimation = VecSimIndex_EstimateElementSize(&params) * (bs % n + bs);
+    estimation = VecSimIndex_EstimateElementSize(&params) * bs;
 
     actual = 0;
     for (size_t i = 0; i < bs; i++) {

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -17,6 +17,15 @@ protected:
     void TearDown() override {}
 };
 
+TEST_F(HNSWTest, TEST_TEST_TEST) {
+    auto al = VecSimAllocator::newVecsimAllocator();
+    auto s = al->getAllocationSize();
+    vecsim_stl::vector<idType>vec(0, al);
+    auto e = al->getAllocationSize();
+    printf("%zi\n", e-s);
+    ASSERT_EQ(e-s, 0);
+}
+
 TEST_F(HNSWTest, hnsw_vector_add_test) {
     size_t dim = 4;
     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -1661,8 +1661,8 @@ TEST_F(HNSWTest, testCosine) {
 
 TEST_F(HNSWTest, testSizeEstimation) {
     size_t dim = 128;
-    size_t n = 10000;
-    size_t bs = 1000;
+    size_t n = 1000;
+    size_t bs = DEFAULT_BLOCK_SIZE;
     size_t M = 32;
 
     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
@@ -1697,7 +1697,7 @@ TEST_F(HNSWTest, testSizeEstimation) {
     }
 
     // Estimate the memory delta of adding a full new block.
-    estimation = VecSimIndex_EstimateElementSize(&params) * bs;
+    estimation = VecSimIndex_EstimateElementSize(&params) * (bs % n + bs);
 
     actual = 0;
     for (size_t i = 0; i < bs; i++) {

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -22,7 +22,6 @@ TEST_F(HNSWTest, TEST_TEST_TEST) {
     auto s = al->getAllocationSize();
     vecsim_stl::vector<idType>vec(0, al);
     auto e = al->getAllocationSize();
-    printf("%zi\n", e-s);
     ASSERT_EQ(e-s, 0);
 }
 

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -274,7 +274,7 @@ TEST_F(HNSWTest, emptyIndex) {
     VecSimIndex_AddVector(index, (const void *)a, 1);
     // Try to remove it.
     VecSimIndex_DeleteVector(index, 1);
-    // The capacity should change to be aligned with the vector size.
+    // The capacity should change to be aligned with the block size.
 
     HNSWIndex<float, float> *hnswIndex = reinterpret_cast<HNSWIndex<float, float> *>(index);
     size_t new_capacity = hnswIndex->getIndexCapacity();
@@ -681,8 +681,9 @@ TEST_F(HNSWTest, test_dynamic_hnsw_info_iterator) {
 
     // Set the index size artificially so that BATCHES mode will be selected by the heuristics.
     reinterpret_cast<HNSWIndex<float, float> *>(index)->cur_element_count = 1e6;
+    auto &label_lookup = reinterpret_cast<HNSWIndex_Single<float, float> *>(index)->label_lookup_;
     for (size_t i = 0; i < 1e6; i++) {
-        reinterpret_cast<HNSWIndex_Single<float, float> *>(index)->label_lookup_[i] = i;
+        label_lookup[i] = i;
     }
     ASSERT_FALSE(VecSimIndex_PreferAdHocSearch(index, 10, 1, true));
     info = VecSimIndex_Info(index);

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -681,6 +681,9 @@ TEST_F(HNSWTest, test_dynamic_hnsw_info_iterator) {
 
     // Set the index size artificially so that BATCHES mode will be selected by the heuristics.
     reinterpret_cast<HNSWIndex<float, float> *>(index)->cur_element_count = 1e6;
+    for (size_t i = 0; i < 1e6; i++) {
+        reinterpret_cast<HNSWIndex_Single<float, float> *>(index)->label_lookup_[i] = i;
+    }
     ASSERT_FALSE(VecSimIndex_PreferAdHocSearch(index, 10, 1, true));
     info = VecSimIndex_Info(index);
     infoIter = VecSimIndex_InfoIterator(index);
@@ -1569,6 +1572,9 @@ TEST_F(HNSWTest, preferAdHocOptimization) {
 
         // Set the index size artificially to be the required one.
         reinterpret_cast<HNSWIndex<float, float> *>(index)->cur_element_count = index_size;
+        for (size_t i = 0; i < index_size; i++) {
+            reinterpret_cast<HNSWIndex_Single<float, float> *>(index)->label_lookup_[i] = i;
+        }
         ASSERT_EQ(VecSimIndex_IndexSize(index), index_size);
         bool res = VecSimIndex_PreferAdHocSearch(index, (size_t)(r * (float)index_size), k, true);
         ASSERT_EQ(res, comb.second);

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -1269,6 +1269,7 @@ TEST_F(HNSWTest, hnsw_batch_iterator_advanced) {
     VecSimBatchIterator_Free(batchIterator);
     VecSimIndex_Free(index);
 }
+
 TEST_F(HNSWTest, hnsw_resolve_params) {
     size_t dim = 4;
     size_t M = 8;

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -1303,14 +1303,7 @@ TEST_F(HNSWMultiTest, testInitialSizeEstimation_No_InitialCapacity) {
                                                  .blockSize = bs}};
 
     VecSimIndex *index = VecSimIndex_New(&params);
-    // label_lookup_ hash table has additional memory, since STL implementation chooses "an
-    // appropriate prime number" higher than n as the number of allocated buckets (for n=1000, 1031
-    // buckets are created)
     size_t estimation = VecSimIndex_EstimateInitialSize(&params);
-    estimation +=
-        (reinterpret_cast<HNSWIndex_Multi<float, float> *>(index)->label_lookup_.bucket_count() -
-         n) *
-        sizeof(size_t);
 
     size_t actual = index->getAllocator()->getAllocationSize();
     ASSERT_EQ(estimation, actual);

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -1,0 +1,1352 @@
+#include "gtest/gtest.h"
+#include "VecSim/vec_sim.h"
+#include "test_utils.h"
+#include "VecSim/utils/arr_cpp.h"
+#include "VecSim/algorithms/hnsw/hnsw_multi.h"
+#include <cmath>
+
+class HNSWMultiTest : public ::testing::Test {
+protected:
+    HNSWMultiTest() {}
+
+    ~HNSWMultiTest() override {}
+
+    void SetUp() override {}
+
+    void TearDown() override {}
+};
+
+TEST_F(HNSWMultiTest, vector_add_multiple_test) {
+    size_t dim = 4;
+    int rep = 5;
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_IP,
+                                                 .multi = true,
+                                                 .initialCapacity = 200}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    // Adding multiple vectors under the same label
+    for (int j = 0; j < rep; j++) {
+        float a[dim];
+        for (size_t i = 0; i < dim; i++) {
+            a[i] = (float)i * j + i;
+        }
+        VecSimIndex_AddVector(index, (const void *)a, 46);
+    }
+
+    ASSERT_EQ(VecSimIndex_IndexSize(index), rep);
+    ASSERT_EQ((reinterpret_cast<HNSWIndex_Multi<float, float> *>(index))->indexLabelCount(), 1);
+
+    // Deleting the label. All the vectors should be deleted.
+    VecSimIndex_DeleteVector(index, 46);
+
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+    ASSERT_EQ((reinterpret_cast<HNSWIndex_Multi<float, float> *>(index))->indexLabelCount(), 0);
+
+    VecSimIndex_Free(index);
+}
+
+/**** resizing cases ****/
+
+TEST_F(HNSWMultiTest, resizeNAlignIndex) {
+    size_t dim = 4;
+    size_t n = 10;
+    size_t bs = 3;
+    size_t n_labels = 3;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = n,
+                                                 .blockSize = bs}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    float a[dim];
+
+    // Add up to n.
+    for (size_t i = 0; i < n; i++) {
+        for (size_t j = 0; j < dim; j++) {
+            a[j] = (float)i;
+        }
+        VecSimIndex_AddVector(index, (const void *)a, i % n_labels);
+    }
+    // The size and the capacity should be equal.
+    HNSWIndex<float, float> *hnswIndex = reinterpret_cast<HNSWIndex<float, float> *>(index);
+    ASSERT_EQ(hnswIndex->getIndexCapacity(), VecSimIndex_IndexSize(index));
+    // The capacity shouldn't be changed.
+    ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+
+    // Add another vector to exceed the initial capacity.
+    VecSimIndex_AddVector(index, (const void *)a, n);
+
+    // The capacity should be now aligned with the block size.
+    // bs = 3, size = 11 -> capacity = 12
+    // New capacity = initial capacity + blockSize - initial capacity % blockSize.
+    ASSERT_EQ(hnswIndex->getIndexCapacity(), n + bs - n % bs);
+    VecSimIndex_Free(index);
+}
+
+// Test empty index edge cases.
+TEST_F(HNSWMultiTest, empty_index) {
+    size_t dim = 4;
+    size_t n = 20;
+    size_t bs = 6;
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = n,
+                                                 .blockSize = bs}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    // Try to remove from an empty index - should fail because label doesn't exist.
+    VecSimIndex_DeleteVector(index, 0);
+
+    // Add one vector.
+    float a[dim];
+    for (size_t j = 0; j < dim; j++) {
+        a[j] = (float)1.7;
+    }
+
+    VecSimIndex_AddVector(index, (const void *)a, 1);
+    // Try to remove it.
+    VecSimIndex_DeleteVector(index, 1);
+
+    // Size equals 0.
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    // Try to remove it again.
+    VecSimIndex_DeleteVector(index, 1);
+
+    // Nor the size.
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, vector_search_test) {
+    size_t dim = 4;
+    size_t n = 1000;
+    size_t n_labels = 100;
+    size_t k = 11;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 200}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)i;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, (size_t)i % n_labels);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.indexLabelCount, n_labels);
+
+    float query[] = {50, 50, 50, 50};
+    std::set<size_t> expected_ids;
+    for (size_t i = n - 1; i > n - 1 - k; i--) {
+        expected_ids.insert(i);
+    }
+    auto verify_res = [&](size_t id, float score, size_t index) {
+        size_t diff_id = ((int)(id - 50) > 0) ? (id - 50) : (50 - id);
+        ASSERT_EQ(diff_id, (index + 1) / 2);
+        ASSERT_EQ(score, (4 * ((index + 1) / 2) * ((index + 1) / 2)));
+    };
+    runTopKSearchTest(index, query, k, verify_res);
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, search_more_then_there_is) {
+    size_t dim = 4;
+    size_t n = 5;
+    size_t perLabel = 3;
+    size_t n_labels = ceil((float)n / perLabel);
+    size_t k = 3;
+    // This test add 5 vectors under 2 labels, and then query for 3 results.
+    // We want to make sure we get only 2 results back (because the results should have unique
+    // labels), although the index contains 5 vectors.
+
+    VecSimParams params{
+        .algo = VecSimAlgo_HNSWLIB,
+        .hnswParams = HNSWParams{
+            .type = VecSimType_FLOAT32, .dim = dim, .metric = VecSimMetric_L2, .multi = true}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t x = 0; x < dim; x++) {
+            f[x] = (float)i;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, (size_t)(i / perLabel));
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.indexLabelCount, n_labels);
+
+    float query[] = {0, 0, 0, 0};
+    VecSimQueryResult_List res = VecSimIndex_TopKQuery(index, query, k, nullptr, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), n_labels);
+    auto it = VecSimQueryResult_List_GetIterator(res);
+    for (size_t i = 0; i < n_labels; i++) {
+        auto el = VecSimQueryResult_IteratorNext(it);
+        labelType element_label = VecSimQueryResult_GetId(el);
+        ASSERT_EQ(element_label, i);
+        auto ids = reinterpret_cast<HNSWIndex_Multi<float, float> *>(index)->label_lookup_.at(
+            element_label);
+        for (size_t j = 0; j < ids.size(); j++) {
+            // Verifying that each vector is labeled correctly.
+            // ID is calculated according to insertion order.
+            ASSERT_EQ(ids[j], i * perLabel + j);
+        }
+    }
+    VecSimQueryResult_IteratorFree(it);
+    VecSimQueryResult_Free(res);
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, indexing_same_vector) {
+    size_t n = 100;
+    size_t k = 10;
+    size_t perLabel = 10;
+    size_t dim = 4;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 200}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)(i);
+        }
+        VecSimIndex_AddVector(index, (const void *)f, (i / perLabel));
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    float query[] = {0, 0, 0, 0};
+    auto verify_res = [&](size_t id, float score, size_t index) { ASSERT_EQ(id, index); };
+    runTopKSearchTest(index, query, k, verify_res);
+    auto res = VecSimIndex_TopKQuery(index, query, k, nullptr, BY_SCORE);
+    auto it = VecSimQueryResult_List_GetIterator(res);
+    for (size_t i = 0; i < k; i++) {
+        auto el = VecSimQueryResult_IteratorNext(it);
+        labelType element_label = VecSimQueryResult_GetId(el);
+        ASSERT_EQ(element_label, i);
+        auto ids = reinterpret_cast<HNSWIndex_Multi<float, float> *>(index)->label_lookup_.at(
+            element_label);
+        for (size_t j = 0; j < ids.size(); j++) {
+            // Verifying that each vector is labeled correctly.
+            // ID is calculated according to insertion order.
+            ASSERT_EQ(ids[j], i * perLabel + j);
+        }
+    }
+    VecSimQueryResult_IteratorFree(it);
+    VecSimQueryResult_Free(res);
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, find_better_score) {
+    size_t n = 100;
+    size_t k = 10;
+    size_t n_labels = 10;
+    size_t dim = 4;
+    size_t initial_capacity = 200;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = initial_capacity}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    // Building the index. Each label gets 10 vectors with decreasing (by insertion order) element
+    // value, so when we search, each vector is better then the previous one. Furthermore, each
+    // label gets at least one better vector than the previous label and one with a score equals to
+    // the best of the previous label, so the multimap holds at least two labels with the same
+    // score.
+    std::map<size_t, float> scores;
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        // For example, with n_labels == 10 and n == 100,
+        // label 0 will get vector elements 18 -> 9 (aka (9 -> 0) + 9),
+        // label 1 will get vector elements 17 -> 8 (aka (9 -> 0) + 8),
+        // label 2 will get vector elements 16 -> 7 (aka (9 -> 0) + 7),
+        // . . . . .
+        // label 9 will get vector elements 9 -> 0 (aka (9 -> 0) + 0),
+        // and so on, so each label has some common vectors with all the previous labels.
+        size_t el = ((n - i - 1) % n_labels) + ((n - i - 1) / n_labels);
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)el;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i / n_labels);
+        // This should be the best score for each label.
+        if (i % n_labels == n_labels - 1) {
+            // `el * el * dim` is the L2-squared value with the 0 vector.
+            scores.emplace(i / n_labels, el * el * dim);
+        }
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.indexLabelCount, n_labels);
+
+    auto verify_res = [&](size_t id, float score, size_t index) {
+        ASSERT_EQ(id, k - index - 1);
+        ASSERT_FLOAT_EQ(score, scores[id]);
+    };
+
+    float query[] = {0, 0, 0, 0};
+    runTopKSearchTest(index, query, k, verify_res);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, find_better_score_after_pop) {
+    size_t n = 12;
+    size_t n_labels = 3;
+    size_t dim = 4;
+    size_t initial_capacity = 200;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = initial_capacity}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    // Building the index. Each is better than the previous one.
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        size_t el = n - i;
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)el;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i % n_labels);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.indexLabelCount, n_labels);
+
+    float query[] = {0, 0, 0, 0};
+    auto verify_res = [&](size_t id, float score, size_t index) {
+        ASSERT_EQ(id, n_labels - index - 1);
+    };
+    // Having k = n_labels - 1, the heap will continuously pop the worst label before finding the
+    // next vector, which is of the same label and is the best vector yet.
+    runTopKSearchTest(index, query, n_labels - 1, verify_res);
+
+    // Having k = n_labels, the heap will never get to pop the worst label, but we will update the
+    // scores each time.
+    runTopKSearchTest(index, query, n_labels, verify_res);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, reindexing_same_vector_different_id) {
+    size_t n = 100;
+    size_t k = 10;
+    size_t dim = 4;
+    size_t perLabel = 3;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 200}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)(i / 10); // i / 10 is in integer (take the "floor" value)
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i);
+    }
+    // Add more vectors under the same labels. their scores should be worst.
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)(i / 10) + n;
+        }
+        for (size_t j = 0; j < perLabel - 1; j++) {
+            VecSimIndex_AddVector(index, (const void *)f, i);
+        }
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n * perLabel);
+
+    // Run a query where all the results are supposed to be {5,5,5,5} (different ids).
+    float query[] = {4.9, 4.95, 5.05, 5.1};
+    auto verify_res = [&](size_t id, float score, size_t index) {
+        ASSERT_TRUE(id >= 50 && id < 60 && score <= 1);
+    };
+    runTopKSearchTest(index, query, k, verify_res);
+
+    for (size_t i = 0; i < n; i++) {
+        VecSimIndex_DeleteVector(index, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    // Reinsert the same vectors under different ids than before.
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)(i / 10); // i / 10 is in integer (take the "floor" value)
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i + 10);
+    }
+    // Add more vectors under the same labels. their scores should be worst.
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)(i / 10) + n;
+        }
+        for (size_t j = 0; j < perLabel - 1; j++) {
+            VecSimIndex_AddVector(index, (const void *)f, i + 10);
+        }
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n * perLabel);
+
+    // Run the same query again.
+    auto verify_res_different_id = [&](int id, float score, size_t index) {
+        ASSERT_TRUE(id >= 60 && id < 70 && score <= 1);
+    };
+    runTopKSearchTest(index, query, k, verify_res_different_id);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, test_hnsw_info) {
+    size_t n = 100;
+    size_t d = 128;
+
+    // Build with default args.
+    VecSimParams params = {.algo = VecSimAlgo_HNSWLIB,
+                           .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                    .dim = d,
+                                                    .metric = VecSimMetric_L2,
+                                                    .multi = true,
+                                                    .initialCapacity = n}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    VecSimIndexInfo info = VecSimIndex_Info(index);
+    ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(info.hnswInfo.dim, d);
+    ASSERT_TRUE(info.hnswInfo.isMulti);
+    // Default args.
+    ASSERT_EQ(info.hnswInfo.blockSize, DEFAULT_BLOCK_SIZE);
+    ASSERT_EQ(info.hnswInfo.indexSize, 0);
+    VecSimIndex_Free(index);
+
+    d = 1280;
+    params = VecSimParams{.algo = VecSimAlgo_HNSWLIB,
+                          .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                   .dim = d,
+                                                   .metric = VecSimMetric_L2,
+                                                   .multi = true,
+                                                   .initialCapacity = n,
+                                                   .blockSize = 1}};
+    index = VecSimIndex_New(&params);
+    info = VecSimIndex_Info(index);
+    ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(info.hnswInfo.dim, d);
+    ASSERT_TRUE(info.hnswInfo.isMulti);
+    // User args.
+    ASSERT_EQ(info.hnswInfo.blockSize, 1);
+    ASSERT_EQ(info.hnswInfo.indexSize, 0);
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, test_basic_hnsw_info_iterator) {
+    size_t n = 100;
+    size_t d = 128;
+    VecSimMetric metrics[3] = {VecSimMetric_Cosine, VecSimMetric_IP, VecSimMetric_L2};
+
+    for (size_t i = 0; i < 3; i++) {
+        // Build with default args.
+        VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                            .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                     .dim = d,
+                                                     .metric = metrics[i],
+                                                     .multi = true,
+                                                     .initialCapacity = n}};
+        VecSimIndex *index = VecSimIndex_New(&params);
+        VecSimIndexInfo info = VecSimIndex_Info(index);
+        VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(index);
+        compareHNSWIndexInfoToIterator(info, infoIter);
+        VecSimInfoIterator_Free(infoIter);
+        VecSimIndex_Free(index);
+    }
+}
+
+TEST_F(HNSWMultiTest, test_dynamic_hnsw_info_iterator) {
+    size_t d = 128;
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = d,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .blockSize = 1}};
+    float v[d];
+    for (size_t i = 0; i < d; i++) {
+        v[i] = (float)i;
+    }
+    VecSimIndex *index = VecSimIndex_New(&params);
+    VecSimIndexInfo info = VecSimIndex_Info(index);
+    VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(1, info.hnswInfo.blockSize);
+    ASSERT_EQ(0, info.hnswInfo.indexSize);
+    compareHNSWIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    // Add vectors.
+    VecSimIndex_AddVector(index, v, 0);
+    VecSimIndex_AddVector(index, v, 0);
+    VecSimIndex_AddVector(index, v, 1);
+    VecSimIndex_AddVector(index, v, 1);
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(4, info.hnswInfo.indexSize);
+    ASSERT_EQ(2, info.hnswInfo.indexLabelCount);
+    compareHNSWIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    // Delete vectors.
+    VecSimIndex_DeleteVector(index, 0);
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(2, info.hnswInfo.indexSize);
+    ASSERT_EQ(1, info.hnswInfo.indexLabelCount);
+    compareHNSWIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    // Perform (or simulate) Search in all modes.
+    VecSimIndex_AddVector(index, v, 0);
+    auto res = VecSimIndex_TopKQuery(index, v, 1, nullptr, BY_SCORE);
+    VecSimQueryResult_Free(res);
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(STANDARD_KNN, info.hnswInfo.last_mode);
+    compareHNSWIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    res = VecSimIndex_RangeQuery(index, v, 1, nullptr, BY_SCORE);
+    VecSimQueryResult_Free(res);
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(RANGE_QUERY, info.hnswInfo.last_mode);
+    compareHNSWIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 1, 1, true));
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(HYBRID_ADHOC_BF, info.hnswInfo.last_mode);
+    compareHNSWIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    // Set the index size artificially so that BATCHES mode will be selected by the heuristics.
+    size_t perLabel = 3;
+    for (size_t i = 0; i < 1e4; i++) {
+        VecSimIndex_AddVector(index, v, i / perLabel);
+    }
+    ASSERT_FALSE(VecSimIndex_PreferAdHocSearch(index, 7e3, 1, true));
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(HYBRID_BATCHES, info.hnswInfo.last_mode);
+    compareHNSWIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    // Simulate the case where another call to the heuristics is done after realizing that
+    // the subset size is smaller, and change the policy as a result.
+    ASSERT_TRUE(VecSimIndex_PreferAdHocSearch(index, 1, 1, false));
+    info = VecSimIndex_Info(index);
+    infoIter = VecSimIndex_InfoIterator(index);
+    ASSERT_EQ(HYBRID_BATCHES_TO_ADHOC_BF, info.hnswInfo.last_mode);
+    compareHNSWIndexInfoToIterator(info, infoIter);
+    VecSimInfoIterator_Free(infoIter);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, vector_search_test_l2_blocksize_1) {
+    size_t dim = 4;
+    size_t n = 100;
+    size_t k = 11;
+    size_t perLabel = 4;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 200,
+                                                 .blockSize = 1}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    VecSimIndexInfo info = VecSimIndex_Info(index);
+    ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(info.hnswInfo.blockSize, 1);
+
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)i;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i);
+    }
+    // Add more vectors under the same labels. their scores should be worst.
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)i + n;
+        }
+        for (size_t j = 0; j < perLabel - 1; j++) {
+            VecSimIndex_AddVector(index, (const void *)f, i);
+        }
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n * perLabel);
+
+    auto verify_res = [&](size_t id, float score, size_t index) {
+        size_t diff_id = ((int)(id - 50) > 0) ? (id - 50) : (50 - id);
+        ASSERT_EQ(diff_id, (index + 1) / 2);
+        ASSERT_EQ(score, (4 * ((index + 1) / 2) * ((index + 1) / 2)));
+    };
+    float query[] = {50, 50, 50, 50};
+    runTopKSearchTest(index, query, k, verify_res);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, search_empty_index) {
+    size_t dim = 4;
+    size_t n = 100;
+    size_t k = 11;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 200}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    float query[] = {50, 50, 50, 50};
+
+    // We do not expect any results.
+    VecSimQueryResult_List res =
+        VecSimIndex_TopKQuery(index, (const void *)query, k, NULL, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    VecSimQueryResult_Iterator *it = VecSimQueryResult_List_GetIterator(res);
+    ASSERT_EQ(VecSimQueryResult_IteratorNext(it), nullptr);
+    VecSimQueryResult_IteratorFree(it);
+    VecSimQueryResult_Free(res);
+
+    // TODO: uncomment when support for BFM range is enabled
+    // res = VecSimIndex_RangeQuery(index, (const void *)query, 1.0f, NULL, BY_SCORE);
+    // ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    // VecSimQueryResult_Free(res);
+
+    // Add some vectors and remove them all from index, so it will be empty again.
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)i;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    for (size_t i = 0; i < n; i++) {
+        VecSimIndex_DeleteVector(index, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    // Again - we do not expect any results.
+    res = VecSimIndex_TopKQuery(index, (const void *)query, k, NULL, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    it = VecSimQueryResult_List_GetIterator(res);
+    ASSERT_EQ(VecSimQueryResult_IteratorNext(it), nullptr);
+    VecSimQueryResult_IteratorFree(it);
+    VecSimQueryResult_Free(res);
+
+    // TODO: uncomment when support for BFM range is enabled
+    // res = VecSimIndex_RangeQuery(index, (const void *)query, 1.0f, NULL, BY_SCORE);
+    // ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    // VecSimQueryResult_Free(res);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, remove_vector_after_replacing_block) {
+    size_t dim = 4;
+    size_t bs = 2;
+    size_t n = 6;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 200,
+                                                 .blockSize = bs}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    // Setting up vectors
+    float f[n][dim];
+    for (size_t i = 0; i < n; i++) {
+        for (size_t j = 0; j < dim; j++) {
+            f[i][j] = i;
+        }
+    }
+    // Add 1 vector with label 1
+    VecSimIndex_AddVector(index, (const void *)f[0], 1);
+
+    // Add 3 vectors with label 3
+    VecSimIndex_AddVector(index, (const void *)f[1], 3);
+    VecSimIndex_AddVector(index, (const void *)f[2], 3);
+    VecSimIndex_AddVector(index, (const void *)f[3], 3);
+
+    // Add 2 vectors with label 2
+    VecSimIndex_AddVector(index, (const void *)f[4], 2);
+    VecSimIndex_AddVector(index, (const void *)f[5], 2);
+
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    // Delete label 3. the following drawing present the expected changes
+    // [[1, 3], [3, 3], [2, 2]] -> [[1, 2], [3, 3], [2]] -> [[1, 2], [2, 3]] -> [[1, 2], [2]]
+    // [[0, 1], [2, 3], [4, 5]] -> [[0, 5], [2, 3], [4]] -> [[0, 5], [4, 3]] -> [[0, 5], [4]]
+    VecSimIndex_DeleteVector(index, 3);
+
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 3);
+    ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.indexLabelCount, 2);
+    auto hnsw_index = reinterpret_cast<HNSWIndex_Multi<float, float> *>(index);
+    ASSERT_EQ(hnsw_index->getExternalLabel(0), 1);
+    ASSERT_EQ(hnsw_index->getExternalLabel(1), 2);
+    ASSERT_EQ(hnsw_index->getExternalLabel(2), 2);
+    // checking the blob swaps.
+    ASSERT_EQ(hnsw_index->getDataByInternalId(0)[0], 0);
+    ASSERT_EQ(hnsw_index->getDataByInternalId(1)[0], 5);
+    ASSERT_EQ(hnsw_index->getDataByInternalId(2)[0], 4);
+
+    VecSimIndex_DeleteVector(index, 1);
+    VecSimIndex_DeleteVector(index, 2);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, batch_iterator) {
+    size_t dim = 4;
+    size_t perLabel = 5;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 200,
+                                                 .blockSize = 7}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    // run the test twice - for index of size 100, every iteration will run select-based search,
+    // as the number of results is 5, which is more than 0.1% of the index size. for index of size
+    // 10000, we will run the heap-based search until we return 5000 results, and then switch to
+    // select-based search.
+    for (size_t m : {100, 10000}) {
+        size_t n = m * perLabel;
+        for (size_t i = 0; i < n; i++) {
+            float f[dim];
+            for (size_t j = 0; j < dim; j++) {
+                f[j] = (float)i;
+            }
+            VecSimIndex_AddVector(index, (const void *)f, i / perLabel);
+        }
+        ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+        ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.indexLabelCount, m);
+
+        // Query for (n,n,...,n) vector (recall that n is the largest id in te index).
+        float query[dim];
+        for (size_t j = 0; j < dim; j++) {
+            query[j] = (float)n;
+        }
+        VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+        size_t iteration_num = 0;
+
+        // Get the 10 vectors whose ids are the maximal among those that hasn't been returned yet,
+        // in every iteration. The order should be from the largest to the lowest id.
+        size_t n_res = 5;
+        while (VecSimBatchIterator_HasNext(batchIterator)) {
+            std::vector<size_t> expected_ids(n_res);
+            for (size_t i = 0; i < n_res; i++) {
+                expected_ids[i] = (m - iteration_num * n_res - i - 1);
+            }
+            auto verify_res = [&](size_t id, float score, size_t index) {
+                ASSERT_EQ(expected_ids[index], id);
+            };
+            runBatchIteratorSearchTest(batchIterator, n_res, verify_res);
+            iteration_num++;
+        }
+        ASSERT_EQ(iteration_num, m / n_res);
+        VecSimBatchIterator_Free(batchIterator);
+        ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+        ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.indexLabelCount, m);
+        // Cleanup before next round.
+        for (size_t i = 0; i < m; i++) {
+            VecSimIndex_DeleteVector(index, i);
+        }
+    }
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, brute_force_batch_iterator_non_unique_scores) {
+    size_t dim = 4;
+    size_t perLabel = 5;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 200,
+                                                 .blockSize = 5}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    // Run the test twice - for index of size 100, every iteration will run select-based search,
+    // as the number of results is 5, which is more than 0.1% of the index size. for index of size
+    // 10000, we will run the heap-based search until we return 5000 results, and then switch to
+    // select-based search.
+    for (size_t m : {100, 10000}) {
+        size_t n = m * perLabel;
+        for (size_t i = 0; i < n; i++) {
+            float f[dim];
+            for (size_t j = 0; j < dim; j++) {
+                f[j] = (float)(i / (10 * perLabel));
+            }
+            VecSimIndex_AddVector(index, (const void *)f, i / perLabel);
+        }
+        ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+        // Query for (n,n,...,n) vector (recall that n is the largest id in te index).
+        float query[dim];
+        for (size_t j = 0; j < dim; j++) {
+            query[j] = (float)n;
+        }
+        VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+        size_t iteration_num = 0;
+
+        // Get the 5 vectors whose ids are the maximal among those that hasn't been returned yet,
+        // in every iteration. there are n/10 groups of 10 different vectors with the same score.
+        size_t n_res = 5;
+        bool even_iteration = false;
+        std::set<size_t> expected_ids;
+        while (VecSimBatchIterator_HasNext(batchIterator)) {
+            // Insert the maximal 10 ids in every odd iteration.
+            if (!even_iteration) {
+                for (size_t i = 1; i <= 2 * n_res; i++) {
+                    expected_ids.insert(m - iteration_num * n_res - i);
+                }
+            }
+            auto verify_res = [&](size_t id, float score, size_t index) {
+                ASSERT_TRUE(expected_ids.find(id) != expected_ids.end());
+                expected_ids.erase(id);
+            };
+            runBatchIteratorSearchTest(batchIterator, n_res, verify_res);
+            // Make sure that the expected ids set is empty after two iterations.
+            if (even_iteration) {
+                ASSERT_TRUE(expected_ids.empty());
+            }
+            iteration_num++;
+            even_iteration = !even_iteration;
+        }
+        ASSERT_EQ(iteration_num, m / n_res);
+        VecSimBatchIterator_Free(batchIterator);
+        ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+        ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.indexLabelCount, m);
+        // Cleanup before next round.
+        for (size_t i = 0; i < m; i++) {
+            VecSimIndex_DeleteVector(index, i);
+        }
+    }
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, batch_iterator_validate_scores) {
+    size_t dim = 4;
+    size_t perLabel = 10;
+    size_t n_labels = 100;
+
+    size_t init_n = n_labels * (perLabel - 1);
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = init_n,
+                                                 .blockSize = 5}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    // Inserting some big vectors to the index
+    for (size_t i = 0; i < init_n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)(i + n_labels + 46);
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i % n_labels);
+    }
+    // Lastly, inserting small vector for each label
+    for (size_t label = 0; label < n_labels; label++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)label;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, label);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n_labels * perLabel);
+
+    // Query for (0,0,0,...,0) vector.
+    float query[dim];
+    for (size_t j = 0; j < dim; j++) {
+        query[j] = (float)0;
+    }
+    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+    size_t iteration_num = 0;
+
+    size_t n_res = 5;
+    // ids should be in ascending order
+    // scores should match to the score of the last vector for each label.
+    auto verify_res = [&](size_t id, float score, size_t index) {
+        ASSERT_EQ(id, index + iteration_num * n_res);
+        ASSERT_FLOAT_EQ(score, id * id * dim);
+    };
+    while (VecSimBatchIterator_HasNext(batchIterator)) {
+        runBatchIteratorSearchTest(batchIterator, n_res, verify_res);
+        iteration_num++;
+    }
+
+    ASSERT_EQ(iteration_num, n_labels / n_res);
+    VecSimBatchIterator_Free(batchIterator);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n_labels * perLabel);
+    ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.indexLabelCount, n_labels);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, brute_get_distance) {
+    size_t n_labels = 2;
+    size_t dim = 2;
+    size_t numIndex = 3;
+    VecSimIndex *index[numIndex];
+    std::vector<double> distances;
+
+    float v1_0[] = {M_PI, M_PI};
+    float v2_0[] = {M_E, M_E};
+    float v3_1[] = {M_PI, M_E};
+    float v4_1[] = {M_SQRT2, -M_SQRT2};
+
+    VecSimParams params{
+        .algo = VecSimAlgo_HNSWLIB,
+        .hnswParams = HNSWParams{
+            .type = VecSimType_FLOAT32, .dim = dim, .multi = true, .initialCapacity = 4}};
+
+    for (size_t i = 0; i < numIndex; i++) {
+        params.hnswParams.metric = (VecSimMetric)i;
+        index[i] = VecSimIndex_New(&params);
+        VecSimIndex_AddVector(index[i], v1_0, 0);
+        VecSimIndex_AddVector(index[i], v2_0, 0);
+        VecSimIndex_AddVector(index[i], v3_1, 1);
+        VecSimIndex_AddVector(index[i], v4_1, 1);
+        ASSERT_EQ(VecSimIndex_IndexSize(index[i]), 4);
+    }
+
+    void *query = v1_0;
+    void *norm = v2_0;                               // {e, e}
+    VecSim_Normalize(norm, dim, VecSimType_FLOAT32); // now {1/sqrt(2), 1/sqrt(2)}
+    ASSERT_FLOAT_EQ(((float *)norm)[0], 1.0f / sqrt(2.0f));
+    ASSERT_FLOAT_EQ(((float *)norm)[1], 1.0f / sqrt(2.0f));
+    double dist;
+
+    // VecSimMetric_L2
+    // distances are [[0.000, 0.358], [0.179, 23.739]]
+    // minimum of each label are:
+    distances = {0, 0.1791922003030777};
+    for (size_t i = 0; i < n_labels; i++) {
+        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], i, query);
+        ASSERT_DOUBLE_EQ(dist, distances[i]);
+    }
+
+    // VecSimMetric_IP
+    // distances are [[-18.739, -16.079], [-17.409, 1.000]]
+    // minimum of each label are:
+    distances = {-18.73921012878418, -17.409339904785156};
+    for (size_t i = 0; i < n_labels; i++) {
+        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_IP], i, query);
+        ASSERT_DOUBLE_EQ(dist, distances[i]);
+    }
+
+    // VecSimMetric_Cosine
+    // distances are [[5.960e-08, 5.960e-08], [0.0026, 1.000]]
+    // minimum of each label are:
+    distances = {5.9604644775390625e-08, 0.0025991201400756836};
+    for (size_t i = 0; i < n_labels; i++) {
+        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], i, norm);
+        ASSERT_DOUBLE_EQ(dist, distances[i]);
+    }
+
+    // Bad values
+    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], -1, norm);
+    ASSERT_TRUE(std::isnan(dist));
+    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], 46, query);
+    ASSERT_TRUE(std::isnan(dist));
+
+    // Clean-up.
+    for (size_t i = 0; i < numIndex; i++) {
+        VecSimIndex_Free(index[i]);
+    }
+}
+
+// TEST_F(HNSWMultiTest, testCosine) {
+//     size_t dim = 128;
+//     size_t n = 100;
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                              .dim = dim,
+//                                              .metric = VecSimMetric_Cosine,
+//                                              .multi = true,
+//                                              .initialCapacity = n}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 1; i <= n; i++) {
+//         float f[dim];
+//         f[0] = (float)i / n;
+//         for (size_t j = 1; j < dim; j++) {
+//             f[j] = 1.0f;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+//     float query[dim];
+//     for (size_t i = 0; i < dim; i++) {
+//         query[i] = 1.0f;
+//     }
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         ASSERT_EQ(id, (n - index));
+//         float first_coordinate = (float)id / n;
+//         // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query
+//         vector
+//         // and B is the current result vector.
+//         float expected_score =
+//             1.0f -
+//             ((first_coordinate + (float)dim - 1.0f) /
+//              (sqrtf((float)dim) * sqrtf((float)(dim - 1) + first_coordinate *
+//              first_coordinate)));
+//         // Verify that abs difference between the actual and expected score is at most 1/10^6.
+//         ASSERT_NEAR(score, expected_score, 1e-5);
+//     };
+//     runTopKSearchTest(index, query, 10, verify_res);
+
+//     // Test with batch iterator.
+//     VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+//     size_t iteration_num = 0;
+
+//     // get the 10 vectors whose ids are the maximal among those that hasn't been returned yet,
+//     // in every iteration. The order should be from the largest to the lowest id.
+//     size_t n_res = 10;
+//     while (VecSimBatchIterator_HasNext(batchIterator)) {
+//         std::vector<size_t> expected_ids(n_res);
+//         auto verify_res_batch = [&](size_t id, float score, size_t index) {
+//             ASSERT_EQ(id, (n - n_res * iteration_num - index));
+//             float first_coordinate = (float)id / n;
+//             // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query
+//             // vector and B is the current result vector.
+//             float expected_score =
+//                 1.0f - ((first_coordinate + (float)dim - 1.0f) /
+//                         (sqrtf((float)dim) *
+//                          sqrtf((float)(dim - 1) + first_coordinate * first_coordinate)));
+//             // Verify that abs difference between the actual and expected score is at most
+//             1/10^6. ASSERT_NEAR(score, expected_score, 1e-5);
+//         };
+//         runBatchIteratorSearchTest(batchIterator, n_res, verify_res_batch);
+//         iteration_num++;
+//     }
+//     ASSERT_EQ(iteration_num, n / n_res);
+//     VecSimBatchIterator_Free(batchIterator);
+//     VecSimIndex_Free(index);
+// }
+
+TEST_F(HNSWMultiTest, testSizeEstimation) {
+    size_t dim = 128;
+    size_t n = 0;
+    size_t bs = DEFAULT_BLOCK_SIZE;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_Cosine,
+                                                 .multi = true,
+                                                 .initialCapacity = n,
+                                                 .blockSize = bs}};
+    float vec[dim];
+    for (size_t i = 0; i < dim; i++) {
+        vec[i] = 1.0f;
+    }
+
+    size_t estimation = VecSimIndex_EstimateInitialSize(&params);
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    size_t actual = index->getAllocator()->getAllocationSize();
+    ASSERT_EQ(estimation, actual);
+
+    estimation = VecSimIndex_EstimateElementSize(&params) * bs;
+    actual = VecSimIndex_AddVector(index, vec, 0);
+    ASSERT_GE(estimation * 1.01, actual);
+    ASSERT_LE(estimation * 0.99, actual);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, testInitialSizeEstimationWithInitialCapacity) {
+    size_t dim = 128;
+    size_t n = 100;
+    size_t bs = DEFAULT_BLOCK_SIZE;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_Cosine,
+                                                 .multi = true,
+                                                 .initialCapacity = n,
+                                                 .blockSize = bs}};
+
+    size_t estimation = VecSimIndex_EstimateInitialSize(&params);
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    size_t actual = index->getAllocator()->getAllocationSize();
+    ASSERT_EQ(estimation, actual);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, testTimeoutReturn) {
+    size_t dim = 4;
+    float vec[] = {1.0f, 1.0f, 1.0f, 1.0f};
+    VecSimQueryResult_List rl;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 1,
+                                                 .blockSize = 5}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    VecSimIndex_AddVector(index, vec, 0);
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out
+
+    // Checks return code on timeout - knn
+    rl = VecSimIndex_TopKQuery(index, vec, 1, NULL, BY_ID);
+    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+    VecSimQueryResult_Free(rl);
+
+    // Check timeout again - range query
+    // TODO: uncomment when support for BFM range is enabled
+    // rl = VecSimIndex_RangeQuery(index, vec, 1, NULL, BY_ID);
+    // ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+    // ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+    // VecSimQueryResult_Free(rl);
+
+    VecSimIndex_Free(index);
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; }); // cleanup
+}
+
+TEST_F(HNSWMultiTest, testTimeoutReturn_batch_iterator) {
+    size_t dim = 4;
+    size_t n = 10;
+    VecSimQueryResult_List rl;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = n,
+                                                 .blockSize = 5}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)i;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    float query[dim];
+    for (size_t j = 0; j < dim; j++) {
+        query[j] = (float)n;
+    }
+
+    // Fail on second batch (after calculation already completed)
+    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+
+    rl = VecSimBatchIterator_Next(batchIterator, 1, BY_ID);
+    ASSERT_EQ(rl.code, VecSim_QueryResult_OK);
+    ASSERT_NE(VecSimQueryResult_Len(rl), 0);
+    VecSimQueryResult_Free(rl);
+
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out
+    rl = VecSimBatchIterator_Next(batchIterator, 1, BY_ID);
+    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+    VecSimQueryResult_Free(rl);
+
+    VecSimBatchIterator_Free(batchIterator);
+
+    // Fail on first batch (while calculating)
+    // Timeout callback function already set to always time out
+    batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+
+    rl = VecSimBatchIterator_Next(batchIterator, 1, BY_ID);
+    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+    VecSimQueryResult_Free(rl);
+
+    VecSimBatchIterator_Free(batchIterator);
+
+    VecSimIndex_Free(index);
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; }); // cleanup
+}
+
+// TEST_F(HNSWMultiTest, rangeQuery) {
+//     size_t n = 2000;
+//     size_t dim = 4;
+
+//     VecSimParams params{
+//         .algo = VecSimAlgo_HNSWLIB,
+//         .hnswParams = HNSWParams{
+//             .type = VecSimType_FLOAT32, .dim = dim, .metric = VecSimMetric_L2, .blockSize = n /
+//             2}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, (int)i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     size_t pivot_id = n / 2; // The id to return vectors around it.
+//     float query[] = {(float)pivot_id, (float)pivot_id, (float)pivot_id, (float)pivot_id};
+
+//     // Validate invalid params are caught with runtime exception.
+//     try {
+//         VecSimIndex_RangeQuery(index, (const void *)query, -1, nullptr, BY_SCORE);
+//         FAIL();
+//     } catch (std::runtime_error const &err) {
+//         EXPECT_EQ(err.what(), std::string("radius must be non-negative"));
+//     }
+//     try {
+//         VecSimIndex_RangeQuery(index, (const void *)query, 1, nullptr,
+//         VecSimQueryResult_Order(2)); FAIL();
+//     } catch (std::runtime_error const &err) {
+//         EXPECT_EQ(err.what(), std::string("Possible order values are only 'BY_ID' or
+//         'BY_SCORE'"));
+//     }
+
+//     auto verify_res_by_score = [&](size_t id, float score, size_t index) {
+//         ASSERT_EQ(std::abs(int(id - pivot_id)), (index + 1) / 2);
+//         ASSERT_EQ(score, dim * powf((index + 1) / 2, 2));
+//     };
+//     uint expected_num_results = 11;
+//     // To get 11 results in the range [pivot_id - 5, pivot_id + 5], set the radius as the L2
+//     score
+//     // in the boundaries.
+//     float radius = dim * powf(expected_num_results / 2, 2);
+//     runRangeQueryTest(index, query, radius, verify_res_by_score, expected_num_results, BY_SCORE);
+
+//     // Get results by id.
+//     auto verify_res_by_id = [&](size_t id, float score, size_t index) {
+//         ASSERT_EQ(id, pivot_id - expected_num_results / 2 + index);
+//         ASSERT_EQ(score, dim * pow(std::abs(int(id - pivot_id)), 2));
+//     };
+//     runRangeQueryTest(index, query, radius, verify_res_by_id, expected_num_results);
+
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWMultiTest, rangeQueryCosine) {
+//     size_t n = 100;
+//     size_t dim = 4;
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                              .dim = dim,
+//                                              .metric = VecSimMetric_Cosine,
+//                                              .blockSize = n / 2}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         f[0] = float(i + 1) / n;
+//         for (size_t j = 1; j < dim; j++) {
+//             f[j] = 1.0f;
+//         }
+//         // Use as label := n - (internal id)
+//         VecSimIndex_AddVector(index, (const void *)f, n - i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+//     float query[dim];
+//     for (size_t i = 0; i < dim; i++) {
+//         query[i] = 1.0f;
+//     }
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         ASSERT_EQ(id, index + 1);
+//         float first_coordinate = float(n - index) / n;
+//         // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query
+//         vector
+//         // and B is the current result vector.
+//         float expected_score =
+//             1.0f -
+//             ((first_coordinate + (float)dim - 1.0f) /
+//              (sqrtf((float)dim) * sqrtf((float)(dim - 1) + first_coordinate *
+//              first_coordinate)));
+//         // Verify that abs difference between the actual and expected score is at most 1/10^5.
+//         ASSERT_NEAR(score, expected_score, 1e-5);
+//     };
+//     uint expected_num_results = 31;
+//     // Calculate the score of the 31st distant vector from the query vector (whose id should be
+//     30)
+//     // to get the radius.
+//     float edge_first_coordinate = (float)(n - expected_num_results + 1) / n;
+//     float radius =
+//         1.0f - ((edge_first_coordinate + (float)dim - 1.0f) /
+//                 (sqrtf((float)dim) *
+//                  sqrtf((float)(dim - 1) + edge_first_coordinate * edge_first_coordinate)));
+//     runRangeQueryTest(index, query, radius, verify_res, expected_num_results, BY_SCORE);
+//     // Return results BY_ID should give the same results.
+//     runRangeQueryTest(index, query, radius, verify_res, expected_num_results, BY_ID);
+
+//     VecSimIndex_Free(index);
+// }

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -50,49 +50,6 @@ TEST_F(HNSWMultiTest, vector_add_multiple_test) {
     VecSimIndex_Free(index);
 }
 
-/**** resizing cases ****/
-
-TEST_F(HNSWMultiTest, resizeNAlignIndex) {
-    size_t dim = 4;
-    size_t n = 10;
-    size_t bs = 3;
-    size_t n_labels = 3;
-
-    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-                                                 .dim = dim,
-                                                 .metric = VecSimMetric_L2,
-                                                 .multi = true,
-                                                 .initialCapacity = n,
-                                                 .blockSize = bs}};
-    VecSimIndex *index = VecSimIndex_New(&params);
-    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
-
-    float a[dim];
-
-    // Add up to n.
-    for (size_t i = 0; i < n; i++) {
-        for (size_t j = 0; j < dim; j++) {
-            a[j] = (float)i;
-        }
-        VecSimIndex_AddVector(index, (const void *)a, i % n_labels);
-    }
-    // The size and the capacity should be equal.
-    HNSWIndex<float, float> *hnswIndex = reinterpret_cast<HNSWIndex<float, float> *>(index);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), VecSimIndex_IndexSize(index));
-    // The capacity shouldn't be changed.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
-
-    // Add another vector to exceed the initial capacity.
-    VecSimIndex_AddVector(index, (const void *)a, n);
-
-    // The capacity should be now aligned with the block size.
-    // bs = 3, size = 11 -> capacity = 12
-    // New capacity = initial capacity + blockSize - initial capacity % blockSize.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n + bs - n % bs);
-    VecSimIndex_Free(index);
-}
-
 // Test empty index edge cases.
 TEST_F(HNSWMultiTest, empty_index) {
     size_t dim = 4;
@@ -575,6 +532,10 @@ TEST_F(HNSWMultiTest, test_dynamic_hnsw_info_iterator) {
 
     // Set the index size artificially so that BATCHES mode will be selected by the heuristics.
     reinterpret_cast<HNSWIndex<float, float> *>(index)->cur_element_count = 1e6;
+    vecsim_stl::vector<idType> vec(index->getAllocator());
+    for (size_t i = 0; i < 1e5; i++) {
+        reinterpret_cast<HNSWIndex_Multi<float, float> *>(index)->label_lookup_.emplace(i, vec);
+    }
     ASSERT_FALSE(VecSimIndex_PreferAdHocSearch(index, 10, 1, true));
     info = VecSimIndex_Info(index);
     infoIter = VecSimIndex_InfoIterator(index);
@@ -594,37 +555,39 @@ TEST_F(HNSWMultiTest, test_dynamic_hnsw_info_iterator) {
     VecSimIndex_Free(index);
 }
 
+// TODO: test different label count.
 TEST_F(HNSWMultiTest, preferAdHocOptimization) {
     // Save the expected result for every combination that represent a different leaf in the tree.
     // map: [k, index_size, dim, M, r] -> res
     std::map<std::vector<float>, bool> combinations;
-    combinations[{5, 1000, 5, 5, 0.5}] = true;
-    combinations[{5, 6000, 5, 5, 0.1}] = true;
-    combinations[{5, 6000, 5, 5, 0.2}] = false;
-    combinations[{5, 6000, 60, 5, 0.5}] = false;
-    combinations[{5, 6000, 60, 15, 0.5}] = true;
-    combinations[{15, 6000, 50, 5, 0.5}] = true;
-    combinations[{5, 700000, 60, 5, 0.05}] = true;
-    combinations[{5, 800000, 60, 5, 0.05}] = false;
-    combinations[{10, 800000, 60, 5, 0.01}] = true;
-    combinations[{10, 800000, 60, 5, 0.05}] = false;
-    combinations[{10, 800000, 60, 5, 0.1}] = false;
-    combinations[{10, 60000, 100, 5, 0.1}] = true;
-    combinations[{10, 80000, 100, 5, 0.1}] = false;
-    combinations[{10, 60000, 100, 60, 0.1}] = true;
-    combinations[{10, 60000, 100, 5, 0.3}] = false;
-    combinations[{20, 60000, 100, 5, 0.1}] = true;
-    combinations[{20, 60000, 100, 5, 0.2}] = false;
-    combinations[{20, 60000, 100, 20, 0.1}] = true;
-    combinations[{20, 350000, 100, 20, 0.1}] = true;
-    combinations[{20, 350000, 100, 20, 0.2}] = false;
+    combinations[{5, 1000, 1000, 5, 5, 0.5}] = true;
+    combinations[{5, 6000, 6000, 5, 5, 0.1}] = true;
+    combinations[{5, 6000, 6000, 5, 5, 0.2}] = false;
+    combinations[{5, 6000, 6000, 60, 5, 0.5}] = false;
+    combinations[{5, 6000, 6000, 60, 15, 0.5}] = true;
+    combinations[{15, 6000, 6000, 50, 5, 0.5}] = true;
+    combinations[{5, 700000, 700000, 60, 5, 0.05}] = true;
+    combinations[{5, 800000, 800000, 60, 5, 0.05}] = false;
+    combinations[{10, 800000, 800000, 60, 5, 0.01}] = true;
+    combinations[{10, 800000, 800000, 60, 5, 0.05}] = false;
+    combinations[{10, 800000, 800000, 60, 5, 0.1}] = false;
+    combinations[{10, 60000, 60000, 100, 5, 0.1}] = true;
+    combinations[{10, 80000, 80000, 100, 5, 0.1}] = false;
+    combinations[{10, 60000, 60000, 100, 60, 0.1}] = true;
+    combinations[{10, 60000, 60000, 100, 5, 0.3}] = false;
+    combinations[{20, 60000, 60000, 100, 5, 0.1}] = true;
+    combinations[{20, 60000, 60000, 100, 5, 0.2}] = false;
+    combinations[{20, 60000, 60000, 100, 20, 0.1}] = true;
+    combinations[{20, 350000, 350000, 100, 20, 0.1}] = true;
+    combinations[{20, 350000, 350000, 100, 20, 0.2}] = false;
 
     for (auto &comb : combinations) {
         auto k = (size_t)comb.first[0];
         auto index_size = (size_t)comb.first[1];
-        auto dim = (size_t)comb.first[2];
-        auto M = (size_t)comb.first[3];
-        auto r = comb.first[4];
+        auto label_count = (size_t)comb.first[2];
+        auto dim = (size_t)comb.first[3];
+        auto M = (size_t)comb.first[4];
+        auto r = comb.first[5];
 
         // Create index and check for the expected output of "prefer ad-hoc" heuristics.
         VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
@@ -640,6 +603,10 @@ TEST_F(HNSWMultiTest, preferAdHocOptimization) {
 
         // Set the index size artificially to be the required one.
         reinterpret_cast<HNSWIndex<float, float> *>(index)->cur_element_count = index_size;
+        vecsim_stl::vector<idType> vec(index->getAllocator());
+        for (size_t i = 0; i < label_count; i++) {
+            reinterpret_cast<HNSWIndex_Multi<float, float> *>(index)->label_lookup_.emplace(i, vec);
+        }
         ASSERT_EQ(VecSimIndex_IndexSize(index), index_size);
         bool res = VecSimIndex_PreferAdHocSearch(index, (size_t)(r * (float)index_size), k, true);
         ASSERT_EQ(res, comb.second);
@@ -830,6 +797,1173 @@ TEST_F(HNSWMultiTest, remove_vector_after_replacing_block) {
 
     VecSimIndex_Free(index);
 }
+
+TEST_F(HNSWMultiTest, hnsw_get_distance) {
+    size_t n_labels = 2;
+    size_t dim = 2;
+    size_t numIndex = 3;
+    VecSimIndex *index[numIndex];
+    std::vector<double> distances;
+
+    float v1_0[] = {M_PI, M_PI};
+    float v2_0[] = {M_E, M_E};
+    float v3_1[] = {M_PI, M_E};
+    float v4_1[] = {M_SQRT2, -M_SQRT2};
+
+    VecSimParams params{
+        .algo = VecSimAlgo_HNSWLIB,
+        .hnswParams = HNSWParams{
+            .type = VecSimType_FLOAT32, .dim = dim, .multi = true, .initialCapacity = 4}};
+
+    for (size_t i = 0; i < numIndex; i++) {
+        params.hnswParams.metric = (VecSimMetric)i;
+        index[i] = VecSimIndex_New(&params);
+        VecSimIndex_AddVector(index[i], v1_0, 0);
+        VecSimIndex_AddVector(index[i], v2_0, 0);
+        VecSimIndex_AddVector(index[i], v3_1, 1);
+        VecSimIndex_AddVector(index[i], v4_1, 1);
+        ASSERT_EQ(VecSimIndex_IndexSize(index[i]), 4);
+    }
+
+    void *query = v1_0;
+    void *norm = v2_0;                               // {e, e}
+    VecSim_Normalize(norm, dim, VecSimType_FLOAT32); // now {1/sqrt(2), 1/sqrt(2)}
+    ASSERT_FLOAT_EQ(((float *)norm)[0], 1.0f / sqrt(2.0f));
+    ASSERT_FLOAT_EQ(((float *)norm)[1], 1.0f / sqrt(2.0f));
+    double dist;
+
+    // VecSimMetric_L2
+    // distances are [[0.000, 0.358], [0.179, 23.739]]
+    // minimum of each label are:
+    distances = {0, 0.1791922003030777};
+    for (size_t i = 0; i < n_labels; i++) {
+        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], i, query);
+        ASSERT_DOUBLE_EQ(dist, distances[i]);
+    }
+
+    // VecSimMetric_IP
+    // distances are [[-18.739, -16.079], [-17.409, 1.000]]
+    // minimum of each label are:
+    distances = {-18.73921012878418, -17.409339904785156};
+    for (size_t i = 0; i < n_labels; i++) {
+        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_IP], i, query);
+        ASSERT_DOUBLE_EQ(dist, distances[i]);
+    }
+
+    // VecSimMetric_Cosine
+    // distances are [[5.960e-08, 5.960e-08], [0.0026, 1.000]]
+    // minimum of each label are:
+    distances = {5.9604644775390625e-08, 0.0025991201400756836};
+    for (size_t i = 0; i < n_labels; i++) {
+        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], i, norm);
+        ASSERT_DOUBLE_EQ(dist, distances[i]);
+    }
+
+    // Bad values
+    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], -1, norm);
+    ASSERT_TRUE(std::isnan(dist));
+    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], 46, query);
+    ASSERT_TRUE(std::isnan(dist));
+
+    // Clean-up.
+    for (size_t i = 0; i < numIndex; i++) {
+        VecSimIndex_Free(index[i]);
+    }
+}
+
+TEST_F(HNSWMultiTest, testSizeEstimation) {
+    size_t dim = 128;
+    size_t n = 1000;
+    size_t bs = DEFAULT_BLOCK_SIZE;
+    size_t M = 32;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = n,
+                                                 .blockSize = bs,
+                                                 .M = M}};
+
+    size_t estimation = VecSimIndex_EstimateInitialSize(&params);
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    size_t actual = index->getAllocator()->getAllocationSize();
+    // labels_lookup hash table has additional memory, since STL implementation chooses "an
+    // appropriate prime number" higher than n as the number of allocated buckets (for n=1000, 1031
+    // buckets are created)
+    estimation +=
+        (reinterpret_cast<HNSWIndex_Multi<float, float> *>(index)->label_lookup_.bucket_count() -
+         n) *
+        sizeof(size_t);
+
+    ASSERT_EQ(estimation, actual);
+
+    float vec[dim];
+    for (size_t i = 0; i < n; i++) {
+        for (size_t j = 0; j < dim; j++) {
+            vec[j] = (float)i;
+        }
+        VecSimIndex_AddVector(index, vec, i);
+    }
+
+    // Estimate the memory delta of adding a full new block.
+    estimation = VecSimIndex_EstimateElementSize(&params) * (bs % n + bs);
+
+    actual = 0;
+    for (size_t i = 0; i < bs; i++) {
+        for (size_t j = 0; j < dim; j++) {
+            vec[j] = (float)i;
+        }
+        actual += VecSimIndex_AddVector(index, vec, n + i);
+    }
+    ASSERT_GE(estimation * 1.01, actual);
+    ASSERT_LE(estimation * 0.99, actual);
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, testInitialSizeEstimation_No_InitialCapacity) {
+    size_t dim = 128;
+    size_t n = 0;
+    size_t bs = DEFAULT_BLOCK_SIZE;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_Cosine,
+                                                 .multi = true,
+                                                 .initialCapacity = n,
+                                                 .blockSize = bs}};
+
+    VecSimIndex *index = VecSimIndex_New(&params);
+    size_t estimation = VecSimIndex_EstimateInitialSize(&params);
+
+    size_t actual = index->getAllocator()->getAllocationSize();
+
+    // labels_lookup and element_levels containers are not allocated at all in some platforms,
+    // when initial capacity is zero, while in other platforms labels_lookup is allocated with a
+    // single bucket. This, we get the following range in which we expect the initial memory to be
+    // in.
+    ASSERT_GE(actual, estimation);
+    ASSERT_LE(actual, estimation + sizeof(size_t) + 2 * sizeof(size_t));
+
+    VecSimIndex_Free(index);
+}
+
+TEST_F(HNSWMultiTest, testTimeoutReturn) {
+    size_t dim = 4;
+    float vec[] = {1.0f, 1.0f, 1.0f, 1.0f};
+    VecSimQueryResult_List rl;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = 1,
+                                                 .blockSize = 5}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    VecSimIndex_AddVector(index, vec, 0);
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out
+
+    // Checks return code on timeout - knn
+    rl = VecSimIndex_TopKQuery(index, vec, 1, NULL, BY_ID);
+    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+    VecSimQueryResult_Free(rl);
+
+    // Check timeout again - range query
+    // TODO: uncomment when support for BFM range is enabled
+    // rl = VecSimIndex_RangeQuery(index, vec, 1, NULL, BY_ID);
+    // ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+    // ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+    // VecSimQueryResult_Free(rl);
+
+    VecSimIndex_Free(index);
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; }); // cleanup
+}
+
+TEST_F(HNSWMultiTest, testTimeoutReturn_batch_iterator) {
+    size_t dim = 4;
+    size_t n = 10;
+    VecSimQueryResult_List rl;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = n,
+                                                 .blockSize = 5}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    for (size_t i = 0; i < n; i++) {
+        float f[dim];
+        for (size_t j = 0; j < dim; j++) {
+            f[j] = (float)i;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    float query[dim];
+    for (size_t j = 0; j < dim; j++) {
+        query[j] = (float)n;
+    }
+
+    // Fail on second batch (after calculation already completed)
+    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+
+    rl = VecSimBatchIterator_Next(batchIterator, 1, BY_ID);
+    ASSERT_EQ(rl.code, VecSim_QueryResult_OK);
+    ASSERT_NE(VecSimQueryResult_Len(rl), 0);
+    VecSimQueryResult_Free(rl);
+
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out
+    rl = VecSimBatchIterator_Next(batchIterator, 1, BY_ID);
+    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+    VecSimQueryResult_Free(rl);
+
+    VecSimBatchIterator_Free(batchIterator);
+
+    // Fail on first batch (while calculating)
+    // Timeout callback function already set to always time out
+    batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+
+    rl = VecSimBatchIterator_Next(batchIterator, 1, BY_ID);
+    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+    VecSimQueryResult_Free(rl);
+
+    VecSimBatchIterator_Free(batchIterator);
+
+    VecSimIndex_Free(index);
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; }); // cleanup
+}
+
+// TEST_F(HNSWTest, hnsw_vector_add_test) {
+//     size_t dim = 4;
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = 200,
+//                                                  .M = 16,
+//                                                  .efConstruction = 200}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     float a[dim];
+//     for (size_t i = 0; i < dim; i++) {
+//         a[i] = (float)i;
+//     }
+//     VecSimIndex_AddVector(index, (const void *)a, 1);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 1);
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, hnsw_blob_sanity_test) {
+//     size_t dim = 4;
+//     size_t bs = 1;
+#define ASSERT_HNSW_BLOB_EQ(id, blob)                                                              \
+    do {                                                                                           \
+        void *v = hnsw_index->getDataByInternalId(id);                                             \
+        ASSERT_FALSE(memcmp(v, blob, sizeof(blob)));                                               \
+    } while (0)
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{
+//                             .type = VecSimType_FLOAT32,
+//                             .dim = dim,
+//                             .metric = VecSimMetric_L2,
+//                             .blockSize = bs,
+//                         }};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     float a[dim], b[dim], c[dim], d[dim];
+//     for (size_t i = 0; i < dim; i++) {
+//         a[i] = (float)0;
+//         b[i] = (float)1;
+//         c[i] = (float)2;
+//         d[i] = (float)3;
+//     }
+//     HNSWIndex<float, float> *hnsw_index = reinterpret_cast<HNSWIndex<float, float> *>(index);
+
+//     VecSimIndex_AddVector(index, (const void *)a, 42);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 1);
+//     ASSERT_HNSW_BLOB_EQ(0, a);
+//     ASSERT_EQ(hnsw_index->getExternalLabel(0), 42);
+
+//     VecSimIndex_AddVector(index, (const void *)b, 46);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 2);
+//     ASSERT_HNSW_BLOB_EQ(1, b);
+//     ASSERT_EQ(hnsw_index->getExternalLabel(1), 46);
+
+//     // After inserting c with label 46, we first delete id 1 from the index.
+//     // we expect id 0 to not change
+//     VecSimIndex_AddVector(index, (const void *)c, 46);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 2);
+//     ASSERT_HNSW_BLOB_EQ(0, a);
+//     ASSERT_HNSW_BLOB_EQ(1, c);
+//     ASSERT_EQ(hnsw_index->getExternalLabel(0), 42);
+//     ASSERT_EQ(hnsw_index->getExternalLabel(1), 46);
+
+//     // After inserting d with label 42, we first delete id 0 and move the last id (1) to be 0.
+//     // Then we add the new vector d under the internal id 1.
+//     VecSimIndex_AddVector(index, (const void *)d, 42);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 2);
+//     ASSERT_HNSW_BLOB_EQ(0, c);
+//     ASSERT_HNSW_BLOB_EQ(1, d);
+//     ASSERT_EQ(hnsw_index->getExternalLabel(0), 46);
+//     ASSERT_EQ(hnsw_index->getExternalLabel(1), 42);
+
+//     VecSimIndex_Free(index);
+// }
+
+/**** resizing cases ****/
+
+// Add up to capacity.
+TEST_F(HNSWMultiTest, resizeNAlignIndex) {
+    size_t dim = 4;
+    size_t n = 10;
+    size_t bs = 3;
+    size_t n_labels = 3;
+
+    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                                                 .dim = dim,
+                                                 .metric = VecSimMetric_L2,
+                                                 .multi = true,
+                                                 .initialCapacity = n,
+                                                 .blockSize = bs}};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    float a[dim];
+
+    // Add up to n.
+    for (size_t i = 0; i < n; i++) {
+        for (size_t j = 0; j < dim; j++) {
+            a[j] = (float)i;
+        }
+        VecSimIndex_AddVector(index, (const void *)a, i % n_labels);
+    }
+    // The size and the capacity should be equal.
+    HNSWIndex<float, float> *hnswIndex = reinterpret_cast<HNSWIndex<float, float> *>(index);
+    ASSERT_EQ(hnswIndex->getIndexCapacity(), VecSimIndex_IndexSize(index));
+    // The capacity shouldn't be changed.
+    ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+
+    // Add another vector to exceed the initial capacity.
+    VecSimIndex_AddVector(index, (const void *)a, n);
+
+    // The capacity should be now aligned with the block size.
+    // bs = 3, size = 11 -> capacity = 12
+    // New capacity = initial capacity + blockSize - initial capacity % blockSize.
+    ASSERT_EQ(hnswIndex->getIndexCapacity(), n + bs - n % bs);
+    VecSimIndex_Free(index);
+}
+
+// // Case 1: initial capacity is larger than block size, and it is not aligned.
+// TEST_F(HNSWTest, resizeNAlignIndex_largeInitialCapacity) {
+//     size_t dim = 4;
+//     size_t n = 10;
+//     size_t bs = 3;
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .blockSize = bs}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     float a[dim];
+
+//     // add up to blocksize + 1 = 3 + 1 = 4
+//     for (size_t i = 0; i < bs + 1; i++) {
+//         for (size_t j = 0; j < dim; j++) {
+//             a[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)a, i);
+//     }
+
+//     // The capacity shouldn't change, should remain n.
+//     HNSWIndex<float, float> *hnswIndex = reinterpret_cast<HNSWIndex<float, float> *>(index);
+//     ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+
+//     // Delete last vector, to get size % block_size == 0. size = 3
+//     VecSimIndex_DeleteVector(index, bs);
+
+//     // Index size = bs = 3.
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), bs);
+
+//     // New capacity = initial capacity - block_size - number_of_vectors_to_align =
+//     // 10  - 3 - 10 % 3 (1) = 6
+//     size_t curr_capacity = hnswIndex->getIndexCapacity();
+//     ASSERT_EQ(curr_capacity, n - bs - n % bs);
+
+//     // Delete all the vectors to decrease capacity by another bs.
+//     size_t i = 0;
+//     while (VecSimIndex_IndexSize(index) > 0) {
+//         VecSimIndex_DeleteVector(index, i);
+//         ++i;
+//     }
+//     ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+//     // Add and delete a vector to achieve:
+//     // size % block_size == 0 && size + bs <= capacity(3).
+//     // the capacity should be resized to zero
+//     VecSimIndex_AddVector(index, (const void *)a, 0);
+//     VecSimIndex_DeleteVector(index, 0);
+//     ASSERT_EQ(hnswIndex->getIndexCapacity(), 0);
+
+//     // Do it again. This time after adding a vector the capacity is increased by bs.
+//     // Upon deletion it will be resized to zero again.
+//     VecSimIndex_AddVector(index, (const void *)a, 0);
+//     ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+//     VecSimIndex_DeleteVector(index, 0);
+//     ASSERT_EQ(hnswIndex->getIndexCapacity(), 0);
+
+//     VecSimIndex_Free(index);
+// }
+
+// // Case 2: initial capacity is smaller than block_size.
+// TEST_F(HNSWTest, resizeNAlignIndex_largerBlockSize) {
+//     size_t dim = 4;
+//     size_t n = 4;
+//     size_t bs = 6;
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .blockSize = bs}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     float a[dim];
+
+//     // Add up to initial capacity.
+//     for (size_t i = 0; i < n; i++) {
+//         for (size_t j = 0; j < dim; j++) {
+//             a[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)a, i);
+//     }
+
+//     HNSWIndex<float, float> *hnswIndex = reinterpret_cast<HNSWIndex<float, float> *>(index);
+//     // The capacity shouldn't change.
+//     ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+
+//     // Size equals capacity.
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     // Add another vector - > the capacity is increased to a multiplication of block_size.
+//     VecSimIndex_AddVector(index, (const void *)a, n);
+//     ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+
+//     // Size increased by 1.
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n + 1);
+
+//     // Delete random vector.
+//     VecSimIndex_DeleteVector(index, 1);
+
+//     // The capacity should remain the same.
+//     ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+
+//     VecSimIndex_Free(index);
+// }
+
+// // Test empty index edge cases.
+// TEST_F(HNSWTest, emptyIndex) {
+//     size_t dim = 4;
+//     size_t n = 20;
+//     size_t bs = 6;
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .blockSize = bs}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     // Try to remove from an empty index - should fail because label doesn't exist.
+//     VecSimIndex_DeleteVector(index, 0);
+
+//     // Add one vector.
+//     float a[dim];
+//     for (size_t j = 0; j < dim; j++) {
+//         a[j] = (float)1.7;
+//     }
+
+//     VecSimIndex_AddVector(index, (const void *)a, 1);
+//     // Try to remove it.
+//     VecSimIndex_DeleteVector(index, 1);
+//     // The capacity should change to be aligned with the vector size.
+
+//     HNSWIndex<float, float> *hnswIndex = reinterpret_cast<HNSWIndex<float, float> *>(index);
+//     size_t new_capacity = hnswIndex->getIndexCapacity();
+//     ASSERT_EQ(new_capacity, n - n % bs - bs);
+
+//     // Size equals 0.
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     // Try to remove it again.
+//     // The capacity should remain unchanged, as we are trying to delete a label that doesn't
+//     exist. VecSimIndex_DeleteVector(index, 1); ASSERT_EQ(hnswIndex->getIndexCapacity(),
+//     new_capacity);
+//     // Nor the size.
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, hnsw_vector_search_test) {
+//     size_t n = 100;
+//     size_t k = 11;
+//     size_t dim = 4;
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = 200,
+//                                                  .M = 16,
+//                                                  .efConstruction = 200}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, (size_t)i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     float query[] = {50, 50, 50, 50};
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         size_t diff_id = ((int)(id - 50) > 0) ? (id - 50) : (50 - id);
+//         ASSERT_EQ(diff_id, (index + 1) / 2);
+//         ASSERT_EQ(score, (4 * ((index + 1) / 2) * ((index + 1) / 2)));
+//     };
+//     runTopKSearchTest(index, query, k, verify_res);
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, hnsw_vector_search_by_id_test) {
+//     size_t n = 100;
+//     size_t dim = 4;
+//     size_t k = 11;
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = 200,
+//                                                  .M = 16,
+//                                                  .efConstruction = 200}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, (int)i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     float query[] = {50, 50, 50, 50};
+//     auto verify_res = [&](size_t id, float score, size_t index) { ASSERT_EQ(id, (index + 45)); };
+//     runTopKSearchTest(index, query, k, verify_res, nullptr, BY_ID);
+
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, hnsw_indexing_same_vector) {
+//     size_t n = 100;
+//     size_t dim = 4;
+//     size_t k = 10;
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = 200,
+//                                                  .M = 16,
+//                                                  .efConstruction = 200}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)(i / 10);
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     // Run a query where all the results are supposed to be {5,5,5,5} (different ids).
+//     float query[] = {4.9, 4.95, 5.05, 5.1};
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         ASSERT_TRUE(id >= 50 && id < 60 && score <= 1);
+//     };
+//     runTopKSearchTest(index, query, k, verify_res);
+
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, hnsw_reindexing_same_vector) {
+//     size_t n = 100;
+//     size_t dim = 4;
+//     size_t k = 10;
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = 200,
+//                                                  .M = 16,
+//                                                  .efConstruction = 200}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)(i / 10); // i / 10 is in integer (take the "floor" value)
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     // Run a query where all the results are supposed to be {5,5,5,5} (different ids).
+//     float query[] = {4.9, 4.95, 5.05, 5.1};
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         ASSERT_TRUE(id >= 50 && id < 60 && score <= 1);
+//     };
+//     runTopKSearchTest(index, query, k, verify_res);
+
+//     for (size_t i = 0; i < n; i++) {
+//         VecSimIndex_DeleteVector(index, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     // Reinsert the same vectors under the same ids
+//     for (size_t i = 0; i < n; i++) {
+//         float num = (float)(i / 10);
+//         float f[] = {num, num, num, num};
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     // Run the same query again
+//     runTopKSearchTest(index, query, k, verify_res);
+
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, hnsw_reindexing_same_vector_different_id) {
+//     size_t n = 100;
+//     size_t dim = 4;
+//     size_t k = 10;
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = 200,
+//                                                  .M = 16,
+//                                                  .efConstruction = 200}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)(i / 10); // i / 10 is in integer (take the "floor" value)
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     // Run a query where all the results are supposed to be {5,5,5,5} (different ids).
+//     float query[] = {4.9, 4.95, 5.05, 5.1};
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         ASSERT_TRUE(id >= 50 && id < 60 && score <= 1);
+//     };
+//     runTopKSearchTest(index, query, k, verify_res);
+
+//     for (size_t i = 0; i < n; i++) {
+//         VecSimIndex_DeleteVector(index, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     // Reinsert the same vectors under different ids than before
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)(i / 10); // i / 10 is in integer (take the "floor" value)
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i + 10);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     // Run the same query again
+//     auto verify_res_different_id = [&](int id, float score, size_t index) {
+//         ASSERT_TRUE(id >= 60 && id < 70 && score <= 1);
+//     };
+//     runTopKSearchTest(index, query, k, verify_res_different_id);
+
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, sanity_reinsert_1280) {
+//     size_t n = 5;
+//     size_t d = 1280;
+//     size_t k = 5;
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = d,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .M = 16,
+//                                                  .efConstruction = 200}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     auto *vectors = (float *)malloc(n * d * sizeof(float));
+
+//     // Generate random vectors in every iteration and inert them under different ids.
+//     for (size_t iter = 1; iter <= 3; iter++) {
+//         for (size_t i = 0; i < n; i++) {
+//             for (size_t j = 0; j < d; j++) {
+//                 (vectors + i * d)[j] = (float)rand() / (float)(RAND_MAX) / 100;
+//             }
+//         }
+//         auto expected_ids = std::set<size_t>();
+//         for (size_t i = 0; i < n; i++) {
+//             VecSimIndex_AddVector(index, (const void *)(vectors + i * d), i * iter);
+//             expected_ids.insert(i * iter);
+//         }
+//         auto verify_res = [&](size_t id, float score, size_t index) {
+//             ASSERT_TRUE(expected_ids.find(id) != expected_ids.end());
+//             expected_ids.erase(id);
+//         };
+
+//         // Send arbitrary vector (the first) and search for top k. This should return all the
+//         // vectors that were inserted in this iteration - verify their ids.
+//         runTopKSearchTest(index, (const void *)vectors, k, verify_res);
+
+//         // Remove vectors form current iteration.
+//         for (size_t i = 0; i < n; i++) {
+//             VecSimIndex_DeleteVector(index, i * iter);
+//         }
+//     }
+//     free(vectors);
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, test_hnsw_info) {
+//     size_t n = 100;
+//     size_t d = 128;
+
+//     // Build with default args
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = d,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .M = 16,
+//                                                  .efConstruction = 200}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+//     VecSimIndexInfo info = VecSimIndex_Info(index);
+//     ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
+//     ASSERT_EQ(info.hnswInfo.dim, d);
+//     // Default args.
+//     ASSERT_EQ(info.hnswInfo.blockSize, DEFAULT_BLOCK_SIZE);
+//     ASSERT_EQ(info.hnswInfo.M, HNSW_DEFAULT_M);
+//     ASSERT_EQ(info.hnswInfo.efConstruction, HNSW_DEFAULT_EF_C);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
+//     ASSERT_DOUBLE_EQ(info.hnswInfo.epsilon, HNSW_DEFAULT_EPSILON);
+//     VecSimIndex_Free(index);
+
+//     d = 1280;
+//     size_t bs = 42;
+//     params = {.algo = VecSimAlgo_HNSWLIB,
+//               .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                        .dim = d,
+//                                        .metric = VecSimMetric_L2,
+//                                        .initialCapacity = n,
+//                                        .blockSize = bs,
+//                                        .M = 200,
+//                                        .efConstruction = 1000,
+//                                        .efRuntime = 500,
+//                                        .epsilon = 0.005}};
+//     index = VecSimIndex_New(&params);
+//     info = VecSimIndex_Info(index);
+//     ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
+//     ASSERT_EQ(info.hnswInfo.dim, d);
+//     // User args.
+//     ASSERT_EQ(info.hnswInfo.blockSize, bs);
+//     ASSERT_EQ(info.hnswInfo.efConstruction, 1000);
+//     ASSERT_EQ(info.hnswInfo.M, 200);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, 500);
+//     ASSERT_EQ(info.hnswInfo.epsilon, 0.005);
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, test_basic_hnsw_info_iterator) {
+//     size_t n = 100;
+//     size_t d = 128;
+
+//     VecSimMetric metrics[3] = {VecSimMetric_Cosine, VecSimMetric_IP, VecSimMetric_L2};
+//     for (size_t i = 0; i < 3; i++) {
+//         // Build with default args.
+//         VecSimParams params{
+//             .algo = VecSimAlgo_HNSWLIB,
+//             .hnswParams = HNSWParams{
+//                 .type = VecSimType_FLOAT32, .dim = d, .metric = metrics[i], .initialCapacity =
+//                 n}};
+//         VecSimIndex *index = VecSimIndex_New(&params);
+//         VecSimIndexInfo info = VecSimIndex_Info(index);
+//         VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(index);
+//         compareHNSWIndexInfoToIterator(info, infoIter);
+//         VecSimInfoIterator_Free(infoIter);
+//         VecSimIndex_Free(index);
+//     }
+// }
+
+// TEST_F(HNSWTest, test_query_runtime_params_default_build_args) {
+//     size_t n = 100;
+//     size_t d = 4;
+//     size_t k = 11;
+
+//     // Build with default args.
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = d,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .M = 16,
+//                                                  .efConstruction = 200}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 0; i < n; i++) {
+//         float f[d];
+//         for (size_t j = 0; j < d; j++) {
+//             f[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         size_t diff_id = ((int)(id - 50) > 0) ? (id - 50) : (50 - id);
+//         ASSERT_EQ(diff_id, (index + 1) / 2);
+//         ASSERT_EQ(score, (4 * ((index + 1) / 2) * ((index + 1) / 2)));
+//     };
+//     float query[] = {50, 50, 50, 50};
+//     runTopKSearchTest(index, query, k, verify_res);
+
+//     VecSimIndexInfo info = VecSimIndex_Info(index);
+//     // Check that default args did not change.
+//     ASSERT_EQ(info.hnswInfo.M, HNSW_DEFAULT_M);
+//     ASSERT_EQ(info.hnswInfo.efConstruction, HNSW_DEFAULT_EF_C);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
+
+//     // Run same query again, set efRuntime to 300.
+//     VecSimQueryParams queryParams{.hnswRuntimeParams = HNSWRuntimeParams{.efRuntime = 300}};
+//     runTopKSearchTest(index, query, k, verify_res, &queryParams);
+
+//     info = VecSimIndex_Info(index);
+//     // Check that default args did not change.
+//     ASSERT_EQ(info.hnswInfo.M, HNSW_DEFAULT_M);
+//     ASSERT_EQ(info.hnswInfo.efConstruction, HNSW_DEFAULT_EF_C);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
+
+//     // Create batch iterator without query param - verify that ef_runtime didn't change.
+//     VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+//     info = VecSimIndex_Info(index);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
+//     // Run one batch for sanity.
+//     runBatchIteratorSearchTest(batchIterator, k, verify_res);
+//     // After releasing the batch iterator, ef_runtime should return to the default one.
+//     VecSimBatchIterator_Free(batchIterator);
+//     info = VecSimIndex_Info(index);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
+
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, test_query_runtime_params_user_build_args) {
+//     size_t n = 100;
+//     size_t d = 4;
+//     size_t M = 100;
+//     size_t efConstruction = 300;
+//     size_t efRuntime = 500;
+//     // Build with default args.
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = d,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .M = M,
+//                                                  .efConstruction = efConstruction,
+//                                                  .efRuntime = efRuntime}};
+
+//     size_t k = 11;
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     for (size_t i = 0; i < n; i++) {
+//         float f[d];
+//         for (size_t j = 0; j < d; j++) {
+//             f[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         size_t diff_id = ((int)(id - 50) > 0) ? (id - 50) : (50 - id);
+//         ASSERT_EQ(diff_id, (index + 1) / 2);
+//         ASSERT_EQ(score, (4 * ((index + 1) / 2) * ((index + 1) / 2)));
+//     };
+//     float query[] = {50, 50, 50, 50};
+//     runTopKSearchTest(index, query, k, verify_res);
+
+//     VecSimIndexInfo info = VecSimIndex_Info(index);
+//     // Check that user args did not change.
+//     ASSERT_EQ(info.hnswInfo.M, M);
+//     ASSERT_EQ(info.hnswInfo.efConstruction, efConstruction);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, efRuntime);
+
+//     // Run same query again, set efRuntime to 300.
+//     VecSimQueryParams queryParams{.hnswRuntimeParams = HNSWRuntimeParams{.efRuntime = 300}};
+//     runTopKSearchTest(index, query, k, verify_res, &queryParams);
+
+//     info = VecSimIndex_Info(index);
+//     // Check that user args did not change.
+//     ASSERT_EQ(info.hnswInfo.M, M);
+//     ASSERT_EQ(info.hnswInfo.efConstruction, efConstruction);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, efRuntime);
+
+//     // Create batch iterator with query param - verify that ef_runtime is set.
+//     VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, &queryParams);
+//     info = VecSimIndex_Info(index);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, 300);
+//     // Run one batch for sanity.
+//     runBatchIteratorSearchTest(batchIterator, k, verify_res);
+//     // After releasing the batch iterator, ef_runtime should return to the default one.
+//     VecSimBatchIterator_Free(batchIterator);
+//     info = VecSimIndex_Info(index);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, efRuntime);
+
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, hnsw_search_empty_index) {
+//     size_t n = 100;
+//     size_t k = 11;
+//     size_t d = 4;
+//     VecSimParams params{
+//         .algo = VecSimAlgo_HNSWLIB,
+//         .hnswParams = HNSWParams{
+//             .type = VecSimType_FLOAT32, .dim = d, .metric = VecSimMetric_L2, .initialCapacity =
+//             0}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     float query[] = {50, 50, 50, 50};
+
+//     // We do not expect any results.
+//     VecSimQueryResult_List res =
+//         VecSimIndex_TopKQuery(index, (const void *)query, k, NULL, BY_SCORE);
+//     ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+//     VecSimQueryResult_Iterator *it = VecSimQueryResult_List_GetIterator(res);
+//     ASSERT_EQ(VecSimQueryResult_IteratorNext(it), nullptr);
+//     VecSimQueryResult_IteratorFree(it);
+//     VecSimQueryResult_Free(res);
+
+//     res = VecSimIndex_RangeQuery(index, (const void *)query, 1.0f, NULL, BY_SCORE);
+//     ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+//     VecSimQueryResult_Free(res);
+
+//     // Add some vectors and remove them all from index, so it will be empty again.
+//     for (size_t i = 0; i < n; i++) {
+//         float f[d];
+//         for (size_t j = 0; j < d; j++) {
+//             f[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+//     for (size_t i = 0; i < n; i++) {
+//         VecSimIndex_DeleteVector(index, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+//     // Again - we do not expect any results.
+//     res = VecSimIndex_TopKQuery(index, (const void *)query, k, NULL, BY_SCORE);
+//     ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+//     it = VecSimQueryResult_List_GetIterator(res);
+//     ASSERT_EQ(VecSimQueryResult_IteratorNext(it), nullptr);
+//     VecSimQueryResult_IteratorFree(it);
+//     VecSimQueryResult_Free(res);
+
+//     res = VecSimIndex_RangeQuery(index, (const void *)query, 1.0f, NULL, BY_SCORE);
+//     ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+//     VecSimQueryResult_Free(res);
+
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, hnsw_inf_score) {
+//     size_t n = 4;
+//     size_t k = 4;
+//     size_t dim = 2;
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+
+//     // The 32 bits of "efgh" and "efgg", and the 32 bits of "abcd" and "abbd" will
+//     // yield "inf" result when we calculate distance between the vectors.
+//     VecSimIndex_AddVector(index, "abcdefgh", 1);
+//     VecSimIndex_AddVector(index, "abcdefgg", 2);
+//     VecSimIndex_AddVector(index, "aacdefgh", 3);
+//     VecSimIndex_AddVector(index, "abbdefgh", 4);
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), 4);
+
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         if (index == 0) {
+//             ASSERT_EQ(1, id);
+//         } else if (index == 1) {
+//             ASSERT_EQ(3, id);
+//         } else {
+//             ASSERT_TRUE(id == 2 || id == 4);
+//         }
+//     };
+//     runTopKSearchTest(index, "abcdefgh", k, verify_res);
+//     VecSimIndex_Free(index);
+// }
+
+// // Tests VecSimIndex_New failure on bad M parameter. Should return null.
+// TEST_F(HNSWTest, hnsw_bad_params) {
+//     size_t n = 1000000;
+//     size_t dim = 2;
+//     size_t bad_M[] = {
+//         1,         // Will fail because 1/log(M).
+//         100000000, // Will fail on this->allocator->allocate(max_elements_ *
+//         size_data_per_element_) SIZE_MAX,  // Will fail on M * 2 overflow. SIZE_MAX / 2, // Will
+//         fail on M * 2 overflow. SIZE_MAX / 4  // Will fail on size_links_level0_ calculation:
+//                       // sizeof(linklistsizeint) + M * 2 * sizeof(idType) + sizeof(void *)
+//     };
+//     unsigned long len = sizeof(bad_M) / sizeof(size_t);
+
+//     for (unsigned long i = 0; i < len; i++) {
+//         VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                             .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                      .dim = dim,
+//                                                      .metric = VecSimMetric_L2,
+//                                                      .initialCapacity = n}};
+
+//         params.hnswParams.M = bad_M[i];
+//         VecSimIndex *index = VecSimIndex_New(&params);
+//         ASSERT_TRUE(index == NULL);
+//     }
+// }
+
+// TEST_F(HNSWTest, hnsw_delete_entry_point) {
+//     size_t n = 10000;
+//     size_t dim = 2;
+//     size_t M = 2;
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .M = M,
+//                                                  .efConstruction = 0,
+//                                                  .efRuntime = 0}};
+
+//     VecSimIndex *index = VecSimIndex_New(&params);
+//     ASSERT_TRUE(index != NULL);
+
+//     int64_t vec[dim];
+//     for (size_t i = 0; i < dim; i++)
+//         vec[i] = i;
+//     for (size_t j = 0; j < n; j++)
+//         VecSimIndex_AddVector(index, vec, j);
+
+//     VecSimIndexInfo info = VecSimIndex_Info(index);
+
+//     while (info.hnswInfo.indexSize > 0) {
+//         ASSERT_NO_THROW(VecSimIndex_DeleteVector(index, info.hnswInfo.entrypoint));
+//         info = VecSimIndex_Info(index);
+//     }
+//     VecSimIndex_Free(index);
+// }
+
+// TEST_F(HNSWTest, hnsw_override) {
+//     size_t n = 100;
+//     size_t dim = 4;
+//     size_t M = 8;
+//     size_t ef = 300;
+
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .M = M,
+//                                                  .efConstruction = 20,
+//                                                  .efRuntime = ef}};
+
+//     VecSimIndex *index = VecSimIndex_New(&params);
+//     ASSERT_TRUE(index != nullptr);
+
+//     // Insert n == 100 vectors.
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+//     // Insert again 300 vectors, the first 100 will be overwritten (deleted first).
+//     n = 300;
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+
+//     float query[dim];
+//     for (size_t j = 0; j < dim; j++) {
+//         query[j] = (float)n;
+//     }
+//     // This is testing a bug fix - before we had the seconder sorting by id in CompareByFirst,
+//     // the graph got disconnected due to the deletion of some node followed by a bad repairing of
+//     // one of its neighbours. Here, we ensure that we get all the nodes in the graph as results.
+//     auto verify_res = [&](size_t id, float score, size_t index) {
+//         ASSERT_TRUE(id == n - 1 - index);
+//     };
+//     runTopKSearchTest(index, query, 300, verify_res);
+
+//     VecSimIndex_Free(index);
+// }
 
 // TEST_F(HNSWMultiTest, hnsw_batch_iterator_basic) {
 //     size_t dim = 4;
@@ -1095,81 +2229,109 @@ TEST_F(HNSWMultiTest, remove_vector_after_replacing_block) {
 //     VecSimIndex_Free(index);
 // }
 
-TEST_F(HNSWMultiTest, hnsw_get_distance) {
-    size_t n_labels = 2;
-    size_t dim = 2;
-    size_t numIndex = 3;
-    VecSimIndex *index[numIndex];
-    std::vector<double> distances;
+// TEST_F(HNSWTest, hnsw_multi_serialization_v1) {
+//     size_t dim = 4;
+//     size_t n = 1000;
+//     size_t M = 8;
+//     size_t ef = 10;
 
-    float v1_0[] = {M_PI, M_PI};
-    float v2_0[] = {M_E, M_E};
-    float v3_1[] = {M_PI, M_E};
-    float v4_1[] = {M_SQRT2, -M_SQRT2};
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .blockSize = 1,
+//                                                  .M = M,
+//                                                  .efConstruction = ef,
+//                                                  .efRuntime = ef}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
 
-    VecSimParams params{
-        .algo = VecSimAlgo_HNSWLIB,
-        .hnswParams = HNSWParams{
-            .type = VecSimType_FLOAT32, .dim = dim, .multi = true, .initialCapacity = 4}};
+//     auto serializer = HNSWIndexSerializer(reinterpret_cast<HNSWIndex<float, float> *>(index));
 
-    for (size_t i = 0; i < numIndex; i++) {
-        params.hnswParams.metric = (VecSimMetric)i;
-        index[i] = VecSimIndex_New(&params);
-        VecSimIndex_AddVector(index[i], v1_0, 0);
-        VecSimIndex_AddVector(index[i], v2_0, 0);
-        VecSimIndex_AddVector(index[i], v3_1, 1);
-        VecSimIndex_AddVector(index[i], v4_1, 1);
-        ASSERT_EQ(VecSimIndex_IndexSize(index[i]), 4);
-    }
+//     auto file_name = std::string(getenv("ROOT")) + "/tests/unit/data/1k-d4-L2-M8-ef_c10.hnsw_v1";
+//     // Save and load an empty index.
+//     serializer.saveIndex(file_name);
+//     serializer.loadIndex(file_name);
+//     auto res = serializer.checkIntegrity();
+//     ASSERT_TRUE(res.valid_state);
 
-    void *query = v1_0;
-    void *norm = v2_0;                               // {e, e}
-    VecSim_Normalize(norm, dim, VecSimType_FLOAT32); // now {1/sqrt(2), 1/sqrt(2)}
-    ASSERT_FLOAT_EQ(((float *)norm)[0], 1.0f / sqrt(2.0f));
-    ASSERT_FLOAT_EQ(((float *)norm)[1], 1.0f / sqrt(2.0f));
-    double dist;
+//     for (size_t i = 0; i < n; i++) {
+//         float f[dim];
+//         for (size_t j = 0; j < dim; j++) {
+//             f[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, (const void *)f, i);
+//     }
+//     // Get index info and copy it, so it will be available after the index is deleted.
+//     VecSimIndexInfo info = VecSimIndex_Info(index);
 
-    // VecSimMetric_L2
-    // distances are [[0.000, 0.358], [0.179, 23.739]]
-    // minimum of each label are:
-    distances = {0, 0.1791922003030777};
-    for (size_t i = 0; i < n_labels; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], i, query);
-        ASSERT_DOUBLE_EQ(dist, distances[i]);
-    }
+//     // Persist index with the serializer, and delete it.
+//     serializer.saveIndex(file_name);
+//     VecSimIndex_Free(index);
 
-    // VecSimMetric_IP
-    // distances are [[-18.739, -16.079], [-17.409, 1.000]]
-    // minimum of each label are:
-    distances = {-18.73921012878418, -17.409339904785156};
-    for (size_t i = 0; i < n_labels; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_IP], i, query);
-        ASSERT_DOUBLE_EQ(dist, distances[i]);
-    }
+//     // Create new index, set it into the serializer and extract the data to it.
+//     auto new_index = VecSimIndex_New(&params);
+//     ASSERT_EQ(VecSimIndex_IndexSize(new_index), 0);
 
-    // VecSimMetric_Cosine
-    // distances are [[5.960e-08, 5.960e-08], [0.0026, 1.000]]
-    // minimum of each label are:
-    distances = {5.9604644775390625e-08, 0.0025991201400756836};
-    for (size_t i = 0; i < n_labels; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], i, norm);
-        ASSERT_DOUBLE_EQ(dist, distances[i]);
-    }
+//     serializer.reset(reinterpret_cast<HNSWIndex<float, float> *>(new_index));
+//     serializer.loadIndex(file_name);
 
-    // Bad values
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], -1, norm);
-    ASSERT_TRUE(std::isnan(dist));
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], 46, query);
-    ASSERT_TRUE(std::isnan(dist));
+//     // Validate that the new loaded index has the same meta-data as the original.
+//     VecSimIndexInfo new_info = VecSimIndex_Info(new_index);
+//     ASSERT_EQ(info.algo, new_info.algo);
+//     ASSERT_EQ(info.hnswInfo.M, new_info.hnswInfo.M);
+//     ASSERT_EQ(info.hnswInfo.efConstruction, new_info.hnswInfo.efConstruction);
+//     ASSERT_EQ(info.hnswInfo.efRuntime, new_info.hnswInfo.efRuntime);
+//     ASSERT_EQ(info.hnswInfo.indexSize, new_info.hnswInfo.indexSize);
+//     ASSERT_EQ(info.hnswInfo.max_level, new_info.hnswInfo.max_level);
+//     ASSERT_EQ(info.hnswInfo.entrypoint, new_info.hnswInfo.entrypoint);
+//     ASSERT_EQ(info.hnswInfo.metric, new_info.hnswInfo.metric);
+//     ASSERT_EQ(info.hnswInfo.type, new_info.hnswInfo.type);
+//     ASSERT_EQ(info.hnswInfo.dim, new_info.hnswInfo.dim);
 
-    // Clean-up.
-    for (size_t i = 0; i < numIndex; i++) {
-        VecSimIndex_Free(index[i]);
-    }
-}
+//     res = serializer.checkIntegrity();
+//     ASSERT_TRUE(res.valid_state);
+
+//     // Add 1000 random vectors, override the existing ones to trigger deletions.
+//     std::vector<float> data((n + 1) * dim);
+//     std::mt19937 rng;
+//     rng.seed(47);
+//     std::uniform_real_distribution<> distrib;
+//     for (size_t i = 0; i < (n + 1) * dim; ++i) {
+//         data[i] = (float)distrib(rng);
+//     }
+//     for (size_t i = 0; i < n + 1; ++i) {
+//         VecSimIndex_AddVector(new_index, data.data() + dim * i, i);
+//     }
+
+//     // Delete arbitrary vector (trigger removal of a block).
+//     VecSimIndex_DeleteVector(new_index, (size_t)(distrib(rng) * (n + 1)));
+
+//     HNSWIndex<float, float> *hnswNewIndex = reinterpret_cast<HNSWIndex<float, float>
+//     *>(new_index); ASSERT_EQ(hnswNewIndex->getIndexCapacity(), n);
+
+//     // Persist index, delete it from memory and restore.
+//     serializer.saveIndex(file_name);
+//     VecSimIndex_Free(new_index);
+
+//     params.hnswParams.initialCapacity = n / 2; // to ensure that we resize in load time.
+//     auto restored_index = VecSimIndex_New(&params);
+//     ASSERT_EQ(VecSimIndex_IndexSize(restored_index), 0);
+
+//     serializer.reset(reinterpret_cast<HNSWIndex<float, float> *>(restored_index));
+//     serializer.loadIndex(file_name);
+//     ASSERT_EQ(VecSimIndex_IndexSize(restored_index), n);
+//     res = serializer.checkIntegrity();
+//     ASSERT_TRUE(res.valid_state);
+
+//     // Clean-up.
+//     remove(file_name.c_str());
+//     VecSimIndex_Free(restored_index);
+//     serializer.reset();
+// }
 
 TEST_F(HNSWMultiTest, testCosine) {
-    size_t dim = 128;
+    size_t dim = 4;
     size_t n = 100;
 
     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
@@ -1188,7 +2350,16 @@ TEST_F(HNSWMultiTest, testCosine) {
         }
         VecSimIndex_AddVector(index, (const void *)f, i);
     }
-    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    // Add more worst vector for each label
+    for (size_t i = 1; i <= n; i++) {
+        float f[dim];
+        f[0] = (float)i + n;
+        for (size_t j = 1; j < dim; j++) {
+            f[j] = 1.0f;
+        }
+        VecSimIndex_AddVector(index, (const void *)f, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 2 * n);
     float query[dim];
     for (size_t i = 0; i < dim; i++) {
         query[i] = 1.0f;
@@ -1211,7 +2382,7 @@ TEST_F(HNSWMultiTest, testCosine) {
     VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
     size_t iteration_num = 0;
 
-    // get the 10 vectors whose ids are the maximal among those that hasn't been returned yet,
+    // Get the 10 vectors whose ids are the maximal among those that hasn't been returned yet,
     // in every iteration. The order should be from the largest to the lowest id.
     size_t n_res = 10;
     while (VecSimBatchIterator_HasNext(batchIterator)) {
@@ -1236,181 +2407,117 @@ TEST_F(HNSWMultiTest, testCosine) {
     VecSimIndex_Free(index);
 }
 
-TEST_F(HNSWMultiTest, testSizeEstimation) {
-    size_t dim = 128;
-    size_t n = 1000;
-    size_t bs = DEFAULT_BLOCK_SIZE;
-    size_t M = 32;
+// TEST_F(HNSWTest, testSizeEstimation) {
+//     size_t dim = 128;
+//     size_t n = 1000;
+//     size_t bs = DEFAULT_BLOCK_SIZE;
+//     size_t M = 32;
 
-    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-                                                 .dim = dim,
-                                                 .metric = VecSimMetric_L2,
-                                                 .multi = true,
-                                                 .initialCapacity = n,
-                                                 .blockSize = bs,
-                                                 .M = M}};
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = n,
+//                                                  .blockSize = bs,
+//                                                  .M = M}};
 
-    size_t estimation = VecSimIndex_EstimateInitialSize(&params);
-    VecSimIndex *index = VecSimIndex_New(&params);
+//     size_t estimation = VecSimIndex_EstimateInitialSize(&params);
+//     VecSimIndex *index = VecSimIndex_New(&params);
 
-    size_t actual = index->getAllocator()->getAllocationSize();
-    // labels_lookup hash table has additional memory, since STL implementation chooses "an
-    // appropriate prime number" higher than n as the number of allocated buckets (for n=1000, 1031
-    // buckets are created)
-    estimation +=
-        (reinterpret_cast<HNSWIndex_Multi<float, float> *>(index)->label_lookup_.bucket_count() -
-         n) *
-        sizeof(size_t);
+//     size_t actual = index->getAllocator()->getAllocationSize();
+//     // labels_lookup hash table has additional memory, since STL implementation chooses "an
+//     // appropriate prime number" higher than n as the number of allocated buckets (for n=1000,
+//     1031
+//     // buckets are created)
+//     estimation += (reinterpret_cast<HNSWIndex_Single<float, float> *>(index)
 
-    ASSERT_EQ(estimation, actual);
+//                        ->label_lookup_.bucket_count() -
+//                    n) *
+//                   sizeof(size_t);
 
-    float vec[dim];
-    for (size_t i = 0; i < n; i++) {
-        for (size_t j = 0; j < dim; j++) {
-            vec[j] = (float)i;
-        }
-        VecSimIndex_AddVector(index, vec, i);
-    }
+//     ASSERT_EQ(estimation, actual);
 
-    // Estimate the memory delta of adding a full new block.
-    estimation = VecSimIndex_EstimateElementSize(&params) * (bs % n + bs);
+//     float vec[dim];
+//     for (size_t i = 0; i < n; i++) {
+//         for (size_t j = 0; j < dim; j++) {
+//             vec[j] = (float)i;
+//         }
+//         VecSimIndex_AddVector(index, vec, i);
+//     }
 
-    actual = 0;
-    for (size_t i = 0; i < bs; i++) {
-        for (size_t j = 0; j < dim; j++) {
-            vec[j] = (float)i;
-        }
-        actual += VecSimIndex_AddVector(index, vec, n + i);
-    }
-    ASSERT_GE(estimation * 1.01, actual);
-    ASSERT_LE(estimation * 0.99, actual);
+//     // Estimate the memory delta of adding a full new block.
+//     estimation = VecSimIndex_EstimateElementSize(&params) * (bs % n + bs);
 
-    VecSimIndex_Free(index);
-}
+//     actual = 0;
+//     for (size_t i = 0; i < bs; i++) {
+//         for (size_t j = 0; j < dim; j++) {
+//             vec[j] = (float)i;
+//         }
+//         actual += VecSimIndex_AddVector(index, vec, n + i);
+//     }
+//     ASSERT_GE(estimation * 1.01, actual);
+//     ASSERT_LE(estimation * 0.99, actual);
 
-TEST_F(HNSWMultiTest, testInitialSizeEstimation_No_InitialCapacity) {
-    size_t dim = 128;
-    size_t n = 0;
-    size_t bs = DEFAULT_BLOCK_SIZE;
+//     VecSimIndex_Free(index);
+// }
 
-    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-                                                 .dim = dim,
-                                                 .metric = VecSimMetric_Cosine,
-                                                 .multi = true,
-                                                 .initialCapacity = n,
-                                                 .blockSize = bs}};
+// TEST_F(HNSWTest, testTimeoutReturn) {
+//     size_t dim = 4;
+//     float vec[] = {1.0f, 1.0f, 1.0f, 1.0f};
+//     VecSimQueryResult_List rl;
 
-    VecSimIndex *index = VecSimIndex_New(&params);
-    size_t estimation = VecSimIndex_EstimateInitialSize(&params);
+//     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+//                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_L2,
+//                                                  .initialCapacity = 1,
+//                                                  .blockSize = 5}};
+//     VecSimIndex *index = VecSimIndex_New(&params);
+//     VecSimIndex_AddVector(index, vec, 0);
+//     VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out
 
-    size_t actual = index->getAllocator()->getAllocationSize();
+//     // Checks return code on timeout.
+//     rl = VecSimIndex_TopKQuery(index, vec, 1, NULL, BY_ID);
+//     ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+//     ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+//     VecSimQueryResult_Free(rl);
 
-    // labels_lookup and element_levels containers are not allocated at all in some platforms,
-    // when initial capacity is zero, while in other platforms labels_lookup is allocated with a
-    // single bucket. This, we get the following range in which we expect the initial memory to be
-    // in.
-    ASSERT_GE(actual, estimation);
-    ASSERT_LE(actual, estimation + sizeof(size_t) + 2 * sizeof(size_t));
+//     // Check timeout again - range query.
+//     VecSimIndex_AddVector(index, vec, 1);
+//     ASSERT_EQ(VecSimIndex_Info(index).hnswInfo.max_level, 0);
+//     // Here, the entry point is inserted to the results set before we test for timeout.
+//     // hence, expect a single result to be returned (instead of 2 that would have return without
+//     // timeout).
+//     rl = VecSimIndex_RangeQuery(index, vec, 1, NULL, BY_ID);
+//     ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+//     ASSERT_EQ(VecSimQueryResult_Len(rl), 1);
+//     VecSimQueryResult_Free(rl);
 
-    VecSimIndex_Free(index);
-}
+//     // Fail on searching bottom layer entry point.
+//     // We need to have at least 1 vector in layer higher than 0 to fail there.
+//     size_t next = 0;
+//     while (VecSimIndex_Info(index).hnswInfo.max_level == 0) {
+//         VecSimIndex_AddVector(index, vec, next++);
+//     }
+//     VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out.
 
-TEST_F(HNSWMultiTest, testTimeoutReturn) {
-    size_t dim = 4;
-    float vec[] = {1.0f, 1.0f, 1.0f, 1.0f};
-    VecSimQueryResult_List rl;
+//     rl = VecSimIndex_TopKQuery(index, vec, 2, NULL, BY_ID);
+//     ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+//     ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+//     VecSimQueryResult_Free(rl);
 
-    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-                                                 .dim = dim,
-                                                 .metric = VecSimMetric_L2,
-                                                 .multi = true,
-                                                 .initialCapacity = 1,
-                                                 .blockSize = 5}};
-    VecSimIndex *index = VecSimIndex_New(&params);
-    VecSimIndex_AddVector(index, vec, 0);
-    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out
+//     // Timeout on searching bottom layer entry point - range query.
+//     rl = VecSimIndex_RangeQuery(index, vec, 1, NULL, BY_ID);
+//     ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+//     ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+//     VecSimQueryResult_Free(rl);
 
-    // Checks return code on timeout - knn
-    rl = VecSimIndex_TopKQuery(index, vec, 1, NULL, BY_ID);
-    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
-    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
-    VecSimQueryResult_Free(rl);
+//     VecSimIndex_Free(index);
+//     VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; }); // Cleanup.
+// }
 
-    // Check timeout again - range query
-    // TODO: uncomment when support for BFM range is enabled
-    // rl = VecSimIndex_RangeQuery(index, vec, 1, NULL, BY_ID);
-    // ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
-    // ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
-    // VecSimQueryResult_Free(rl);
-
-    VecSimIndex_Free(index);
-    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; }); // cleanup
-}
-
-TEST_F(HNSWMultiTest, testTimeoutReturn_batch_iterator) {
-    size_t dim = 4;
-    size_t n = 10;
-    VecSimQueryResult_List rl;
-
-    VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                        .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-                                                 .dim = dim,
-                                                 .metric = VecSimMetric_L2,
-                                                 .multi = true,
-                                                 .initialCapacity = n,
-                                                 .blockSize = 5}};
-    VecSimIndex *index = VecSimIndex_New(&params);
-
-    for (size_t i = 0; i < n; i++) {
-        float f[dim];
-        for (size_t j = 0; j < dim; j++) {
-            f[j] = (float)i;
-        }
-        VecSimIndex_AddVector(index, (const void *)f, i);
-    }
-    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
-
-    float query[dim];
-    for (size_t j = 0; j < dim; j++) {
-        query[j] = (float)n;
-    }
-
-    // Fail on second batch (after calculation already completed)
-    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
-
-    rl = VecSimBatchIterator_Next(batchIterator, 1, BY_ID);
-    ASSERT_EQ(rl.code, VecSim_QueryResult_OK);
-    ASSERT_NE(VecSimQueryResult_Len(rl), 0);
-    VecSimQueryResult_Free(rl);
-
-    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out
-    rl = VecSimBatchIterator_Next(batchIterator, 1, BY_ID);
-    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
-    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
-    VecSimQueryResult_Free(rl);
-
-    VecSimBatchIterator_Free(batchIterator);
-
-    // Fail on first batch (while calculating)
-    // Timeout callback function already set to always time out
-    batchIterator = VecSimBatchIterator_New(index, query, nullptr);
-
-    rl = VecSimBatchIterator_Next(batchIterator, 1, BY_ID);
-    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
-    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
-    VecSimQueryResult_Free(rl);
-
-    VecSimBatchIterator_Free(batchIterator);
-
-    VecSimIndex_Free(index);
-    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; }); // cleanup
-}
-
-// TEST_F(HNSWMultiTest, rangeQuery) {
-//     size_t n = 2000;
+// TEST_F(HNSWTest, rangeQuery) {
+//     size_t n = 5000;
 //     size_t dim = 4;
 
 //     VecSimParams params{
@@ -1429,23 +2536,8 @@ TEST_F(HNSWMultiTest, testTimeoutReturn_batch_iterator) {
 //     }
 //     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
 
-//     size_t pivot_id = n / 2; // The id to return vectors around it.
+//     size_t pivot_id = n / 2; // the id to return vectors around it.
 //     float query[] = {(float)pivot_id, (float)pivot_id, (float)pivot_id, (float)pivot_id};
-
-//     // Validate invalid params are caught with runtime exception.
-//     try {
-//         VecSimIndex_RangeQuery(index, (const void *)query, -1, nullptr, BY_SCORE);
-//         FAIL();
-//     } catch (std::runtime_error const &err) {
-//         EXPECT_EQ(err.what(), std::string("radius must be non-negative"));
-//     }
-//     try {
-//         VecSimIndex_RangeQuery(index, (const void *)query, 1, nullptr,
-//         VecSimQueryResult_Order(2)); FAIL();
-//     } catch (std::runtime_error const &err) {
-//         EXPECT_EQ(err.what(), std::string("Possible order values are only 'BY_ID' or
-//         'BY_SCORE'"));
-//     }
 
 //     auto verify_res_by_score = [&](size_t id, float score, size_t index) {
 //         ASSERT_EQ(std::abs(int(id - pivot_id)), (index + 1) / 2);
@@ -1458,6 +2550,15 @@ TEST_F(HNSWMultiTest, testTimeoutReturn_batch_iterator) {
 //     float radius = dim * powf(expected_num_results / 2, 2);
 //     runRangeQueryTest(index, query, radius, verify_res_by_score, expected_num_results, BY_SCORE);
 
+//     // Rerun with a given query params. This high epsilon value will cause the range search main
+//     // loop to break since we insert a candidate whose distance is within the dynamic range
+//     // boundaries at the beginning of the search, but when this candidate is popped out from the
+//     // queue, it's no longer within the dynamic range boundaries.
+//     auto query_params = VecSimQueryParams{.hnswRuntimeParams = HNSWRuntimeParams{.epsilon
+//     = 1.0}}; runRangeQueryTest(index, query, radius, verify_res_by_score, expected_num_results,
+//     BY_SCORE,
+//                       &query_params);
+
 //     // Get results by id.
 //     auto verify_res_by_id = [&](size_t id, float score, size_t index) {
 //         ASSERT_EQ(id, pivot_id - expected_num_results / 2 + index);
@@ -1468,15 +2569,15 @@ TEST_F(HNSWMultiTest, testTimeoutReturn_batch_iterator) {
 //     VecSimIndex_Free(index);
 // }
 
-// TEST_F(HNSWMultiTest, rangeQueryCosine) {
-//     size_t n = 100;
+// TEST_F(HNSWTest, rangeQueryCosine) {
+//     size_t n = 800;
 //     size_t dim = 4;
 
 //     VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
 //                         .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
-//                                              .dim = dim,
-//                                              .metric = VecSimMetric_Cosine,
-//                                              .blockSize = n / 2}};
+//                                                  .dim = dim,
+//                                                  .metric = VecSimMetric_Cosine,
+//                                                  .blockSize = n / 2}};
 //     VecSimIndex *index = VecSimIndex_New(&params);
 
 //     for (size_t i = 0; i < n; i++) {
@@ -1488,6 +2589,7 @@ TEST_F(HNSWMultiTest, testTimeoutReturn_batch_iterator) {
 //         // Use as label := n - (internal id)
 //         VecSimIndex_AddVector(index, (const void *)f, n - i);
 //     }
+
 //     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
 //     float query[dim];
 //     for (size_t i = 0; i < dim; i++) {
@@ -1517,6 +2619,7 @@ TEST_F(HNSWMultiTest, testTimeoutReturn_batch_iterator) {
 //                 (sqrtf((float)dim) *
 //                  sqrtf((float)(dim - 1) + edge_first_coordinate * edge_first_coordinate)));
 //     runRangeQueryTest(index, query, radius, verify_res, expected_num_results, BY_SCORE);
+
 //     // Return results BY_ID should give the same results.
 //     runRangeQueryTest(index, query, radius, verify_res, expected_num_results, BY_ID);
 

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -569,7 +569,7 @@ TEST_F(HNSWMultiTest, test_dynamic_hnsw_info_iterator) {
 
 TEST_F(HNSWMultiTest, preferAdHocOptimization) {
     // Save the expected result for every combination that represent a different leaf in the tree.
-    // map: [k, index_size, dim, M, r] -> res
+    // map: [k, label_count, vectors per label, dim, M, r] -> res
     std::map<std::vector<float>, bool> combinations;
     combinations[{5, 100, 3, 5, 5, 0.5}] = true;
     combinations[{5, 100, 5, 5, 5, 0.5}] = true;

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -1283,8 +1283,8 @@ TEST_F(HNSWMultiTest, testSizeEstimation) {
         }
         actual += VecSimIndex_AddVector(index, vec, n + i);
     }
-    ASSERT_GE(estimation * 1.001, actual);
-    ASSERT_LE(estimation * 0.999, actual);
+    ASSERT_GE(estimation * 1.01, actual);
+    ASSERT_LE(estimation * 0.99, actual);
 
     VecSimIndex_Free(index);
 }

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -1306,7 +1306,13 @@ TEST_F(HNSWMultiTest, testInitialSizeEstimation_No_InitialCapacity) {
     size_t estimation = VecSimIndex_EstimateInitialSize(&params);
 
     size_t actual = index->getAllocator()->getAllocationSize();
-    ASSERT_EQ(estimation, actual);
+
+    // labels_lookup and element_levels containers are not allocated at all in some platforms,
+    // when initial capacity is zero, while in other platforms labels_lookup is allocated with a
+    // single bucket. This, we get the following range in which we expect the initial memory to be
+    // in.
+    ASSERT_GE(actual, estimation);
+    ASSERT_LE(actual, estimation + sizeof(size_t) + 2 * sizeof(size_t));
 
     VecSimIndex_Free(index);
 }


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR implements the multi-value HNSW algorithm. it splits the `hnsw.h` file into `hnsw.h` for the base class and `hnsw_single.h` for the single (regular) case.

**Main objects this PR modified**
1. HNSW index file is now the base class, and hnsw_single and hnsw_multi derive from it.
2. improved the size estimation for HNSW (and modified to support multi-index)
3. "prefer ad-hoc" is changed to check the ratio between the sub-set size and the label count.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
