### PR TITLE
Multi-Value - HNSW - enable range queries

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -304,6 +304,7 @@ BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double ra
     for (auto vectorBlock : this->vectorBlocks) {
         auto scores = computeBlockScores(vectorBlock, queryBlob, timeoutCtx, &rl.code);
         if (VecSim_OK != rl.code) {
+            delete res_container;
             return rl;
         }
         for (size_t i = 0; i < scores.size(); i++) {

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -69,7 +69,7 @@ protected:
     getNewMaxPriorityQueue() = 0;
 
     // inline label to id setters that need to be implemented by derived class
-    virtual inline vecsim_stl::abstract_results_container *
+    virtual inline std::unique_ptr<vecsim_stl::abstract_results_container>
     getNewResultsContainer(size_t cap) const = 0;
 
     // inline label to id setters that need to be implemented by derived class
@@ -296,7 +296,7 @@ BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double ra
     }
 
     // Compute scores in every block and save results that are within the range.
-    auto *res_container =
+    auto res_container =
         getNewResultsContainer(10); // Use 10 as the initial capacity for the dynamic array.
 
     DistType radius_ = DistType(radius);
@@ -304,7 +304,6 @@ BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double ra
     for (auto vectorBlock : this->vectorBlocks) {
         auto scores = computeBlockScores(vectorBlock, queryBlob, timeoutCtx, &rl.code);
         if (VecSim_OK != rl.code) {
-            delete res_container;
             return rl;
         }
         for (size_t i = 0; i < scores.size(); i++) {
@@ -317,7 +316,6 @@ BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double ra
     assert(curr_id == this->count);
     rl.code = VecSim_QueryResult_OK;
     rl.results = res_container->get_results();
-    delete res_container;
     return rl;
 }
 

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -301,10 +301,11 @@ BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double ra
 
     DistType radius_ = DistType(radius);
     idType curr_id = 0;
+    rl.code = VecSim_QueryResult_OK;
     for (auto vectorBlock : this->vectorBlocks) {
         auto scores = computeBlockScores(vectorBlock, queryBlob, timeoutCtx, &rl.code);
         if (VecSim_OK != rl.code) {
-            return rl;
+            break;
         }
         for (size_t i = 0; i < scores.size(); i++) {
             if (scores[i] <= radius_) {
@@ -313,8 +314,8 @@ BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double ra
             ++curr_id;
         }
     }
-    assert(curr_id == this->count);
-    rl.code = VecSim_QueryResult_OK;
+    // assert only if the loop finished iterating all the ids (we didn't get rl.code != VecSim_OK).
+    assert((rl.code == VecSim_OK ? curr_id == this->count : true));
     rl.results = res_container->get_results();
     return rl;
 }

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -315,7 +315,7 @@ BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double ra
         }
     }
     // assert only if the loop finished iterating all the ids (we didn't get rl.code != VecSim_OK).
-    assert((rl.code == VecSim_OK ? curr_id == this->count : true));
+    assert((rl.code != VecSim_OK || curr_id == this->count));
     rl.results = res_container->get_results();
     return rl;
 }

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -4,6 +4,7 @@
 #include "VecSim/vec_sim_index.h"
 #include "VecSim/spaces/spaces.h"
 #include "VecSim/utils/vecsim_stl.h"
+#include "VecSim/utils/vecsim_results_container.h"
 #include "VecSim/algorithms/brute_force/brute_force_factory.h"
 #include "VecSim/spaces/spaces.h"
 #include "VecSim/query_result_struct.h"
@@ -66,6 +67,10 @@ protected:
     // inline priority queue getter that need to be implemented by derived class
     virtual inline vecsim_stl::abstract_priority_queue<DistType, labelType> *
     getNewMaxPriorityQueue() = 0;
+
+    // inline label to id setters that need to be implemented by derived class
+    virtual inline vecsim_stl::abstract_results_container *
+    getNewResultsContainer(size_t cap) const = 0;
 
     // inline label to id setters that need to be implemented by derived class
     virtual inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) = 0;
@@ -291,8 +296,8 @@ BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double ra
     }
 
     // Compute scores in every block and save results that are within the range.
-    rl.results =
-        array_new<VecSimQueryResult>(10); // Use 10 as the initial capacity for the dynamic array.
+    auto *res_container =
+        getNewResultsContainer(10); // Use 10 as the initial capacity for the dynamic array.
 
     DistType radius_ = DistType(radius);
     idType curr_id = 0;
@@ -303,14 +308,15 @@ BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double ra
         }
         for (size_t i = 0; i < scores.size(); i++) {
             if (scores[i] <= radius_) {
-                auto res = VecSimQueryResult{getVectorLabel(curr_id), scores[i]};
-                rl.results = array_append(rl.results, res);
+                res_container->emplace(getVectorLabel(curr_id), scores[i]);
             }
             ++curr_id;
         }
     }
     assert(curr_id == this->count);
     rl.code = VecSim_QueryResult_OK;
+    rl.results = res_container->get_results();
+    delete res_container;
     return rl;
 }
 

--- a/src/VecSim/algorithms/brute_force/brute_force_multi.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_multi.h
@@ -20,6 +20,11 @@ public:
     int deleteVector(labelType labelType) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
 
+    inline vecsim_stl::abstract_results_container *
+    getNewResultsContainer(size_t cap) const override {
+        return new (this->allocator) vecsim_stl::unique_results_container(cap, this->allocator);
+    }
+
     inline size_t indexLabelCount() const override { return this->labelToIdsLookup.size(); }
 
 private:

--- a/src/VecSim/algorithms/brute_force/brute_force_multi.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_multi.h
@@ -19,13 +19,13 @@ public:
     int addVector(const void *vector_data, labelType label) override;
     int deleteVector(labelType labelType) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
-
-    inline vecsim_stl::abstract_results_container *
-    getNewResultsContainer(size_t cap) const override {
-        return new (this->allocator) vecsim_stl::unique_results_container(cap, this->allocator);
-    }
-
     inline size_t indexLabelCount() const override { return this->labelToIdsLookup.size(); }
+
+    inline std::unique_ptr<vecsim_stl::abstract_results_container>
+    getNewResultsContainer(size_t cap) const override {
+        return std::unique_ptr<vecsim_stl::abstract_results_container>(
+            new (this->allocator) vecsim_stl::unique_results_container(cap, this->allocator));
+    }
 
 private:
     // inline definitions

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -18,6 +18,11 @@ public:
     int deleteVector(labelType label) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
 
+    inline vecsim_stl::abstract_results_container *
+    getNewResultsContainer(size_t cap) const override {
+        return new (this->allocator) vecsim_stl::default_results_container(cap, this->allocator);
+    }
+
     inline size_t indexLabelCount() const override { return this->count; }
 
 protected:

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -18,9 +18,10 @@ public:
     int deleteVector(labelType label) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
 
-    inline vecsim_stl::abstract_results_container *
+    inline std::unique_ptr<vecsim_stl::abstract_results_container>
     getNewResultsContainer(size_t cap) const override {
-        return new (this->allocator) vecsim_stl::default_results_container(cap, this->allocator);
+        return std::unique_ptr<vecsim_stl::abstract_results_container>(
+            new (this->allocator) vecsim_stl::default_results_container(cap, this->allocator));
     }
 
     inline size_t indexLabelCount() const override { return this->count; }

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -1415,6 +1415,7 @@ VecSimQueryResult *HNSWIndex<DataType, DistType>::searchRangeBottomLayer_WithTim
     idType ep_id, const void *data_point, double epsilon, double radius, void *timeoutCtx,
     VecSimQueryResult_Code *rc) const {
 
+    *rc = VecSim_QueryResult_OK;
     auto *res_container = getNewResultsContainer(10); // arbitrary initial cap.
 
 #ifdef ENABLE_PARALLELIZATION
@@ -1450,9 +1451,7 @@ VecSimQueryResult *HNSWIndex<DataType, DistType>::searchRangeBottomLayer_WithTim
         }
         if (__builtin_expect(VecSimIndexAbstract<DistType>::timeoutCallback(timeoutCtx), 0)) {
             *rc = VecSim_QueryResult_TimedOut;
-            auto res = res_container->get_results();
-            delete res_container;
-            return res;
+            break;
         }
         candidate_set.pop();
 
@@ -1470,11 +1469,10 @@ VecSimQueryResult *HNSWIndex<DataType, DistType>::searchRangeBottomLayer_WithTim
                                      res_container, candidate_set, dynamic_range_search_boundaries,
                                      radius);
     }
+
 #ifdef ENABLE_PARALLELIZATION
     visited_nodes_handler_pool->returnVisitedNodesHandlerToPool(this->visited_nodes_handler);
 #endif
-
-    *rc = VecSim_QueryResult_OK;
     auto res = res_container->get_results();
     delete res_container;
     return res;

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -192,7 +192,7 @@ public:
 
 protected:
     // inline label to id setters that need to be implemented by derived class
-    virtual inline vecsim_stl::abstract_results_container *
+    virtual inline std::unique_ptr<vecsim_stl::abstract_results_container>
     getNewResultsContainer(size_t cap) const = 0;
     virtual inline void replaceIdOfLabel(labelType label, idType new_id, idType old_id) = 0;
     virtual inline void setVectorId(labelType label, idType id) = 0;
@@ -1415,8 +1415,7 @@ VecSimQueryResult *HNSWIndex<DataType, DistType>::searchRangeBottomLayer_WithTim
     VecSimQueryResult_Code *rc) const {
 
     *rc = VecSim_QueryResult_OK;
-    std::unique_ptr<vecsim_stl::abstract_results_container> res_container(
-        getNewResultsContainer(10)); // arbitrary initial cap.
+    auto res_container = getNewResultsContainer(10); // arbitrary initial cap.
 
 #ifdef ENABLE_PARALLELIZATION
     this->visited_nodes_handler =

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -32,6 +32,10 @@ public:
         return new (this->allocator)
             vecsim_stl::updatable_max_heap<DistType, labelType>(this->allocator);
     }
+    inline vecsim_stl::abstract_results_container *
+    getNewResultsContainer(size_t cap) const override {
+        return new (this->allocator) vecsim_stl::unique_results_container(cap, this->allocator);
+    }
 
     inline size_t indexLabelCount() const override;
     VecSimBatchIterator *newBatchIterator(const void *queryBlob,
@@ -40,8 +44,6 @@ public:
     int deleteVector(labelType label) override;
     int addVector(const void *vector_data, labelType label) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
-    VecSimQueryResult_List rangeQuery(const void *query_data, double radius,
-                                      VecSimQueryParams *queryParams) override;
 };
 
 /**
@@ -122,15 +124,6 @@ int HNSWIndex_Multi<DataType, DistType>::addVector(const void *vector_data, cons
     }
 
     return this->appendVector(vector_data, label);
-}
-
-// TODO: support range queries
-template <typename DataType, typename DistType>
-VecSimQueryResult_List
-HNSWIndex_Multi<DataType, DistType>::rangeQuery(const void *query_data, double radius,
-                                                VecSimQueryParams *queryParams) {
-    this->last_mode = RANGE_QUERY;
-    return {array_new<VecSimQueryResult>(0), VecSim_QueryResult_OK};
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -32,9 +32,10 @@ public:
         return new (this->allocator)
             vecsim_stl::updatable_max_heap<DistType, labelType>(this->allocator);
     }
-    inline vecsim_stl::abstract_results_container *
+    inline std::unique_ptr<vecsim_stl::abstract_results_container>
     getNewResultsContainer(size_t cap) const override {
-        return new (this->allocator) vecsim_stl::unique_results_container(cap, this->allocator);
+        return std::unique_ptr<vecsim_stl::abstract_results_container>(
+            new (this->allocator) vecsim_stl::unique_results_container(cap, this->allocator));
     }
 
     inline size_t indexLabelCount() const override;

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -29,9 +29,10 @@ public:
         return new (this->allocator)
             vecsim_stl::max_priority_queue<DistType, labelType>(this->allocator);
     }
-    inline vecsim_stl::abstract_results_container *
+    inline std::unique_ptr<vecsim_stl::abstract_results_container>
     getNewResultsContainer(size_t cap) const override {
-        return new (this->allocator) vecsim_stl::default_results_container(cap, this->allocator);
+        return std::unique_ptr<vecsim_stl::abstract_results_container>(
+            new (this->allocator) vecsim_stl::default_results_container(cap, this->allocator));
     }
 
     inline size_t indexLabelCount() const override;

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -29,6 +29,10 @@ public:
         return new (this->allocator)
             vecsim_stl::max_priority_queue<DistType, labelType>(this->allocator);
     }
+    inline vecsim_stl::abstract_results_container *
+    getNewResultsContainer(size_t cap) const override {
+        return new (this->allocator) vecsim_stl::default_results_container(cap, this->allocator);
+    }
 
     inline size_t indexLabelCount() const override;
     VecSimBatchIterator *newBatchIterator(const void *queryBlob,

--- a/src/VecSim/utils/vecsim_results_container.h
+++ b/src/VecSim/utils/vecsim_results_container.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "VecSim/utils/arr_cpp.h"
+#include "VecSim/utils/vecsim_stl.h"
+#include "VecSim/query_result_struct.h"
+
+namespace vecsim_stl {
+
+// An abstract API for query result container, used by RANGE queries.
+struct abstract_results_container : public VecsimBaseObject {
+public:
+    abstract_results_container(const std::shared_ptr<VecSimAllocator> &alloc)
+        : VecsimBaseObject(alloc) {}
+    ~abstract_results_container() {}
+
+    // Inserts (or updates) a new result to the container.
+    virtual inline void emplace(size_t id, double score) = 0;
+
+    // Returns the size of the container
+    virtual inline size_t size() const = 0;
+
+    // Returns an array (arr_cpp.h) containing all current data, and passes its ownership
+    virtual inline VecSimQueryResult *get_results() = 0;
+};
+
+struct unique_results_container : public abstract_results_container {
+private:
+    vecsim_stl::unordered_map<size_t, double> um;
+
+public:
+    explicit unique_results_container(const std::shared_ptr<VecSimAllocator> &alloc)
+        : abstract_results_container(alloc), um(alloc) {}
+    explicit unique_results_container(size_t cap, const std::shared_ptr<VecSimAllocator> &alloc)
+        : abstract_results_container(alloc), um(cap, alloc) {}
+
+    inline void emplace(size_t id, double score) override {
+        auto x = um.find(id);
+        if (x == um.end()) {
+            um.emplace(id, score);
+        } else if (x->second > score) {
+            x->second = score;
+        }
+    }
+
+    inline size_t size() const override { return um.size(); }
+
+    inline VecSimQueryResult *get_results() override {
+        auto *data = array_new_len<VecSimQueryResult>(um.size(), um.size());
+        size_t index = 0;
+        for (auto res : um) {
+            VecSimQueryResult_SetId(data[index], res.first);
+            VecSimQueryResult_SetScore(data[index], res.second);
+            index++;
+        }
+        return data;
+    }
+};
+
+struct default_results_container : public abstract_results_container {
+private:
+    VecSimQueryResult *_data;
+
+public:
+    explicit default_results_container(const std::shared_ptr<VecSimAllocator> &alloc)
+        : abstract_results_container(alloc), _data(array_new<VecSimQueryResult>(0)) {}
+    explicit default_results_container(size_t cap, const std::shared_ptr<VecSimAllocator> &alloc)
+        : abstract_results_container(alloc), _data(array_new<VecSimQueryResult>(cap)) {}
+
+    inline void emplace(size_t id, double score) override {
+        auto res = VecSimQueryResult{id, score};
+        _data = array_append(_data, res);
+    }
+    inline size_t size() const override { return array_len(_data); }
+    inline VecSimQueryResult *get_results() override { return _data; }
+};
+} // namespace vecsim_stl

--- a/tests/flow/test_bruteforce.py
+++ b/tests/flow/test_bruteforce.py
@@ -211,3 +211,62 @@ def test_bf_multivalue():
 
     assert_allclose(bf_labels, [keys],  rtol=1e-5, atol=0)
     assert_allclose(bf_distances, [dists],  rtol=1e-5, atol=0)
+
+def test_multi_range_query():
+    dim = 100
+    num_labels = 20000
+    per_label = 5
+
+    num_elements = num_labels * per_label
+
+    bfparams = BFParams()
+
+    bfparams.dim = dim
+    bfparams.metric = VecSimMetric_L2
+    bfparams.multi = True
+    bfparams.type = VecSimType_FLOAT32
+
+    bfindex = BFIndex(bfparams)
+
+    np.random.seed(47)
+    data = np.float32(np.random.random((num_labels, per_label, dim)))
+    vectors = []
+    for label, vecs in enumerate(data):
+        for vector in vecs:
+            bfindex.add_vector(vector, label)
+            vectors.append((label, vector))
+
+    query_data = np.float32(np.random.random((1, dim)))
+
+    radius = 13.0
+    recalls = {}
+    # calculate distances of the labels in the index
+    dists = {}
+    for key, vec in vectors:
+        dists[key] = min(spatial.distance.sqeuclidean(query_data, vec), dists.get(key, np.inf))
+
+    dists = list(dists.items())
+    dists = sorted(dists, key=lambda pair: pair[1])
+    keys = [key for key, dist in dists if dist <= radius]
+
+    for epsilon_rt in [0.001, 0.01, 0.1]:
+
+        start = time.time()
+        bf_labels, bf_distances = bfindex.range_query(query_data, radius=radius)
+        end = time.time()
+        res_num = len(bf_labels[0])
+
+        print(f'\nlookup time for ({num_labels} X {per_label}) vectors with dim={dim} took {end - start} seconds'
+              f' got {res_num} results, which are {res_num/len(keys)} of the entire results in the range.')
+
+        # Compare the number of vectors that are actually within the range to the returned results.
+        assert np.all(np.isin(bf_labels, np.array(keys)))
+
+        # Asserts that all the results are unique
+        assert len(bf_labels[0]) == len(np.unique(bf_labels[0]))
+
+        assert max(bf_distances[0]) <= radius
+
+    # Expect zero results for radius==0
+    bf_labels, bf_distances = bfindex.range_query(query_data, radius=0)
+    assert len(bf_labels[0]) == 0

--- a/tests/flow/test_bruteforce.py
+++ b/tests/flow/test_bruteforce.py
@@ -256,7 +256,7 @@ def test_multi_range_query():
     print(f'\nlookup time for ({num_labels} X {per_label}) vectors with dim={dim} took {end - start} seconds')
     
     # Recall should be 100%.
-    assert res_num/len(keys) == 1
+    assert res_num == len(keys)
 
     # Compare the number of vectors that are actually within the range to the returned results.
     assert np.all(np.isin(bf_labels, np.array(keys)))

--- a/tests/flow/test_hnswlib.py
+++ b/tests/flow/test_hnswlib.py
@@ -512,7 +512,7 @@ def test_multi_range_query():
         assert np.all(np.isin(hnsw_labels, np.array(keys)))
 
         # Asserts that all the results are unique
-        assert len(hnsw_labels) == len(np.unique(hnsw_labels))
+        assert len(hnsw_labels[0]) == len(np.unique(hnsw_labels[0]))
 
         assert max(hnsw_distances[0]) <= radius
         recalls[epsilon_rt] = res_num/len(keys)

--- a/tests/flow/test_hnswlib.py
+++ b/tests/flow/test_hnswlib.py
@@ -448,3 +448,76 @@ def test_recall_for_hnsw_multi_value():
     recall = float(correct)/(k*num_queries)
     print("\nrecall is: \n", recall)
     assert(recall > 0.9)
+
+
+def test_multi_range_query():
+    dim = 100
+    num_labels = 20000
+    per_label = 5
+
+    epsilon = 0.01
+
+    num_elements = num_labels * per_label
+
+    params = VecSimParams()
+    hnswparams = HNSWParams()
+
+    params.algo = VecSimAlgo_HNSWLIB
+
+    hnswparams.dim = dim
+    hnswparams.metric = VecSimMetric_L2
+    hnswparams.multi = True
+    hnswparams.type = VecSimType_FLOAT32
+    hnswparams.M = 32
+    hnswparams.efConstruction = 200
+    hnswparams.initialCapacity = num_elements
+    hnswparams.epsilon = epsilon
+
+    params.hnswParams = hnswparams
+    index = VecSimIndex(params)
+
+    np.random.seed(47)
+    data = np.float32(np.random.random((num_labels, per_label, dim)))
+    vectors = []
+    for label, vecs in enumerate(data):
+        for vector in vecs:
+            index.add_vector(vector, label)
+            vectors.append((label, vector))
+
+    query_data = np.float32(np.random.random((1, dim)))
+
+    radius = 13.0
+    recalls = {}
+    # sort distances of every vector from the target vector and get actual k nearest vectors
+    dists = {}
+    for key, vec in vectors:
+        dists[key] = min(spatial.distance.sqeuclidean(query_data, vec), dists.get(key, np.inf))
+
+    dists = list(dists.items())
+    dists = sorted(dists, key=lambda pair: pair[1])
+
+    for epsilon_rt in [0.001, 0.01, 0.1]:
+        query_params = VecSimQueryParams()
+        query_params.hnswRuntimeParams.epsilon = epsilon_rt
+        start = time.time()
+        hnsw_labels, hnsw_distances = index.range_query(query_data, radius=radius, query_param=query_params)
+        end = time.time()
+        res_num = len(hnsw_labels[0])
+
+        keys = [key for key, dist in dists if dist <= radius]
+
+        print(f'\nlookup time for ({num_labels} X {per_label}) vectors with dim={dim} took {end - start} seconds with epsilon={epsilon_rt},'
+              f' got {res_num} results, which are {res_num/len(keys)} of the entire results in the range.')
+
+        # Compare the number of vectors that are actually within the range to the returned results.
+        assert np.all(np.isin(hnsw_labels, np.array(keys)))
+
+        assert max(hnsw_distances[0]) <= radius
+        recalls[epsilon_rt] = res_num/len(keys)
+
+    # Expect higher recalls for higher epsilon values.
+    assert recalls[0.001] <= recalls[0.01] <= recalls[0.1]
+
+    # Expect zero results for radius==0
+    hnsw_labels, hnsw_distances = index.range_query(query_data, radius=0)
+    assert len(hnsw_labels[0]) == 0

--- a/tests/unit/test_bruteforce_multi.cpp
+++ b/tests/unit/test_bruteforce_multi.cpp
@@ -1124,11 +1124,10 @@ TYPED_TEST(BruteForceMultiTest, testTimeoutReturn) {
     VecSimQueryResult_Free(rl);
 
     // Check timeout again - range query
-    // TODO: uncomment when support for BFM range is enabled
-    // rl = VecSimIndex_RangeQuery(index, query, 1, NULL, BY_ID);
-    // ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
-    // ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
-    // VecSimQueryResult_Free(rl);
+    rl = VecSimIndex_RangeQuery(index, query, 1, NULL, BY_ID);
+    ASSERT_EQ(rl.code, VecSim_QueryResult_TimedOut);
+    ASSERT_EQ(VecSimQueryResult_Len(rl), 0);
+    VecSimQueryResult_Free(rl);
 
     VecSimIndex_Free(index);
     VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; }); // cleanup

--- a/tests/unit/test_bruteforce_multi.cpp
+++ b/tests/unit/test_bruteforce_multi.cpp
@@ -664,7 +664,8 @@ TYPED_TEST(BruteForceMultiTest, search_empty_index) {
 
     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
 
-    TEST_DATA_T query[] = {50, 50, 50, 50};
+    TEST_DATA_T query[dim];
+    GenerateVector<TEST_DATA_T>(query, dim, 50);
 
     // We do not expect any results.
     VecSimQueryResult_List res = VecSimIndex_TopKQuery(index, query, k, NULL, BY_SCORE);
@@ -674,10 +675,9 @@ TYPED_TEST(BruteForceMultiTest, search_empty_index) {
     VecSimQueryResult_IteratorFree(it);
     VecSimQueryResult_Free(res);
 
-    // TODO: uncomment when support for BFM range is enabled
-    // res = VecSimIndex_RangeQuery(index, (const void *)query, 1.0f, NULL, BY_SCORE);
-    // ASSERT_EQ(VecSimQueryResult_Len(res), 0);
-    // VecSimQueryResult_Free(res);
+    res = VecSimIndex_RangeQuery(index, query, 1.0, NULL, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    VecSimQueryResult_Free(res);
 
     // Add some vectors and remove them all from index, so it will be empty again.
     for (size_t i = 0; i < n; i++) {
@@ -697,10 +697,9 @@ TYPED_TEST(BruteForceMultiTest, search_empty_index) {
     VecSimQueryResult_IteratorFree(it);
     VecSimQueryResult_Free(res);
 
-    // TODO: uncomment when support for BFM range is enabled
-    // res = VecSimIndex_RangeQuery(index, (const void *)query, 1.0f, NULL, BY_SCORE);
-    // ASSERT_EQ(VecSimQueryResult_Len(res), 0);
-    // VecSimQueryResult_Free(res);
+    res = VecSimIndex_RangeQuery(index, query, 1.0, NULL, BY_SCORE);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 0);
+    VecSimQueryResult_Free(res);
 
     VecSimIndex_Free(index);
 }
@@ -1183,113 +1182,61 @@ TYPED_TEST(BruteForceMultiTest, testTimeoutReturn_batch_iterator) {
     VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; }); // cleanup
 }
 
-// TEST_F(BruteForceMultiTest, rangeQuery) {
-//     size_t n = 2000;
-//     size_t dim = 4;
+TYPED_TEST(BruteForceMultiTest, rangeQuery) {
+    size_t n_labels = 1000;
+    size_t per_label = 5;
+    size_t dim = 4;
 
-//     BFParams params{.type = VecSimType_FLOAT32,
-//       .dim = dim, .metric = VecSimMetric_L2,
-//      .blockSize = n / 2};
-// VecSimIndex *index = CreateNewIndex(params);
+    size_t n = n_labels * per_label;
 
-//     for (size_t i = 0; i < n; i++) {
-//         float f[dim];
-//         for (size_t j = 0; j < dim; j++) {
-//             f[j] = (float)i;
-//         }
-//         VecSimIndex_AddVector(index, (const void *)f, (int)i);
-//     }
-//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    BFParams params{.dim = dim, .metric = VecSimMetric_L2, .blockSize = n / 2};
 
-//     size_t pivot_id = n / 2; // The id to return vectors around it.
-//     float query[] = {(float)pivot_id, (float)pivot_id, (float)pivot_id, (float)pivot_id};
+    VecSimIndex *index = this->CreateNewIndex(params);
 
-//     // Validate invalid params are caught with runtime exception.
-//     try {
-//         VecSimIndex_RangeQuery(index, (const void *)query, -1, nullptr, BY_SCORE);
-//         FAIL();
-//     } catch (std::runtime_error const &err) {
-//         EXPECT_EQ(err.what(), std::string("radius must be non-negative"));
-//     }
-//     try {
-//         VecSimIndex_RangeQuery(index, (const void *)query, 1, nullptr,
-//         VecSimQueryResult_Order(2)); FAIL();
-//     } catch (std::runtime_error const &err) {
-//         EXPECT_EQ(err.what(), std::string("Possible order values are only 'BY_ID' or
-//         'BY_SCORE'"));
-//     }
+    for (size_t i = 0; i < n_labels; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(index, dim, i, i);
+        // Add some vectors, worst than the second loop (for the given query)
+        for (size_t j = 0; j < per_label - 1; j++)
+            GenerateAndAddVector(index, dim, i, (TEST_DATA_T)i + n);
+    }
 
-//     auto verify_res_by_score = [&](size_t id, float score, size_t index) {
-//         ASSERT_EQ(std::abs(int(id - pivot_id)), (index + 1) / 2);
-//         ASSERT_EQ(score, dim * powf((index + 1) / 2, 2));
-//     };
-//     uint expected_num_results = 11;
-//     // To get 11 results in the range [pivot_id - 5, pivot_id + 5], set the radius as the L2
-//     score
-//     // in the boundaries.
-//     float radius = dim * powf(expected_num_results / 2, 2);
-//     runRangeQueryTest(index, query, radius, verify_res_by_score, expected_num_results, BY_SCORE);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    ASSERT_EQ(index->indexLabelCount(), n_labels);
 
-//     // Get results by id.
-//     auto verify_res_by_id = [&](size_t id, float score, size_t index) {
-//         ASSERT_EQ(id, pivot_id - expected_num_results / 2 + index);
-//         ASSERT_EQ(score, dim * pow(std::abs(int(id - pivot_id)), 2));
-//     };
-//     runRangeQueryTest(index, query, radius, verify_res_by_id, expected_num_results);
+    size_t pivot_id = n_labels / 2; // The id to return vectors around it.
+    TEST_DATA_T query[dim];
+    GenerateVector<TEST_DATA_T>(query, dim, pivot_id);
 
-//     VecSimIndex_Free(index);
-// }
+    // Validate invalid params are caught with runtime exception.
+    try {
+        VecSimIndex_RangeQuery(index, query, -1, nullptr, BY_SCORE);
+        FAIL();
+    } catch (std::runtime_error const &err) {
+        EXPECT_EQ(err.what(), std::string("radius must be non-negative"));
+    }
+    try {
+        VecSimIndex_RangeQuery(index, query, 1, nullptr, VecSimQueryResult_Order(2));
+        FAIL();
+    } catch (std::runtime_error const &err) {
+        EXPECT_EQ(err.what(), std::string("Possible order values are only 'BY_ID' or 'BY_SCORE'"));
+    }
 
-// TEST_F(BruteForceMultiTest, rangeQueryCosine) {
-//     size_t n = 100;
-//     size_t dim = 4;
+    auto verify_res_by_score = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(std::abs(int(id - pivot_id)), (index + 1) / 2);
+        ASSERT_EQ(score, dim * pow((index + 1) / 2, 2));
+    };
+    uint expected_num_results = 11;
+    // To get 11 results in the range [pivot_id - 5, pivot_id + 5], set the radius as the L2 score
+    // in the boundaries.
+    double radius = dim * pow(expected_num_results / 2, 2);
+    runRangeQueryTest(index, query, radius, verify_res_by_score, expected_num_results, BY_SCORE);
 
-//     BFParams params{.type = VecSimType_FLOAT32,
-//                                              .dim = dim,
-//                                              .metric = VecSimMetric_Cosine,
-//                                              .blockSize = n / 2};
-// VecSimIndex *index = CreateNewIndex(params);
+    // Get results by id.
+    auto verify_res_by_id = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(id, pivot_id - expected_num_results / 2 + index);
+        ASSERT_EQ(score, dim * pow(std::abs(int(id - pivot_id)), 2));
+    };
+    runRangeQueryTest(index, query, radius, verify_res_by_id, expected_num_results);
 
-//     for (size_t i = 0; i < n; i++) {
-//         float f[dim];
-//         f[0] = float(i + 1) / n;
-//         for (size_t j = 1; j < dim; j++) {
-//             f[j] = 1.0f;
-//         }
-//         // Use as label := n - (internal id)
-//         VecSimIndex_AddVector(index, (const void *)f, n - i);
-//     }
-//     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
-//     float query[dim];
-//     for (size_t i = 0; i < dim; i++) {
-//         query[i] = 1.0f;
-//     }
-//     auto verify_res = [&](size_t id, float score, size_t index) {
-//         ASSERT_EQ(id, index + 1);
-//         float first_coordinate = float(n - index) / n;
-//         // By cosine definition: 1 - ((A \dot B) / (norm(A)*norm(B))), where A is the query
-//         vector
-//         // and B is the current result vector.
-//         float expected_score =
-//             1.0f -
-//             ((first_coordinate + (float)dim - 1.0f) /
-//              (sqrtf((float)dim) * sqrtf((float)(dim - 1) + first_coordinate *
-//              first_coordinate)));
-//         // Verify that abs difference between the actual and expected score is at most 1/10^5.
-//         ASSERT_NEAR(score, expected_score, 1e-5);
-//     };
-//     uint expected_num_results = 31;
-//     // Calculate the score of the 31st distant vector from the query vector (whose id should be
-//     30)
-//     // to get the radius.
-//     float edge_first_coordinate = (float)(n - expected_num_results + 1) / n;
-//     float radius =
-//         1.0f - ((edge_first_coordinate + (float)dim - 1.0f) /
-//                 (sqrtf((float)dim) *
-//                  sqrtf((float)(dim - 1) + edge_first_coordinate * edge_first_coordinate)));
-//     runRangeQueryTest(index, query, radius, verify_res, expected_num_results, BY_SCORE);
-//     // Return results BY_ID should give the same results.
-//     runRangeQueryTest(index, query, radius, verify_res, expected_num_results, BY_ID);
-
-//     VecSimIndex_Free(index);
-// }
+    VecSimIndex_Free(index);
+}

--- a/tests/unit/test_common.cpp
+++ b/tests/unit/test_common.cpp
@@ -5,6 +5,7 @@
 #include "VecSim/utils/updatable_heap.h"
 #include "VecSim/utils/vec_utils.h"
 #include "test_utils.h"
+#include "VecSim/utils/vecsim_results_container.h"
 
 #include <cstdlib>
 #include <limits>
@@ -276,6 +277,43 @@ TYPED_TEST(UtilsTests, VecSim_Normalize_Vector) {
     TypeParam one = 1.0;
     ASSERT_NEAR(one, norm, 0.0000001);
 }
+
+TEST_F(CommonTest, results_containers) {
+    std::shared_ptr<VecSimAllocator> allocator = VecSimAllocator::newVecsimAllocator();
+
+    auto res1 = VecSimQueryResult_List{0};
+    auto res2 = VecSimQueryResult_List{0};
+    {
+        vecsim_stl::default_results_container drc(allocator);
+        vecsim_stl::unique_results_container urc(allocator);
+
+        for (size_t i = 0; i < 10; i++) {
+            drc.emplace(i, i);
+            urc.emplace(i, i + 10);
+        }
+        for (size_t i = 0; i < 10; i++) {
+            urc.emplace(i, i);
+        }
+        ASSERT_EQ(drc.size(), 10);
+        ASSERT_EQ(urc.size(), 10);
+
+        res1.results = drc.get_results();
+        res2.results = urc.get_results();
+    }
+    sort_results_by_id(res1);
+    sort_results_by_score(res2);
+
+    for (size_t i = 0; i < VecSimQueryResult_Len(res1); i++) {
+        ASSERT_EQ(i, VecSimQueryResult_GetId(res1.results + i));
+    }
+    for (size_t i = 0; i < VecSimQueryResult_Len(res2); i++) {
+        ASSERT_EQ(i, VecSimQueryResult_GetId(res2.results + i));
+    }
+
+    VecSimQueryResult_Free(res1);
+    VecSimQueryResult_Free(res2);
+}
+
 
 class CommonAPITest : public ::testing::Test {};
 

--- a/tests/unit/test_common.cpp
+++ b/tests/unit/test_common.cpp
@@ -286,16 +286,25 @@ TYPED_TEST(UtilsTests, results_containers) {
     {
         vecsim_stl::default_results_container drc(allocator);
         vecsim_stl::unique_results_container urc(allocator);
+        // Checks for leaks if `get_results()` is not invoked
+        vecsim_stl::default_results_container dummy1(allocator);
+        vecsim_stl::unique_results_container dummy2(allocator);
 
         for (size_t i = 0; i < 10; i++) {
             drc.emplace(i, i);
             urc.emplace(i, i + 10);
+
+            dummy1.emplace(i, i);
+            dummy2.emplace(i, i + 10);
         }
         for (size_t i = 0; i < 10; i++) {
             urc.emplace(i, i);
+            dummy2.emplace(i, i);
         }
         ASSERT_EQ(drc.size(), 10);
         ASSERT_EQ(urc.size(), 10);
+        ASSERT_EQ(dummy1.size(), 10);
+        ASSERT_EQ(dummy2.size(), 10);
 
         res1.results = drc.get_results();
         res2.results = urc.get_results();

--- a/tests/unit/test_common.cpp
+++ b/tests/unit/test_common.cpp
@@ -323,7 +323,6 @@ TYPED_TEST(UtilsTests, results_containers) {
     VecSimQueryResult_Free(res2);
 }
 
-
 class CommonAPITest : public ::testing::Test {};
 
 TEST(CommonAPITest, VecSim_QueryResult_Iterator) {

--- a/tests/unit/test_common.cpp
+++ b/tests/unit/test_common.cpp
@@ -278,7 +278,7 @@ TYPED_TEST(UtilsTests, VecSim_Normalize_Vector) {
     ASSERT_NEAR(one, norm, 0.0000001);
 }
 
-TEST_F(CommonTest, results_containers) {
+TYPED_TEST(UtilsTests, results_containers) {
     std::shared_ptr<VecSimAllocator> allocator = VecSimAllocator::newVecsimAllocator();
 
     auto res1 = VecSimQueryResult_List{0};

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -1731,7 +1731,7 @@ TYPED_TEST(HNSWMultiTest, rangeQuery) {
     // loop to break since we insert a candidate whose distance is within the dynamic range
     // boundaries at the beginning of the search, but when this candidate is popped out from the
     // queue, it's no longer within the dynamic range boundaries.
-    auto query_params = VecSimQueryParams{.hnswRuntimeParams = HNSWRuntimeParams{.epsilon = 1.0}};
+    VecSimQueryParams query_params = CreateQueryParams(HNSWRuntimeParams{.epsilon = 1.0});
     runRangeQueryTest(index, query, radius, verify_res_by_score, expected_num_results, BY_SCORE,
                       &query_params);
 

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -1693,22 +1693,11 @@ TYPED_TEST(HNSWMultiTest, rangeQuery) {
     HNSWParams params{.dim = dim, .metric = VecSimMetric_L2, .blockSize = n / 2};
     VecSimIndex *index = this->CreateNewIndex(params);
 
-    // Add some vectors, worst than the second loop (for the given query)
     for (size_t i = 0; i < n_labels; i++) {
-        TEST_DATA_T f[dim];
-        for (size_t j = 0; j < dim; j++) {
-            f[j] = (TEST_DATA_T)i + n;
-        }
-        // Use as label := n - (internal id)
+        GenerateAndAddVector<TEST_DATA_T>(index, dim, i, i);
+        // Add some vectors, worst than the previous vector (for the given query)
         for (size_t j = 0; j < per_label - 1; j++)
-            VecSimIndex_AddVector(index, (const void *)f, i);
-    }
-    for (size_t i = 0; i < n_labels; i++) {
-        TEST_DATA_T f[dim];
-        for (size_t j = 0; j < dim; j++) {
-            f[j] = (TEST_DATA_T)i;
-        }
-        VecSimIndex_AddVector(index, (const void *)f, (int)i);
+            GenerateAndAddVector<TEST_DATA_T>(index, dim, i, i + n);
     }
     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
     ASSERT_EQ(index->indexLabelCount(), n_labels);

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -1703,8 +1703,8 @@ TYPED_TEST(HNSWMultiTest, rangeQuery) {
     ASSERT_EQ(index->indexLabelCount(), n_labels);
 
     size_t pivot_id = n_labels / 2; // the id to return vectors around it.
-    TEST_DATA_T query[] = {(TEST_DATA_T)pivot_id, (TEST_DATA_T)pivot_id, (TEST_DATA_T)pivot_id,
-                           (TEST_DATA_T)pivot_id};
+    TEST_DATA_T query[dim];
+    GenerateVector<TEST_DATA_T>(query, dim, pivot_id);
 
     auto verify_res_by_score = [&](size_t id, double score, size_t index) {
         ASSERT_EQ(std::abs(int(id - pivot_id)), (index + 1) / 2);
@@ -1713,7 +1713,7 @@ TYPED_TEST(HNSWMultiTest, rangeQuery) {
     uint expected_num_results = 11;
     // To get 11 results in the range [pivot_id - 5, pivot_id + 5], set the radius as the L2 score
     // in the boundaries.
-    TEST_DATA_T radius = dim * pow(expected_num_results / 2, 2);
+    double radius = dim * pow(expected_num_results / 2, 2);
     runRangeQueryTest(index, query, radius, verify_res_by_score, expected_num_results, BY_SCORE);
 
     // Rerun with a given query params. This high epsilon value will cause the range search main

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -217,6 +217,7 @@ void runRangeQueryTest(VecSimIndex *index, const void *query, double radius,
     VecSimQueryResult_List res =
         VecSimIndex_RangeQuery(index, (const void *)query, radius, params, order);
     ASSERT_EQ(VecSimQueryResult_Len(res), expected_res_num);
+    ASSERT_TRUE(allUniqueResults(res));
     VecSimQueryResult_Iterator *iterator = VecSimQueryResult_List_GetIterator(res);
     int res_ind = 0;
     while (VecSimQueryResult_IteratorHasNext(iterator)) {


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR enables RANGE queries on multi-value HNSW indices.
It also includes a definition for abstract API for results containers (for collecting results while scanning the index), and implementations for two results containers, for single and multi indices.

**Which issues this PR fixes**
1. [MOD-3934](https://redislabs.atlassian.net/browse/MOD-3934)
2. [MOD-4280](https://redislabs.atlassian.net/browse/MOD-4280)


**Main objects this PR modified**
1. results container API and implementation
2. HNSW base class
3. HNSW single and multi

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
