### PR TITLE
Distance calculation functions for doubles - no optimizations

### DIFF
--- a/src/VecSim/spaces/IP/IP.cpp
+++ b/src/VecSim/spaces/IP/IP.cpp
@@ -1,13 +1,31 @@
 #include "IP.h"
 
 float FP32_InnerProduct_impl(const void *pVect1, const void *pVect2, size_t qty) {
+    float *vec1 = (float *)pVect1;
+    float *vec2 = (float *)pVect2;
+
     float res = 0;
-    for (unsigned i = 0; i < qty; i++) {
-        res += ((float *)pVect1)[i] * ((float *)pVect2)[i];
+    for (size_t i = 0; i < qty; i++) {
+        res += vec1[i] * vec2[i];
     }
     return res;
 }
 
 float FP32_InnerProduct(const void *pVect1, const void *pVect2, size_t qty) {
     return 1.0f - FP32_InnerProduct_impl(pVect1, pVect2, qty);
+}
+
+double FP64_InnerProduct_impl(const void *pVect1, const void *pVect2, size_t qty) {
+    double *vec1 = (double *)pVect1;
+    double *vec2 = (double *)pVect2;
+
+    double res = 0;
+    for (size_t i = 0; i < qty; i++) {
+        res += vec1[i] * vec2[i];
+    }
+    return res;
+}
+
+double FP64_InnerProduct(const void *pVect1, const void *pVect2, size_t qty) {
+    return 1.0 - FP64_InnerProduct_impl(pVect1, pVect2, qty);
 }

--- a/src/VecSim/spaces/IP/IP.h
+++ b/src/VecSim/spaces/IP/IP.h
@@ -5,3 +5,7 @@
 float FP32_InnerProduct(const void *pVect1, const void *pVect2, size_t qty);
 
 float FP32_InnerProduct_impl(const void *pVect1, const void *pVect2, size_t qty);
+
+double FP64_InnerProduct(const void *pVect1, const void *pVect2, size_t qty);
+
+double FP64_InnerProduct_impl(const void *pVect1, const void *pVect2, size_t qty);

--- a/src/VecSim/spaces/IP_space.cpp
+++ b/src/VecSim/spaces/IP_space.cpp
@@ -53,4 +53,51 @@ dist_func_t<float> IP_FP32_GetDistFunc(size_t dim) {
     return ret_dist_func;
 }
 
+dist_func_t<double> IP_FP64_GetDistFunc(size_t dim) {
+
+    dist_func_t<double> ret_dist_func = FP64_InnerProduct;
+    /* #if defined(M1)
+    #elif defined(__x86_64__)
+
+        CalculationGuideline optimization_type = GetCalculationGuideline(dim);
+        switch (arch_opt) {
+        case ARCH_OPT_NONE:
+            break;
+        case ARCH_OPT_AVX512:
+    #ifdef __AVX512F__
+        {
+            static dist_func_t<float> dist_funcs[] = {
+                FP32_InnerProduct, FP32_InnerProductSIMD16Ext_AVX512,
+    FP32_InnerProductSIMD4Ext_AVX512, FP32_InnerProductSIMD16ExtResiduals_AVX512,
+    FP32_InnerProductSIMD4ExtResiduals_AVX512};
+
+            ret_dist_func = dist_funcs[optimization_type];
+        } break;
+    #endif
+        case ARCH_OPT_AVX:
+    #ifdef __AVX__
+        {
+            static dist_func_t<float> dist_funcs[] = {
+                FP32_InnerProduct, FP32_InnerProductSIMD16Ext_AVX, FP32_InnerProductSIMD4Ext_AVX,
+                FP32_InnerProductSIMD16ExtResiduals_AVX, FP32_InnerProductSIMD4ExtResiduals_AVX};
+
+            ret_dist_func = dist_funcs[optimization_type];
+        } break;
+
+    #endif
+        case ARCH_OPT_SSE:
+    #ifdef __SSE__
+        {
+            static dist_func_t<float> dist_funcs[] = {
+                FP32_InnerProduct, FP32_InnerProductSIMD16Ext_SSE, FP32_InnerProductSIMD4Ext_SSE,
+                FP32_InnerProductSIMD16ExtResiduals_SSE, FP32_InnerProductSIMD4ExtResiduals_SSE};
+
+            ret_dist_func = dist_funcs[optimization_type];
+        } break;
+    #endif
+        } // switch
+    #endif // __x86_64__ */
+    return ret_dist_func;
+}
+
 } // namespace spaces

--- a/src/VecSim/spaces/IP_space.cpp
+++ b/src/VecSim/spaces/IP_space.cpp
@@ -53,51 +53,6 @@ dist_func_t<float> IP_FP32_GetDistFunc(size_t dim) {
     return ret_dist_func;
 }
 
-dist_func_t<double> IP_FP64_GetDistFunc(size_t dim) {
-
-    dist_func_t<double> ret_dist_func = FP64_InnerProduct;
-    /* #if defined(M1)
-    #elif defined(__x86_64__)
-
-        CalculationGuideline optimization_type = GetCalculationGuideline(dim);
-        switch (arch_opt) {
-        case ARCH_OPT_NONE:
-            break;
-        case ARCH_OPT_AVX512:
-    #ifdef __AVX512F__
-        {
-            static dist_func_t<float> dist_funcs[] = {
-                FP32_InnerProduct, FP32_InnerProductSIMD16Ext_AVX512,
-    FP32_InnerProductSIMD4Ext_AVX512, FP32_InnerProductSIMD16ExtResiduals_AVX512,
-    FP32_InnerProductSIMD4ExtResiduals_AVX512};
-
-            ret_dist_func = dist_funcs[optimization_type];
-        } break;
-    #endif
-        case ARCH_OPT_AVX:
-    #ifdef __AVX__
-        {
-            static dist_func_t<float> dist_funcs[] = {
-                FP32_InnerProduct, FP32_InnerProductSIMD16Ext_AVX, FP32_InnerProductSIMD4Ext_AVX,
-                FP32_InnerProductSIMD16ExtResiduals_AVX, FP32_InnerProductSIMD4ExtResiduals_AVX};
-
-            ret_dist_func = dist_funcs[optimization_type];
-        } break;
-
-    #endif
-        case ARCH_OPT_SSE:
-    #ifdef __SSE__
-        {
-            static dist_func_t<float> dist_funcs[] = {
-                FP32_InnerProduct, FP32_InnerProductSIMD16Ext_SSE, FP32_InnerProductSIMD4Ext_SSE,
-                FP32_InnerProductSIMD16ExtResiduals_SSE, FP32_InnerProductSIMD4ExtResiduals_SSE};
-
-            ret_dist_func = dist_funcs[optimization_type];
-        } break;
-    #endif
-        } // switch
-    #endif // __x86_64__ */
-    return ret_dist_func;
-}
+dist_func_t<double> IP_FP64_GetDistFunc(size_t dim) { return FP64_InnerProduct; }
 
 } // namespace spaces

--- a/src/VecSim/spaces/IP_space.h
+++ b/src/VecSim/spaces/IP_space.h
@@ -2,5 +2,6 @@
 #include "VecSim/spaces/spaces.h"
 namespace spaces {
 dist_func_t<float> IP_FP32_GetDistFunc(size_t dim);
+dist_func_t<double> IP_FP64_GetDistFunc(size_t dim);
 
 } // namespace spaces

--- a/src/VecSim/spaces/L2/L2.cpp
+++ b/src/VecSim/spaces/L2/L2.cpp
@@ -1,14 +1,24 @@
 #include "L2.h"
 
 float FP32_L2Sqr(const void *pVect1v, const void *pVect2v, size_t qty) {
-    float *pVect1 = (float *)pVect1v;
-    float *pVect2 = (float *)pVect2v;
+    float *vec1 = (float *)pVect1v;
+    float *vec2 = (float *)pVect2v;
 
     float res = 0;
     for (size_t i = 0; i < qty; i++) {
-        float t = *pVect1 - *pVect2;
-        pVect1++;
-        pVect2++;
+        float t = vec1[i] - vec2[i];
+        res += t * t;
+    }
+    return res;
+}
+
+double FP64_L2Sqr(const void *pVect1v, const void *pVect2v, size_t qty) {
+    double *vec1 = (double *)pVect1v;
+    double *vec2 = (double *)pVect2v;
+
+    double res = 0;
+    for (size_t i = 0; i < qty; i++) {
+        double t = vec1[i] - vec2[i];
         res += t * t;
     }
     return res;

--- a/src/VecSim/spaces/L2/L2.h
+++ b/src/VecSim/spaces/L2/L2.h
@@ -3,3 +3,4 @@
 #include <cstdlib>
 
 float FP32_L2Sqr(const void *pVect1v, const void *pVect2v, size_t qty);
+double FP64_L2Sqr(const void *pVect1v, const void *pVect2v, size_t qty);

--- a/src/VecSim/spaces/L2_space.cpp
+++ b/src/VecSim/spaces/L2_space.cpp
@@ -54,4 +54,51 @@ dist_func_t<float> L2_FP32_GetDistFunc(size_t dim) {
     return ret_dist_func;
 }
 
+dist_func_t<double> L2_FP64_GetDistFunc(size_t dim) {
+
+    dist_func_t<double> ret_dist_func = FP64_L2Sqr;
+    /* #if defined(M1)
+    #elif defined(__x86_64__)
+
+        CalculationGuideline optimization_type = GetCalculationGuideline(dim);
+        switch (arch_opt) {
+        case ARCH_OPT_NONE:
+            break;
+        case ARCH_OPT_AVX512:
+    #ifdef __AVX512F__
+        {
+            static dist_func_t<float> dist_funcs[] = {
+                FP32_L2Sqr, FP32_L2SqrSIMD16Ext_AVX512, FP32_L2SqrSIMD4Ext_AVX512,
+                FP32_L2SqrSIMD16ExtResiduals_AVX512, FP32_L2SqrSIMD4ExtResiduals_AVX512};
+
+            ret_dist_func = dist_funcs[optimization_type];
+        } break;
+    #endif
+        case ARCH_OPT_AVX:
+    #ifdef __AVX__
+        {
+            static dist_func_t<float> dist_funcs[] = {
+                FP32_L2Sqr, FP32_L2SqrSIMD16Ext_AVX, FP32_L2SqrSIMD4Ext_AVX,
+                FP32_L2SqrSIMD16ExtResiduals_AVX, FP32_L2SqrSIMD4ExtResiduals_AVX};
+
+            ret_dist_func = dist_funcs[optimization_type];
+        } break;
+
+    #endif
+        case ARCH_OPT_SSE:
+    #ifdef __SSE__
+        {
+            static dist_func_t<float> dist_funcs[] = {
+                FP32_L2Sqr, FP32_L2SqrSIMD16Ext_SSE, FP32_L2SqrSIMD4Ext_SSE,
+                FP32_L2SqrSIMD16ExtResiduals_SSE, FP32_L2SqrSIMD4ExtResiduals_SSE};
+
+            ret_dist_func = dist_funcs[optimization_type];
+        } break;
+        } // switch
+    #endif
+
+    #endif // __x86_64__ */
+    return ret_dist_func;
+}
+
 } // namespace spaces

--- a/src/VecSim/spaces/L2_space.cpp
+++ b/src/VecSim/spaces/L2_space.cpp
@@ -54,51 +54,5 @@ dist_func_t<float> L2_FP32_GetDistFunc(size_t dim) {
     return ret_dist_func;
 }
 
-dist_func_t<double> L2_FP64_GetDistFunc(size_t dim) {
-
-    dist_func_t<double> ret_dist_func = FP64_L2Sqr;
-    /* #if defined(M1)
-    #elif defined(__x86_64__)
-
-        CalculationGuideline optimization_type = GetCalculationGuideline(dim);
-        switch (arch_opt) {
-        case ARCH_OPT_NONE:
-            break;
-        case ARCH_OPT_AVX512:
-    #ifdef __AVX512F__
-        {
-            static dist_func_t<float> dist_funcs[] = {
-                FP32_L2Sqr, FP32_L2SqrSIMD16Ext_AVX512, FP32_L2SqrSIMD4Ext_AVX512,
-                FP32_L2SqrSIMD16ExtResiduals_AVX512, FP32_L2SqrSIMD4ExtResiduals_AVX512};
-
-            ret_dist_func = dist_funcs[optimization_type];
-        } break;
-    #endif
-        case ARCH_OPT_AVX:
-    #ifdef __AVX__
-        {
-            static dist_func_t<float> dist_funcs[] = {
-                FP32_L2Sqr, FP32_L2SqrSIMD16Ext_AVX, FP32_L2SqrSIMD4Ext_AVX,
-                FP32_L2SqrSIMD16ExtResiduals_AVX, FP32_L2SqrSIMD4ExtResiduals_AVX};
-
-            ret_dist_func = dist_funcs[optimization_type];
-        } break;
-
-    #endif
-        case ARCH_OPT_SSE:
-    #ifdef __SSE__
-        {
-            static dist_func_t<float> dist_funcs[] = {
-                FP32_L2Sqr, FP32_L2SqrSIMD16Ext_SSE, FP32_L2SqrSIMD4Ext_SSE,
-                FP32_L2SqrSIMD16ExtResiduals_SSE, FP32_L2SqrSIMD4ExtResiduals_SSE};
-
-            ret_dist_func = dist_funcs[optimization_type];
-        } break;
-        } // switch
-    #endif
-
-    #endif // __x86_64__ */
-    return ret_dist_func;
-}
-
+dist_func_t<double> L2_FP64_GetDistFunc(size_t dim) { return FP64_L2Sqr; }
 } // namespace spaces

--- a/src/VecSim/spaces/L2_space.h
+++ b/src/VecSim/spaces/L2_space.h
@@ -3,5 +3,6 @@
 
 namespace spaces {
 dist_func_t<float> L2_FP32_GetDistFunc(size_t dim);
+dist_func_t<double> L2_FP64_GetDistFunc(size_t dim);
 
 } // namespace spaces

--- a/src/VecSim/spaces/spaces.cpp
+++ b/src/VecSim/spaces/spaces.cpp
@@ -40,4 +40,16 @@ void SetDistFunc(VecSimMetric metric, size_t dim, dist_func_t<float> *index_dist
     }
 }
 
+void SetDistFunc(VecSimMetric metric, size_t dim, dist_func_t<double> *index_dist_func) {
+
+    if (metric == VecSimMetric_Cosine || metric == VecSimMetric_IP) {
+
+        *index_dist_func = IP_FP64_GetDistFunc(dim);
+
+    } else if (metric == VecSimMetric_L2) {
+
+        *index_dist_func = L2_FP64_GetDistFunc(dim);
+    }
+}
+
 } // namespace spaces

--- a/src/VecSim/spaces/spaces.h
+++ b/src/VecSim/spaces/spaces.h
@@ -27,5 +27,6 @@ enum CalculationGuideline {
 CalculationGuideline GetCalculationGuideline(size_t dim);
 
 void SetDistFunc(VecSimMetric metric, size_t dim, dist_func_t<float> *index_dist_func);
+void SetDistFunc(VecSimMetric metric, size_t dim, dist_func_t<double> *index_dist_func);
 
 } // namespace spaces

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -11,92 +11,6 @@
 #include "VecSim/spaces/spaces.h"
 #include "VecSim/utils/vec_utils.h"
 
-using spaces::dist_func_t;
-/****** templates distance function tests suite ******/
-template <typename DistType>
-class DistFuncTest : public testing::Test {
-public:
-    dist_func_t<DistType> dist_func;
-};
-
-using DistTypes = ::testing::Types<float, double>;
-TYPED_TEST_SUITE(DistFuncTest, DistTypes);
-
-/****** Get distance function tests  ******/
-
-// No Optimization distance function.
-TYPED_TEST(DistFuncTest, l2_no_optimization_get_func_test) {
-    // Choose a dim that has no optimizations
-    size_t dim = 1;
-    VecSimMetric metric = VecSimMetric_L2;
-
-    spaces::SetDistFunc(metric, dim, &(this->dist_func));
-
-    // Casting to void * so both sides of the comparison would have the
-    // same type.
-    if (std::is_same<TypeParam, float>::value) {
-        ASSERT_EQ(spaces::GetCalculationGuideline(dim), spaces::NO_OPTIMIZATION);
-        ASSERT_EQ((void *)(this->dist_func), (void *)(FP32_L2Sqr));
-    } else if (std::is_same<TypeParam, double>::value) {
-        ASSERT_EQ((void *)this->dist_func, (void *)FP64_L2Sqr);
-    }
-}
-
-// No Optimization distance function.
-TYPED_TEST(DistFuncTest, ip_no_optimization_get_func_test) {
-    // Choose a dim that has no optimizations
-    size_t dim = 1;
-    VecSimMetric metric = VecSimMetric_IP;
-
-    spaces::SetDistFunc(metric, dim, &(this->dist_func));
-
-    // Casting to void * so both sides of the comparison would have the
-    // same type.
-    if (std::is_same<TypeParam, float>::value) {
-        ASSERT_EQ((void *)(this->dist_func), (void *)(FP32_InnerProduct));
-    } else if (std::is_same<TypeParam, double>::value) {
-        ASSERT_EQ((void *)this->dist_func, (void *)FP64_InnerProduct);
-    }
-}
-
-/****** no optimization function tests suite ******/
-
-TYPED_TEST(DistFuncTest, l2_no_optimization_func_test) {
-    // Choose a dim that has no optimizations
-    size_t dim = 3;
-    VecSimMetric metric = VecSimMetric_L2;
-
-    spaces::SetDistFunc(metric, dim, &(this->dist_func));
-
-    TypeParam a[dim], b[dim];
-    for (size_t i = 0; i < dim; i++) {
-        a[i] = TypeParam(i + 1.0);
-        b[i] = TypeParam(i + 1.0);
-    }
-
-    TypeParam dist = this->dist_func((const void *)a, (const void *)b, dim);
-    ASSERT_EQ(dist, 0.0);
-}
-
-TYPED_TEST(DistFuncTest, IP_no_optimization_func_test) {
-    // Choose a dim that has no optimizations
-    size_t dim = 3;
-    VecSimMetric metric = VecSimMetric_IP;
-
-    spaces::SetDistFunc(metric, dim, &(this->dist_func));
-
-    TypeParam a[dim], b[dim];
-    for (size_t i = 0; i < dim; i++) {
-        a[i] = TypeParam(i + 1.5);
-        b[i] = TypeParam(i + 1.5);
-    }
-
-    normalizeVector(a, dim);
-    normalizeVector(b, dim);
-
-    TypeParam dist = this->dist_func((const void *)a, (const void *)b, dim);
-    ASSERT_NEAR(dist, 0.0, 0.00000001);
-}
 class SpacesTest : public ::testing::Test {
 
 protected:
@@ -108,6 +22,68 @@ protected:
 
     void TearDown() override {}
 };
+
+TEST_F(SpacesTest, float_l2_no_optimization_func_test) {
+    // Choose a dim that has no optimizations
+    size_t dim = 5;
+
+    float a[dim], b[dim];
+    for (size_t i = 0; i < dim; i++) {
+        a[i] = float(i + 1.0);
+        b[i] = float(i + 1.0);
+    }
+
+    float dist = FP32_L2Sqr((const void *)a, (const void *)b, dim);
+    ASSERT_EQ(dist, 0.0);
+}
+
+TEST_F(SpacesTest, double_l2_no_optimization_func_test) {
+    // Choose a dim that has no optimizations
+    size_t dim = 5;
+
+    double a[dim], b[dim];
+    for (size_t i = 0; i < dim; i++) {
+        a[i] = double(i + 1.0);
+        b[i] = double(i + 1.0);
+    }
+
+    double dist = FP64_L2Sqr((const void *)a, (const void *)b, dim);
+    ASSERT_EQ(dist, 0.0);
+}
+
+TEST_F(SpacesTest, float_ip_no_optimization_func_test) {
+    // Choose a dim that has no optimizations
+    size_t dim = 5;
+
+    float a[dim], b[dim];
+    for (size_t i = 0; i < dim; i++) {
+        a[i] = float(i + 1.5);
+        b[i] = float(i + 1.5);
+    }
+
+    normalizeVector(a, dim);
+    normalizeVector(b, dim);
+
+    float dist = FP32_InnerProduct((const void *)a, (const void *)b, dim);
+    ASSERT_FLOAT_EQ(dist, 0.0f);
+}
+
+TEST_F(SpacesTest, double_ip_no_optimization_func_test) {
+    // Choose a dim that has no optimizations
+    size_t dim = 5;
+
+    double a[dim], b[dim];
+    for (size_t i = 0; i < dim; i++) {
+        a[i] = double(i + 1.5);
+        b[i] = double(i + 1.5);
+    }
+
+    normalizeVector(a, dim);
+    normalizeVector(b, dim);
+
+    double dist = FP64_InnerProduct((const void *)a, (const void *)b, dim);
+    ASSERT_NEAR(dist, 0.0, 0.00000001);
+}
 
 #if defined(M1)
 

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -22,6 +22,43 @@ public:
 using DistTypes = ::testing::Types<float, double>;
 TYPED_TEST_SUITE(DistFuncTest, DistTypes);
 
+/****** Get distance function tests  ******/
+
+// No Optimization distance function.
+TYPED_TEST(DistFuncTest, l2_no_optimization_get_func_test) {
+    // Choose a dim that has no optimizations
+    size_t dim = 1;
+    VecSimMetric metric = VecSimMetric_L2;
+
+    spaces::SetDistFunc(metric, dim, &(this->dist_func));
+
+    // Casting to void * so both sides of the comparison would have the
+    // same type.
+    if (std::is_same<TypeParam, float>::value) {
+        ASSERT_EQ(spaces::GetCalculationGuideline(dim), spaces::NO_OPTIMIZATION);
+        ASSERT_EQ((void *)(this->dist_func), (void *)(FP32_L2Sqr));
+    } else if (std::is_same<TypeParam, double>::value) {
+        ASSERT_EQ((void *)this->dist_func, (void *)FP64_L2Sqr);
+    }
+}
+
+// No Optimization distance function.
+TYPED_TEST(DistFuncTest, ip_no_optimization_get_func_test) {
+    // Choose a dim that has no optimizations
+    size_t dim = 1;
+    VecSimMetric metric = VecSimMetric_IP;
+
+    spaces::SetDistFunc(metric, dim, &(this->dist_func));
+
+    // Casting to void * so both sides of the comparison would have the
+    // same type.
+    if (std::is_same<TypeParam, float>::value) {
+        ASSERT_EQ((void *)(this->dist_func), (void *)(FP32_InnerProduct));
+    } else if (std::is_same<TypeParam, double>::value) {
+        ASSERT_EQ((void *)this->dist_func, (void *)FP64_InnerProduct);
+    }
+}
+
 /****** no optimization function tests suite ******/
 
 TYPED_TEST(DistFuncTest, l2_no_optimization_func_test) {
@@ -30,14 +67,6 @@ TYPED_TEST(DistFuncTest, l2_no_optimization_func_test) {
     VecSimMetric metric = VecSimMetric_L2;
 
     spaces::SetDistFunc(metric, dim, &(this->dist_func));
-
-    // Casting to void * so both sides of the comparison would have the
-    // same type.
-    if (std::is_same<TypeParam, float>::value) {
-        ASSERT_EQ((void *)(this->dist_func), (void *)(FP32_L2Sqr));
-    } else if (std::is_same<TypeParam, double>::value) {
-        ASSERT_EQ((void *)this->dist_func, (void *)FP64_L2Sqr);
-    }
 
     TypeParam a[dim], b[dim];
     for (size_t i = 0; i < dim; i++) {
@@ -55,14 +84,6 @@ TYPED_TEST(DistFuncTest, IP_no_optimization_func_test) {
     VecSimMetric metric = VecSimMetric_IP;
 
     spaces::SetDistFunc(metric, dim, &(this->dist_func));
-
-    // Casting to void * so both sides of the comparison would have the
-    // same type.
-    if (std::is_same<TypeParam, float>::value) {
-        ASSERT_EQ((void *)(this->dist_func), (void *)(FP32_InnerProduct));
-    } else if (std::is_same<TypeParam, double>::value) {
-        ASSERT_EQ((void *)this->dist_func, (void *)FP64_InnerProduct);
-    }
 
     TypeParam a[dim], b[dim];
     for (size_t i = 0; i < dim; i++) {

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -8,7 +8,74 @@
 #include "VecSim/spaces/L2/L2_SSE.h"
 #include "VecSim/spaces/L2/L2_AVX.h"
 #include "VecSim/spaces/L2/L2_AVX512.h"
+#include "VecSim/spaces/spaces.h"
+#include "VecSim/utils/vec_utils.h"
 
+using spaces::dist_func_t;
+/****** templates distance function tests suite ******/
+template <typename DistType>
+class DistFuncTest : public testing::Test {
+public:
+    dist_func_t<DistType> dist_func;
+};
+
+using DistTypes = ::testing::Types<float, double>;
+TYPED_TEST_SUITE(DistFuncTest, DistTypes);
+
+/****** no optimization function tests suite ******/
+
+TYPED_TEST(DistFuncTest, l2_no_optimization_func_test) {
+    // Choose a dim that has no optimizations
+    size_t dim = 3;
+    VecSimMetric metric = VecSimMetric_L2;
+
+    spaces::SetDistFunc(metric, dim, &(this->dist_func));
+
+    // Casting to void * so both sides of the comparison would have the
+    // same type.
+    if (std::is_same<TypeParam, float>::value) {
+        ASSERT_EQ((void *)(this->dist_func), (void *)(FP32_L2Sqr));
+    } else if (std::is_same<TypeParam, double>::value) {
+        ASSERT_EQ((void *)this->dist_func, (void *)FP64_L2Sqr);
+    }
+
+    TypeParam a[dim], b[dim];
+    for (size_t i = 0; i < dim; i++) {
+        a[i] = TypeParam(i + 1.0);
+        b[i] = TypeParam(i + 1.0);
+    }
+
+    TypeParam dist = this->dist_func((const void *)a, (const void *)b, dim);
+    ASSERT_EQ(dist, 0.0);
+}
+
+TYPED_TEST(DistFuncTest, IP_no_optimization_func_test) {
+    // Choose a dim that has no optimizations
+    size_t dim = 3;
+    VecSimMetric metric = VecSimMetric_IP;
+
+    spaces::SetDistFunc(metric, dim, &(this->dist_func));
+
+    // Casting to void * so both sides of the comparison would have the
+    // same type.
+    if (std::is_same<TypeParam, float>::value) {
+        ASSERT_EQ((void *)(this->dist_func), (void *)(FP32_InnerProduct));
+    } else if (std::is_same<TypeParam, double>::value) {
+        ASSERT_EQ((void *)this->dist_func, (void *)FP64_InnerProduct);
+    }
+
+    TypeParam a[dim], b[dim];
+    for (size_t i = 0; i < dim; i++) {
+        a[i] = TypeParam(i + 1.5);
+        b[i] = TypeParam(i + 1.5);
+    }
+
+    normalizeVector(a, dim);
+    normalizeVector(b, dim);
+
+    TypeParam dist = this->dist_func((const void *)a, (const void *)b, dim);
+    ASSERT_NEAR(dist, 0.0, 0.00000001);
+}
 class SpacesTest : public ::testing::Test {
 
 protected:


### PR DESCRIPTION
**Describe the changes in the pull request**
In this PR we added fp64 support to no optimization distance calculation functions.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
