### PR TITLE
added default behavior for bm_files script

### DIFF
--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -1,16 +1,16 @@
-GIT_LABEL=$1
-if [ -z "$GIT_LABEL"  ] || [ "$GIT_LABEL" = "benchmarks-all" ]; then 
+BM_TYPE=$1
+if [ -z "$BM_TYPE"  ] || [ "$BM_TYPE" = "benchmarks-all" ]; then 
     file_name="all"
-elif [ "$GIT_LABEL" = "bm-spaces" ]; then
+elif [ "$BM_TYPE" = "bm-spaces" ]; then
     :
-elif [ "$GIT_LABEL" = "benchmarks-default" ] \
-|| [ "$GIT_LABEL" = "bm-basics-fp32-single" ] \
-|| [ "$GIT_LABEL" = "bm-basics-fp32-multi" ] \
-|| [ "$GIT_LABEL" = "bm-batch-iter-fp32-single" ] \
-|| [ "$GIT_LABEL" = "bm-batch-iter-fp32-multi" ] 
+elif [ "$BM_TYPE" = "benchmarks-default" ] \
+|| [ "$BM_TYPE" = "bm-basics-fp32-single" ] \
+|| [ "$BM_TYPE" = "bm-basics-fp32-multi" ] \
+|| [ "$BM_TYPE" = "bm-batch-iter-fp32-single" ] \
+|| [ "$BM_TYPE" = "bm-batch-iter-fp32-multi" ] 
 then
     file_name="basic_fp32"
-elif [ "$GIT_LABEL" = "bm-updated-fp32-single" ]; then
+elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then
     file_name="updated"
 fi
 

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -1,6 +1,7 @@
 GIT_LABEL=$1
-fp32_labels="benchmarks-default, bm basics fp32 single, bm basics fp32 multi"
-if [ "$GIT_LABEL" = "bm-spaces" ]; then
+if [ -z "$GIT_LABEL"  ] || [ "$GIT_LABEL" = "benchmarks-all" ]; then 
+    file_name="all"
+elif [ "$GIT_LABEL" = "bm-spaces" ]; then
     :
 elif [ "$GIT_LABEL" = "benchmarks-default" ] \
 || [ "$GIT_LABEL" = "bm-basics-fp32-single" ] \
@@ -11,8 +12,6 @@ then
     file_name="basic_fp32"
 elif [ "$GIT_LABEL" = "bm-updated-fp32-single" ]; then
     file_name="updated"
-elif [ "$GIT_LABEL" = "benchmarks-all" ]; then
-    file_name="all"
 fi
 
 wget --no-check-certificate -q -i tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt -P tests/benchmark/data


### PR DESCRIPTION
**Describe the changes in the pull request**

The bm_files.sh script parameter is now optional.
with no arguments, it downloads all files.

**Which issues this PR fixes**
1. The argument passed to the scripts is the git label. In nightly runs, this would be an empty parameter.

**Main objects this PR modified**
1. bm_files.sh

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
