### PR TITLE
[BUG] fix for hnsw break condition

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -510,7 +510,7 @@ candidatesMaxHeap<dist_t> HierarchicalNSW<dist_t>::searchLayer(idType ep_id, con
 
     while (!candidate_set.empty()) {
         std::pair<dist_t, idType> curr_el_pair = candidate_set.top();
-        if ((-curr_el_pair.first) > lowerBound) {
+        if ((-curr_el_pair.first) > lowerBound && top_candidates.size() >= ef) {
             break;
         }
         candidate_set.pop();
@@ -1296,7 +1296,7 @@ HierarchicalNSW<dist_t>::searchBottomLayer_WithTimeout(idType ep_id, const void 
 
     while (!candidate_set.empty()) {
         std::pair<dist_t, idType> curr_el_pair = candidate_set.top();
-        if ((-curr_el_pair.first) > lowerBound) {
+        if ((-curr_el_pair.first) > lowerBound && top_candidates.size() >= ef) {
             break;
         }
         if (__builtin_expect(VecSimIndexAbstract<dist_t>::timeoutCallback(timeoutCtx), 0)) {


### PR DESCRIPTION
When the entry point for the base layer is close to the query vector, the lower bound might be set to a too low value, and therefore we might not get `ef` or even `k` results in the `top_candidates` heap.