### PR TITLE
Fix module test in nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,10 @@ commands:
             - ~/.cache/pip
             - ~/.cache/pypoetry
           key: v2-dependencies-{{ checksum "pyproject.toml" }}-{{ .Environment.CIRCLE_STAGE }}
+      # TODO: REMOVE BEFORE MERGE
+      - run:
+          name: Redis tests
+          command: python3 -m tox -e modtest
 
 #----------------------------------------------------------------------------------------------------------------------------------
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,6 @@ workflows:
           context: common
           <<: *on-perf-and-version-tags
 
-
   benchmark_flow_label:
     when:
       << pipeline.parameters.run_benchmark_flow_label >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,10 +167,6 @@ commands:
             - ~/.cache/pip
             - ~/.cache/pypoetry
           key: v2-dependencies-{{ checksum "pyproject.toml" }}-{{ .Environment.CIRCLE_STAGE }}
-      # TODO: REMOVE BEFORE MERGE
-      - run:
-          name: Redis tests
-          command: python3 -m tox -e modtest
 
 #----------------------------------------------------------------------------------------------------------------------------------
 
@@ -424,6 +420,9 @@ workflows:
       - run-benchmarks:
           context: common
           <<: *on-perf-and-version-tags
+      # TODO: REMOVE BEFORE MERGE
+      - nightly_flow
+
 
   benchmark_flow_label:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,8 +420,6 @@ workflows:
       - run-benchmarks:
           context: common
           <<: *on-perf-and-version-tags
-      # TODO: REMOVE BEFORE MERGE
-      - nightly_flow
 
 
   benchmark_flow_label:

--- a/tests/module/memory_test.c
+++ b/tests/module/memory_test.c
@@ -33,7 +33,7 @@ void _add_vectors(VecSimIndex *index, long long amount) {
     default:
         break;
     }
-    int64_t vec[dim];
+    double vec[dim];
     for (int i = 0; i < dim; i++)
         vec[i] = i;
     for (long long j = 0; j < amount; j++)
@@ -56,9 +56,10 @@ VecSimIndex *_create_index(VecSimAlgo algo) {
     case VecSimAlgo_BF:
         param.bfParams.blockSize = 1;
         param.bfParams.initialCapacity = 1;
-        param.bfParams.type = VecSimType_INT64;
+        param.bfParams.type = VecSimType_FLOAT64;
         param.bfParams.dim = DIMENSION;
         param.bfParams.metric = VecSimMetric_L2;
+        param.bfParams.multi = false;
         break;
 
     case VecSimAlgo_HNSWLIB:
@@ -66,9 +67,10 @@ VecSimIndex *_create_index(VecSimAlgo algo) {
         param.hnswParams.initialCapacity = 1;
         param.hnswParams.efConstruction = 0;
         param.hnswParams.efRuntime = 0;
-        param.hnswParams.type = VecSimType_INT64;
+        param.hnswParams.type = VecSimType_FLOAT64;
         param.hnswParams.dim = DIMENSION;
         param.hnswParams.metric = VecSimMetric_L2;
+        param.hnswParams.multi = false;
         break;
     }
 


### PR DESCRIPTION
Test was using INT64 as vector's data type which is not supported. Since we began validating the data type, these tests fails on nightly. This PR fixes the tests by using FLOAT64 as vectors data type instead.