### PR TITLE
Refactor add/delete API as an enabler for tiered index

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -116,7 +116,7 @@ BruteForceIndex<DataType, DistType>::~BruteForceIndex() {
 
 template <typename DataType, typename DistType>
 void BruteForceIndex<DataType, DistType>::appendVector(const void *vector_data, labelType label) {
-
+    assert(indexCapacity() > indexSize());
     // Give the vector new id and increase count.
     idType id = this->count++;
 

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -37,7 +37,7 @@ public:
 
     size_t indexSize() const override;
     size_t indexCapacity() const override;
-    void resize() override;
+    void increaseCapacity() override;
     vecsim_stl::vector<DistType> computeBlockScores(VectorBlock *block, const void *queryBlob,
                                                     void *timeoutCtx,
                                                     VecSimQueryResult_Code *rc) const;
@@ -203,7 +203,7 @@ size_t BruteForceIndex<DataType, DistType>::indexCapacity() const {
 }
 
 template <typename DataType, typename DistType>
-void BruteForceIndex<DataType, DistType>::resize() {
+void BruteForceIndex<DataType, DistType>::increaseCapacity() {
     size_t vector_bytes_count = this->dim * VecSimType_sizeof(this->vecType);
     auto *new_vector_block =
         new (this->allocator) VectorBlock(this->blockSize, vector_bytes_count, this->allocator);

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -58,10 +58,10 @@ public:
 
 protected:
     // Private internal function that implements generic single vector insertion.
-    virtual int appendVector(const void *vector_data, labelType label);
+    virtual void appendVector(const void *vector_data, labelType label);
 
     // Private internal function that implements generic single vector deletion.
-    virtual int removeVector(idType id);
+    virtual void removeVector(idType id);
 
     inline VectorBlock *getVectorVectorBlock(idType id) const {
         return vectorBlocks.at(id / this->blockSize);
@@ -113,7 +113,7 @@ BruteForceIndex<DataType, DistType>::~BruteForceIndex() {
 /******************** Implementation **************/
 
 template <typename DataType, typename DistType>
-int BruteForceIndex<DataType, DistType>::appendVector(const void *vector_data, labelType label) {
+void BruteForceIndex<DataType, DistType>::appendVector(const void *vector_data, labelType label) {
 
     // Give the vector new id and increase count.
     idType id = this->count++;
@@ -151,12 +151,10 @@ int BruteForceIndex<DataType, DistType>::appendVector(const void *vector_data, l
 
     // add id to label:id map
     setVectorId(label, id);
-
-    return true;
 }
 
 template <typename DataType, typename DistType>
-int BruteForceIndex<DataType, DistType>::removeVector(idType id_to_delete) {
+void BruteForceIndex<DataType, DistType>::removeVector(idType id_to_delete) {
 
     // Get last vector id and label
     idType last_idx = --this->count;
@@ -201,8 +199,6 @@ int BruteForceIndex<DataType, DistType>::removeVector(idType id_to_delete) {
             this->idToLabelMapping.resize(idToLabel_size - this->blockSize - vector_to_align_count);
         }
     }
-
-    return true;
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/brute_force/brute_force_multi.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_multi.h
@@ -22,7 +22,7 @@ public:
 
     ~BruteForceIndex_Multi() {}
 
-    int addVector(const void *vector_data, labelType label, bool override_allowed = true) override;
+    int addVector(const void *vector_data, labelType label, bool overwrite_allowed = true) override;
     int deleteVector(labelType labelType) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
     inline size_t indexLabelCount() const override { return this->labelToIdsLookup.size(); }
@@ -61,7 +61,7 @@ private:
 
 template <typename DataType, typename DistType>
 int BruteForceIndex_Multi<DataType, DistType>::addVector(const void *vector_data, labelType label,
-                                                         bool override_allowed) {
+                                                         bool overwrite_allowed) {
 
     DataType normalized_blob[this->dim]; // This will be use only if metric == VecSimMetric_Cosine.
     if (this->metric == VecSimMetric_Cosine) {

--- a/src/VecSim/algorithms/brute_force/brute_force_multi.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_multi.h
@@ -22,7 +22,7 @@ public:
 
     ~BruteForceIndex_Multi() {}
 
-    int addVector(const void *vector_data, labelType label) override;
+    int addVector(const void *vector_data, labelType label, bool override_allowed = true) override;
     int deleteVector(labelType labelType) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
     inline size_t indexLabelCount() const override { return this->labelToIdsLookup.size(); }
@@ -60,7 +60,8 @@ private:
 /******************************* Implementation **********************************/
 
 template <typename DataType, typename DistType>
-int BruteForceIndex_Multi<DataType, DistType>::addVector(const void *vector_data, labelType label) {
+int BruteForceIndex_Multi<DataType, DistType>::addVector(const void *vector_data, labelType label,
+                                                         bool override_allowed) {
 
     DataType normalized_blob[this->dim]; // This will be use only if metric == VecSimMetric_Cosine.
     if (this->metric == VecSimMetric_Cosine) {
@@ -69,24 +70,25 @@ int BruteForceIndex_Multi<DataType, DistType>::addVector(const void *vector_data
         vector_data = normalized_blob;
     }
 
-    return this->appendVector(vector_data, label);
+    this->appendVector(vector_data, label);
+    return 1;
 }
 
 template <typename DataType, typename DistType>
 int BruteForceIndex_Multi<DataType, DistType>::deleteVector(labelType label) {
+    int ret = 0;
 
     // Find the id to delete.
     auto deleted_label_ids_pair = this->labelToIdsLookup.find(label);
     if (deleted_label_ids_pair == this->labelToIdsLookup.end()) {
         // Nothing to delete.
-        return true;
+        return ret;
     }
-
-    int ret = true;
 
     // Deletes all vectors under the given label.
     for (auto id_to_delete : deleted_label_ids_pair->second) {
-        ret = (this->removeVector(id_to_delete) && ret);
+        this->removeVector(id_to_delete);
+        ret++;
     }
 
     // Remove the pair of the deleted vector.

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -20,7 +20,7 @@ public:
     BruteForceIndex_Single(const BFParams *params, std::shared_ptr<VecSimAllocator> allocator);
     ~BruteForceIndex_Single();
 
-    int addVector(const void *vector_data, labelType label, bool override_allowed = true) override;
+    int addVector(const void *vector_data, labelType label, bool overwrite_allowed = true) override;
     int deleteVector(labelType label) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
 
@@ -83,7 +83,7 @@ BruteForceIndex_Single<DataType, DistType>::~BruteForceIndex_Single() {}
 
 template <typename DataType, typename DistType>
 int BruteForceIndex_Single<DataType, DistType>::addVector(const void *vector_data, labelType label,
-                                                          bool override_allowed) {
+                                                          bool overwrite_allowed) {
 
     DataType normalized_blob[this->dim]; // This will be use only if metric == VecSimMetric_Cosine
     if (this->metric == VecSimMetric_Cosine) {

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -82,8 +82,8 @@ template <typename DataType, typename DistType>
 BruteForceIndex_Single<DataType, DistType>::~BruteForceIndex_Single() {}
 
 template <typename DataType, typename DistType>
-int BruteForceIndex_Single<DataType, DistType>::addVector(const void *vector_data,
-                                                          labelType label, bool override_allowed) {
+int BruteForceIndex_Single<DataType, DistType>::addVector(const void *vector_data, labelType label,
+                                                          bool override_allowed) {
 
     DataType normalized_blob[this->dim]; // This will be use only if metric == VecSimMetric_Cosine
     if (this->metric == VecSimMetric_Cosine) {

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -20,7 +20,7 @@ public:
     BruteForceIndex_Single(const BFParams *params, std::shared_ptr<VecSimAllocator> allocator);
     ~BruteForceIndex_Single();
 
-    int addVector(const void *vector_data, labelType label) override;
+    int addVector(const void *vector_data, labelType label, bool override_allowed = true) override;
     int deleteVector(labelType label) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
 
@@ -83,7 +83,7 @@ BruteForceIndex_Single<DataType, DistType>::~BruteForceIndex_Single() {}
 
 template <typename DataType, typename DistType>
 int BruteForceIndex_Single<DataType, DistType>::addVector(const void *vector_data,
-                                                          labelType label) {
+                                                          labelType label, bool override_allowed) {
 
     DataType normalized_blob[this->dim]; // This will be use only if metric == VecSimMetric_Cosine
     if (this->metric == VecSimMetric_Cosine) {
@@ -97,10 +97,11 @@ int BruteForceIndex_Single<DataType, DistType>::addVector(const void *vector_dat
     if (optionalID != this->labelToIdLookup.end()) {
         idType id = optionalID->second;
         updateVector(id, vector_data);
-        return true;
+        return 0;
     }
 
-    return this->appendVector(vector_data, label);
+    this->appendVector(vector_data, label);
+    return 1;
 }
 
 template <typename DataType, typename DistType>
@@ -110,7 +111,7 @@ int BruteForceIndex_Single<DataType, DistType>::deleteVector(labelType label) {
     auto deleted_label_id_pair = this->labelToIdLookup.find(label);
     if (deleted_label_id_pair == this->labelToIdLookup.end()) {
         // Nothing to delete.
-        return true;
+        return 0;
     }
 
     // Get deleted vector id.
@@ -119,7 +120,8 @@ int BruteForceIndex_Single<DataType, DistType>::deleteVector(labelType label) {
     // Remove the pair of the deleted vector.
     labelToIdLookup.erase(label);
 
-    return this->removeVector(id_to_delete);
+    this->removeVector(id_to_delete);
+    return 1;
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -1238,7 +1238,7 @@ void HNSWIndex<DataType, DistType>::removeVector(const idType element_internal_i
 
 template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::appendVector(const void *vector_data, const labelType label) {
-
+    assert(indexCapacity() > indexSize());
     idType cur_c;
 
     DataType normalized_blob[this->dim]; // This will be use only if metric == VecSimMetric_Cosine

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -205,7 +205,7 @@ public:
 
     inline void markDeletedInternal(idType internalId);
     inline bool isMarkedDeleted(idType internalId) const;
-    void resize() override;
+    void increaseCapacity() override;
 
     // inline priority queue getter that need to be implemented by derived class
     virtual inline candidatesLabelsMaxHeap<DistType> *getNewMaxPriorityQueue() const = 0;
@@ -1141,7 +1141,7 @@ HNSWIndex<DataType, DistType>::~HNSWIndex() {
  * Index API functions
  */
 template <typename DataType, typename DistType>
-void HNSWIndex<DataType, DistType>::resize() {
+void HNSWIndex<DataType, DistType>::increaseCapacity() {
     size_t vectors_to_add = this->blockSize - max_elements_ % this->blockSize;
     resizeIndexInternal(max_elements_ + vectors_to_add);
 }

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -161,10 +161,10 @@ protected:
     inline void SwapLastIdWithDeletedId(idType element_internal_id);
 
     // Protected internal function that implements generic single vector insertion.
-    int appendVector(const void *vector_data, labelType label);
+    void appendVector(const void *vector_data, labelType label);
 
     // Protected internal function that implements generic single vector deletion.
-    int removeVector(idType id);
+    void removeVector(idType id);
 
     inline void emplaceToHeap(vecsim_stl::abstract_priority_queue<DistType, idType> &heap,
                               DistType dist, idType id) const;
@@ -389,16 +389,6 @@ void HNSWIndex<DataType, DistType>::markDeletedInternal(idType internalId) {
         elementFlags *flags = get_flags(internalId);
         *flags |= DELETE_MARK;
         this->num_marked_deleted++;
-    }
-}
-
-template <typename DataType, typename DistType>
-void HNSWIndex<DataType, DistType>::unmarkDeletedInternal(idType internalId) {
-    assert(internalId < this->cur_element_count);
-    if (isMarkedDeleted(internalId)) {
-        elementFlags *flags = get_flags(internalId);
-        *flags &= ~DELETE_MARK;
-        this->num_marked_deleted--;
     }
 }
 
@@ -1148,7 +1138,7 @@ void HNSWIndex<DataType, DistType>::resizeIndex(size_t new_max_elements) {
 }
 
 template <typename DataType, typename DistType>
-int HNSWIndex<DataType, DistType>::removeVector(const idType element_internal_id) {
+void HNSWIndex<DataType, DistType>::removeVector(const idType element_internal_id) {
 
     vecsim_stl::vector<bool> neighbours_bitmap(this->allocator);
 
@@ -1235,11 +1225,10 @@ int HNSWIndex<DataType, DistType>::removeVector(const idType element_internal_id
         // Remove one block from the capacity.
         this->resizeIndex(max_elements_ - this->blockSize - extra_space_to_free);
     }
-    return true;
 }
 
 template <typename DataType, typename DistType>
-int HNSWIndex<DataType, DistType>::appendVector(const void *vector_data, const labelType label) {
+void HNSWIndex<DataType, DistType>::appendVector(const void *vector_data, const labelType label) {
 
     idType cur_c;
 
@@ -1364,7 +1353,6 @@ int HNSWIndex<DataType, DistType>::appendVector(const void *vector_data, const l
         }
         maxlevel_ = element_max_level;
     }
-    return true;
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -141,7 +141,7 @@ int HNSWIndex_Multi<DataType, DistType>::addVector(const void *vector_data, cons
                                                    bool override_allowed) {
 
     this->appendVector(vector_data, label);
-    return 1;  // We always add the vector, no overrides in multi.
+    return 1; // We always add the vector, no overrides in multi.
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -59,10 +59,9 @@ public:
                                           VecSimQueryParams *queryParams) const override;
 
     int deleteVector(labelType label) override;
-    int addVector(const void *vector_data, labelType label) override;
+    int addVector(const void *vector_data, labelType label, bool override_allowed = true) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
-    inline int markDelete(labelType label) override;
-    inline int unmarkDelete(labelType label) override;
+    inline std::vector<idType> markDelete(labelType label) override;
 };
 
 /**
@@ -123,22 +122,26 @@ void HNSWIndex_Multi<DataType, DistType>::resizeLabelLookup(size_t new_max_eleme
 
 template <typename DataType, typename DistType>
 int HNSWIndex_Multi<DataType, DistType>::deleteVector(const labelType label) {
+    int ret = 0;
     // check that the label actually exists in the graph, and update the number of elements.
     auto ids = label_lookup_.find(label);
     if (ids == label_lookup_.end()) {
-        return false;
+        return ret;
     }
     for (idType id : ids->second) {
         this->removeVector(id);
+        ret++;
     }
     label_lookup_.erase(ids);
-    return true;
+    return ret;
 }
 
 template <typename DataType, typename DistType>
-int HNSWIndex_Multi<DataType, DistType>::addVector(const void *vector_data, const labelType label) {
+int HNSWIndex_Multi<DataType, DistType>::addVector(const void *vector_data, const labelType label,
+                                                   bool override_allowed) {
 
-    return this->appendVector(vector_data, label);
+    this->appendVector(vector_data, label);
+    return 1;  // We always add the vector, no overrides in multi.
 }
 
 template <typename DataType, typename DistType>
@@ -160,31 +163,17 @@ HNSWIndex_Multi<DataType, DistType>::newBatchIterator(const void *queryBlob,
  * @param label
  */
 template <typename DataType, typename DistType>
-int HNSWIndex_Multi<DataType, DistType>::markDelete(labelType label) {
+std::vector<idType> HNSWIndex_Multi<DataType, DistType>::markDelete(labelType label) {
+    std::vector<idType> idsToDelete;
     auto search = label_lookup_.find(label);
     if (search == label_lookup_.end()) {
-        return false;
+        return idsToDelete;
     }
 
     for (idType id : search->second) {
         this->markDeletedInternal(id);
+        idsToDelete.push_back(id);
     }
-    return true;
-}
-
-/**
- * Remove the deleted mark of the node, does NOT really change the current graph.
- * @param label
- */
-template <typename DataType, typename DistType>
-int HNSWIndex_Multi<DataType, DistType>::unmarkDelete(labelType label) {
-    auto search = label_lookup_.find(label);
-    if (search == label_lookup_.end()) {
-        return false;
-    }
-
-    for (idType id : search->second) {
-        this->unmarkDeletedInternal(id);
-    }
-    return true;
+    label_lookup_.erase(search);
+    return idsToDelete;
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -59,7 +59,7 @@ public:
                                           VecSimQueryParams *queryParams) const override;
 
     int deleteVector(labelType label) override;
-    int addVector(const void *vector_data, labelType label, bool override_allowed = true) override;
+    int addVector(const void *vector_data, labelType label, bool overwrite_allowed = true) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
     inline std::vector<idType> markDelete(labelType label) override;
 };
@@ -138,7 +138,7 @@ int HNSWIndex_Multi<DataType, DistType>::deleteVector(const labelType label) {
 
 template <typename DataType, typename DistType>
 int HNSWIndex_Multi<DataType, DistType>::addVector(const void *vector_data, const labelType label,
-                                                   bool override_allowed) {
+                                                   bool overwrite_allowed) {
 
     this->appendVector(vector_data, label);
     return 1; // We always add the vector, no overrides in multi.

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -154,8 +154,8 @@ std::vector<idType> HNSWIndex_Single<DataType, DistType>::markDelete(labelType l
     if (search == label_lookup_.end()) {
         return idsToDelete;
     }
-    label_lookup_.erase(search);
     this->markDeletedInternal(search->second);
     idsToDelete.push_back(search->second);
+    label_lookup_.erase(search);
     return idsToDelete;
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -52,10 +52,9 @@ public:
                                           VecSimQueryParams *queryParams) const override;
 
     int deleteVector(labelType label) override;
-    int addVector(const void *vector_data, labelType label) override;
+    int addVector(const void *vector_data, labelType label, bool override_allowed = true) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
-    inline int markDelete(labelType label) override;
-    inline int unmarkDelete(labelType label) override;
+    inline std::vector<idType> markDelete(labelType label) override;
 };
 
 /**
@@ -98,25 +97,35 @@ void HNSWIndex_Single<DataType, DistType>::resizeLabelLookup(size_t new_max_elem
 
 template <typename DataType, typename DistType>
 int HNSWIndex_Single<DataType, DistType>::deleteVector(const labelType label) {
-    // check that the label actually exists in the graph, and update the number of elements.
+    // Check that the label actually exists in the graph, and update the number of elements.
     if (label_lookup_.find(label) == label_lookup_.end()) {
-        return false;
+        return 0;
     }
     idType element_internal_id = label_lookup_[label];
     label_lookup_.erase(label);
-    return this->removeVector(element_internal_id);
+    this->removeVector(element_internal_id);
+    return 1;
 }
 
 template <typename DataType, typename DistType>
 int HNSWIndex_Single<DataType, DistType>::addVector(const void *vector_data,
-                                                    const labelType label) {
+                                                    const labelType label, bool override_allowed) {
 
-    // Checking if an element with the given label already exists. if so, remove it.
+    // Checking if an element with the given label already exists.
+    size_t index_size_before = this->indexSize();
     if (label_lookup_.find(label) != label_lookup_.end()) {
-        deleteVector(label);
+        if (override_allowed) {
+            // Remove the vector in place if override allowed (in non-async scenario)
+            deleteVector(label);
+        } else {
+            // If override is not allowed, we don't do anything.
+            return -1;
+        }
     }
 
-    return this->appendVector(vector_data, label);
+    this->appendVector(vector_data, label);
+    // Return the delta in the index size due to the insertion.
+    return this->indexSize() - index_size_before;
 }
 
 template <typename DataType, typename DistType>
@@ -138,27 +147,14 @@ HNSWIndex_Single<DataType, DistType>::newBatchIterator(const void *queryBlob,
  * @param label
  */
 template <typename DataType, typename DistType>
-int HNSWIndex_Single<DataType, DistType>::markDelete(labelType label) {
+std::vector<idType> HNSWIndex_Single<DataType, DistType>::markDelete(labelType label) {
+    std::vector<idType> idsToDelete;
     auto search = label_lookup_.find(label);
     if (search == label_lookup_.end()) {
-        return false;
+        return idsToDelete;
     }
-
+    label_lookup_.erase(search);
     this->markDeletedInternal(search->second);
-    return true;
-}
-
-/**
- * Remove the deleted mark of the node, does NOT really change the current graph.
- * @param label
- */
-template <typename DataType, typename DistType>
-int HNSWIndex_Single<DataType, DistType>::unmarkDelete(labelType label) {
-    auto search = label_lookup_.find(label);
-    if (search == label_lookup_.end()) {
-        return false;
-    }
-
-    this->unmarkDeletedInternal(search->second);
-    return true;
+    idsToDelete.push_back(search->second);
+    return idsToDelete;
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -108,8 +108,8 @@ int HNSWIndex_Single<DataType, DistType>::deleteVector(const labelType label) {
 }
 
 template <typename DataType, typename DistType>
-int HNSWIndex_Single<DataType, DistType>::addVector(const void *vector_data,
-                                                    const labelType label, bool override_allowed) {
+int HNSWIndex_Single<DataType, DistType>::addVector(const void *vector_data, const labelType label,
+                                                    bool override_allowed) {
 
     // Checking if an element with the given label already exists.
     size_t index_size_before = this->indexSize();

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -52,7 +52,7 @@ public:
                                           VecSimQueryParams *queryParams) const override;
 
     int deleteVector(labelType label) override;
-    int addVector(const void *vector_data, labelType label, bool override_allowed = true) override;
+    int addVector(const void *vector_data, labelType label, bool overwrite_allowed = true) override;
     double getDistanceFrom(labelType label, const void *vector_data) const override;
     inline std::vector<idType> markDelete(labelType label) override;
 };
@@ -109,12 +109,13 @@ int HNSWIndex_Single<DataType, DistType>::deleteVector(const labelType label) {
 
 template <typename DataType, typename DistType>
 int HNSWIndex_Single<DataType, DistType>::addVector(const void *vector_data, const labelType label,
-                                                    bool override_allowed) {
+                                                    bool overwrite_allowed) {
 
     // Checking if an element with the given label already exists.
-    size_t index_size_before = this->indexSize();
+    bool label_exists = false;
     if (label_lookup_.find(label) != label_lookup_.end()) {
-        if (override_allowed) {
+        label_exists = true;
+        if (overwrite_allowed) {
             // Remove the vector in place if override allowed (in non-async scenario)
             deleteVector(label);
         } else {
@@ -125,7 +126,7 @@ int HNSWIndex_Single<DataType, DistType>::addVector(const void *vector_data, con
 
     this->appendVector(vector_data, label);
     // Return the delta in the index size due to the insertion.
-    return this->indexSize() - index_size_before;
+    return label_exists ? 0 : 1;
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -41,8 +41,8 @@ public:
     virtual ~TieredHNSWIndex() = default;
 
     // TODO: Implement the actual methods instead of these temporary ones.
-    int addVector(const void *blob, labelType label, bool override_allowed) override {
-        return this->index->addVector(blob, label, override_allowed);
+    int addVector(const void *blob, labelType label, bool overwrite_allowed) override {
+        return this->index->addVector(blob, label, overwrite_allowed);
     }
     int deleteVector(labelType id) override { return this->index->deleteVector(id); }
     double getDistanceFrom(labelType id, const void *blob) const override {
@@ -50,7 +50,7 @@ public:
     }
     size_t indexSize() const override { return this->index->indexSize(); }
     size_t indexCapacity() const override { return this->index->indexCapacity(); }
-    void resize() override { this->index->resize(); }
+    void increaseCapacity() override { this->index->increaseCapacity(); }
     size_t indexLabelCount() const override { return this->index->indexLabelCount(); }
     VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                      VecSimQueryParams *queryParams) override {

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -49,6 +49,8 @@ public:
         return this->index->getDistanceFrom(id, blob);
     }
     size_t indexSize() const override { return this->index->indexSize(); }
+    size_t indexCapacity() const override { return this->index->indexCapacity(); }
+    void resize() override { this->index->resize(); }
     size_t indexLabelCount() const override { return this->index->indexLabelCount(); }
     VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                      VecSimQueryParams *queryParams) override {

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -41,8 +41,8 @@ public:
     virtual ~TieredHNSWIndex() = default;
 
     // TODO: Implement the actual methods instead of these temporary ones.
-    int addVector(const void *blob, labelType id) override {
-        return this->index->addVector(blob, id);
+    int addVector(const void *blob, labelType label, bool override_allowed) override {
+        return this->index->addVector(blob, label, override_allowed);
     }
     int deleteVector(labelType id) override { return this->index->deleteVector(id); }
     double getDistanceFrom(labelType id, const void *blob) const override {

--- a/src/VecSim/tombstone_interface.h
+++ b/src/VecSim/tombstone_interface.h
@@ -23,5 +23,4 @@ public:
      * @return a vector of internal ids that has been marked as deleted (to be disposed later on).
      */
     virtual inline std::vector<idType> markDelete(labelType label) = 0;
-
 };

--- a/src/VecSim/tombstone_interface.h
+++ b/src/VecSim/tombstone_interface.h
@@ -18,6 +18,10 @@ public:
 
     inline size_t getNumMarkedDeleted() const { return num_marked_deleted; }
 
-    virtual inline int markDelete(labelType label) = 0;
-    virtual inline int unmarkDelete(labelType label) = 0;
+    /**
+     * @param label vector to mark as deleted
+     * @return a vector of internal ids that has been marked as deleted (to be disposed later on).
+     */
+    virtual inline std::vector<idType> markDelete(labelType label) = 0;
+
 };

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -129,6 +129,9 @@ extern "C" size_t VecSimIndex_EstimateInitialSize(const VecSimParams *params) {
 
 extern "C" int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id) {
     int64_t before = index->getAllocationSize();
+    if (index->indexSize() == index->indexCapacity()) {
+        index->resize();
+    }
     index->addVector(blob, id, true);
     int64_t after = index->getAllocationSize();
     return after - before;

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -130,7 +130,7 @@ extern "C" size_t VecSimIndex_EstimateInitialSize(const VecSimParams *params) {
 extern "C" int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id) {
     int64_t before = index->getAllocationSize();
     if (index->indexSize() == index->indexCapacity()) {
-        index->resize();
+        index->increaseCapacity();
     }
     index->addVector(blob, id, true);
     int64_t after = index->getAllocationSize();

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -129,7 +129,7 @@ extern "C" size_t VecSimIndex_EstimateInitialSize(const VecSimParams *params) {
 
 extern "C" int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id) {
     int64_t before = index->getAllocationSize();
-    index->addVector(blob, id);
+    index->addVector(blob, id, true);
     int64_t after = index->getAllocationSize();
     return after - before;
 }

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -37,18 +37,21 @@ public:
      *
      * @param blob binary representation of the vector. Blob size should match the index data type
      * and dimension.
-     * @param id the id of the added vector
-     * @return always returns true
+     * @param label the id of the added vector
+     * @param overrideAllowed if true and id already exists in the index, override it. Otherwise,
+     * ignore the new vector.
+     * @return the number of new vectors inserted (1 for new insertion, 0 for override), or -1
+     * in case that override is not allowed and label already exists.
      */
-    virtual int addVector(const void *blob, labelType id) = 0;
+    virtual int addVector(const void *blob, labelType label, bool overrideAllowed = true) = 0;
 
     /**
      * @brief Remove a vector from an index.
      *
-     * @param id the id of the removed vector
-     * @return always returns true
+     * @param label the label of the vector to remove
+     * @return the number of vectors deleted
      */
-    virtual int deleteVector(labelType id) = 0;
+    virtual int deleteVector(labelType label) = 0;
 
     /**
      * @brief Calculate the distance of a vector from an index to a vector.

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -38,7 +38,7 @@ public:
      * @param blob binary representation of the vector. Blob size should match the index data type
      * and dimension.
      * @param label the label of the added vector.
-     * @param overwriteAllowed if true and id already exists in the index, override it. Otherwise,
+     * @param overwriteAllowed if true and id already exists in the index, overwrite it. Otherwise,
      * ignore the new vector.
      * @return the number of new vectors inserted (1 for new insertion, 0 for override), or -1
      * in case that override is not allowed and label already exists.

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -38,12 +38,12 @@ public:
      * @param blob binary representation of the vector. Blob size should match the index data type
      * and dimension.
      * @param label the label of the added vector.
-     * @param overrideAllowed if true and id already exists in the index, override it. Otherwise,
+     * @param overwriteAllowed if true and id already exists in the index, override it. Otherwise,
      * ignore the new vector.
      * @return the number of new vectors inserted (1 for new insertion, 0 for override), or -1
      * in case that override is not allowed and label already exists.
      */
-    virtual int addVector(const void *blob, labelType label, bool overrideAllowed = true) = 0;
+    virtual int addVector(const void *blob, labelType label, bool overwriteAllowed = true) = 0;
 
     /**
      * @brief Remove a vector from an index.
@@ -80,9 +80,9 @@ public:
     virtual size_t indexCapacity() const = 0;
 
     /**
-     * @brief Change the index capacity (without chaning its data), by adding another block.
+     * @brief Change the index capacity (without changing its data), by adding another block.
      */
-    virtual void resize() = 0;
+    virtual void increaseCapacity() = 0;
 
     /**
      * @brief Return the number of unique labels in the index using its SizeFn.

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -37,7 +37,7 @@ public:
      *
      * @param blob binary representation of the vector. Blob size should match the index data type
      * and dimension.
-     * @param label the id of the added vector
+     * @param label the label of the added vector.
      * @param overrideAllowed if true and id already exists in the index, override it. Otherwise,
      * ignore the new vector.
      * @return the number of new vectors inserted (1 for new insertion, 0 for override), or -1
@@ -71,6 +71,18 @@ public:
      * @return index size.
      */
     virtual size_t indexSize() const = 0;
+
+    /**
+     * @brief Return the index capacity, so we know if resize is required for adding new vectors.
+     *
+     * @return index capacity.
+     */
+    virtual size_t indexCapacity() const = 0;
+
+    /**
+     * @brief Change the index capacity (without chaning its data), by adding another block.
+     */
+    virtual void resize() = 0;
 
     /**
      * @brief Return the number of unique labels in the index using its SizeFn.

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -343,7 +343,7 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw_reclaim_memory) {
     auto *hnswIndex =
         new (allocator) HNSWIndex_Single<TEST_DATA_T, TEST_DIST_T>(&params, allocator);
 
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), 0);
+    ASSERT_EQ(hnswIndex->indexCapacity(), 0);
     size_t initial_memory_size = allocator->getAllocationSize();
     // labels_lookup and element_levels containers are not allocated at all in some platforms,
     // when initial capacity is zero, while in other platforms labels_lookup is allocated with a
@@ -362,7 +362,7 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw_reclaim_memory) {
     }
     // Validate that a single block exists.
     ASSERT_EQ(hnswIndex->indexSize(), block_size);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), block_size);
+    ASSERT_EQ(hnswIndex->indexCapacity(), block_size);
     ASSERT_EQ(allocator->getAllocationSize(), initial_memory_size + accumulated_mem_delta);
     // Also validate that there are no unidirectional connections (these add memory to the incoming
     // edges sets).
@@ -373,7 +373,7 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw_reclaim_memory) {
     size_t mem_delta = GenerateAndAddVector<TEST_DATA_T>(hnswIndex, d, block_size, block_size);
 
     ASSERT_EQ(hnswIndex->indexSize(), block_size + 1);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), 2 * block_size);
+    ASSERT_EQ(hnswIndex->indexCapacity(), 2 * block_size);
     ASSERT_EQ(hnswIndex->checkIntegrity().unidirectional_connections, 0);
 
     // Compute the expected memory allocation due to the last vector insertion.
@@ -400,7 +400,7 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw_reclaim_memory) {
     // memory consumption.
     VecSimIndex_DeleteVector(hnswIndex, block_size);
     ASSERT_EQ(hnswIndex->indexSize(), block_size);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), block_size);
+    ASSERT_EQ(hnswIndex->indexCapacity(), block_size);
     ASSERT_EQ(hnswIndex->checkIntegrity().unidirectional_connections, 0);
     ASSERT_EQ(allocator->getAllocationSize(), initial_memory_size + accumulated_mem_delta);
 
@@ -410,7 +410,7 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw_reclaim_memory) {
     }
 
     ASSERT_EQ(hnswIndex->indexSize(), 0);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), 0);
+    ASSERT_EQ(hnswIndex->indexCapacity(), 0);
     // All data structures' memory returns to as it was, with the exceptional of the labels_lookup
     // (STL unordered_map with hash table implementation), that leaves some empty buckets.
     size_t hash_table_memory = hnswIndex->label_lookup_.bucket_count() * sizeof(size_t);

--- a/tests/unit/test_bruteforce_multi.cpp
+++ b/tests/unit/test_bruteforce_multi.cpp
@@ -50,7 +50,7 @@ TYPED_TEST(BruteForceMultiTest, vector_add_multiple_test) {
         for (size_t i = 0; i < dim; i++) {
             a[i] = (TEST_DATA_T)i * j + i;
         }
-        ASSERT_EQ(index_bf_multi->addVector(a, 46), 1);
+        VecSimIndex_AddVector(index, a, 46);
     }
 
     ASSERT_EQ(VecSimIndex_IndexSize(index), rep);

--- a/tests/unit/test_bruteforce_multi.cpp
+++ b/tests/unit/test_bruteforce_multi.cpp
@@ -50,14 +50,14 @@ TYPED_TEST(BruteForceMultiTest, vector_add_multiple_test) {
         for (size_t i = 0; i < dim; i++) {
             a[i] = (TEST_DATA_T)i * j + i;
         }
-        VecSimIndex_AddVector(index, a, 46);
+        ASSERT_EQ(index_bf_multi->addVector(a, 46), 1);
     }
 
     ASSERT_EQ(VecSimIndex_IndexSize(index), rep);
     ASSERT_EQ(index_bf_multi->indexLabelCount(), 1);
 
     // Deleting the label. All the vectors should be deleted.
-    VecSimIndex_DeleteVector(index, 46);
+    ASSERT_EQ(index_bf_multi->deleteVector(46), rep);
 
     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
     ASSERT_EQ(index_bf_multi->indexLabelCount(), 0);
@@ -92,7 +92,7 @@ TYPED_TEST(BruteForceMultiTest, resize_and_align_index) {
     ASSERT_EQ(bf_index->getVectorBlocks().size(), n / blockSize + 1);
 
     // remove invalid id
-    VecSimIndex_DeleteVector(index, 3459);
+    ASSERT_EQ(bf_index->deleteVector(3459), 0);
 
     // This should do nothing
     info = VecSimIndex_Info(index);

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -130,9 +130,9 @@ TYPED_TEST(HNSWTest, resizeNAlignIndex) {
     }
     // The size and the capacity should be equal.
     HNSWIndex<TEST_DATA_T, TEST_DIST_T> *hnswIndex = this->CastToHNSW(index);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), VecSimIndex_IndexSize(index));
+    ASSERT_EQ(hnswIndex->indexCapacity(), VecSimIndex_IndexSize(index));
     // The capacity shouldn't be changed.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+    ASSERT_EQ(hnswIndex->indexCapacity(), n);
 
     // Add another vector to exceed the initial capacity.
     GenerateAndAddVector<TEST_DATA_T>(index, dim, n);
@@ -140,7 +140,7 @@ TYPED_TEST(HNSWTest, resizeNAlignIndex) {
     // The capacity should be now aligned with the block size.
     // bs = 3, size = 11 -> capacity = 12
     // New capacity = initial capacity + blockSize - initial capacity % blockSize.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n + bs - n % bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), n + bs - n % bs);
     VecSimIndex_Free(index);
 }
 
@@ -164,7 +164,7 @@ TYPED_TEST(HNSWTest, resizeNAlignIndex_largeInitialCapacity) {
 
     // The capacity shouldn't change, should remain n.
     HNSWIndex<TEST_DATA_T, TEST_DIST_T> *hnswIndex = this->CastToHNSW(index);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+    ASSERT_EQ(hnswIndex->indexCapacity(), n);
 
     // Delete last vector, to get size % block_size == 0. size = 3
     VecSimIndex_DeleteVector(index, bs);
@@ -174,7 +174,7 @@ TYPED_TEST(HNSWTest, resizeNAlignIndex_largeInitialCapacity) {
 
     // New capacity = initial capacity - block_size - number_of_vectors_to_align =
     // 10  - 3 - 10 % 3 (1) = 6
-    size_t curr_capacity = hnswIndex->getIndexCapacity();
+    size_t curr_capacity = hnswIndex->indexCapacity();
     ASSERT_EQ(curr_capacity, n - bs - n % bs);
 
     // Delete all the vectors to decrease capacity by another bs.
@@ -183,20 +183,20 @@ TYPED_TEST(HNSWTest, resizeNAlignIndex_largeInitialCapacity) {
         VecSimIndex_DeleteVector(index, i);
         ++i;
     }
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), bs);
     // Add and delete a vector to achieve:
     // size % block_size == 0 && size + bs <= capacity(3).
     // the capacity should be resized to zero
     GenerateAndAddVector<TEST_DATA_T>(index, dim, 0);
     VecSimIndex_DeleteVector(index, 0);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), 0);
+    ASSERT_EQ(hnswIndex->indexCapacity(), 0);
 
     // Do it again. This time after adding a vector the capacity is increased by bs.
     // Upon deletion it will be resized to zero again.
     GenerateAndAddVector<TEST_DATA_T>(index, dim, 0);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), bs);
     VecSimIndex_DeleteVector(index, 0);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), 0);
+    ASSERT_EQ(hnswIndex->indexCapacity(), 0);
 
     VecSimIndex_Free(index);
 }
@@ -221,14 +221,14 @@ TYPED_TEST(HNSWTest, resizeNAlignIndex_largerBlockSize) {
 
     HNSWIndex<TEST_DATA_T, TEST_DIST_T> *hnswIndex = this->CastToHNSW(index);
     // The capacity shouldn't change.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+    ASSERT_EQ(hnswIndex->indexCapacity(), n);
 
     // Size equals capacity.
     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
 
     // Add another vector - > the capacity is increased to a multiplication of block_size.
     GenerateAndAddVector<TEST_DATA_T>(index, dim, n);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), bs);
 
     // Size increased by 1.
     ASSERT_EQ(VecSimIndex_IndexSize(index), n + 1);
@@ -237,7 +237,7 @@ TYPED_TEST(HNSWTest, resizeNAlignIndex_largerBlockSize) {
     VecSimIndex_DeleteVector(index, 1);
 
     // The capacity should remain the same.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), bs);
 
     VecSimIndex_Free(index);
 }
@@ -266,7 +266,7 @@ TYPED_TEST(HNSWTest, emptyIndex) {
     // The capacity should change to be aligned with the block size.
 
     HNSWIndex<TEST_DATA_T, TEST_DIST_T> *hnswIndex = this->CastToHNSW(index);
-    size_t new_capacity = hnswIndex->getIndexCapacity();
+    size_t new_capacity = hnswIndex->indexCapacity();
     ASSERT_EQ(new_capacity, n - n % bs - bs);
 
     // Size equals 0.
@@ -275,7 +275,7 @@ TYPED_TEST(HNSWTest, emptyIndex) {
     // Try to remove it again.
     // The capacity should remain unchanged, as we are trying to delete a label that doesn't exist.
     VecSimIndex_DeleteVector(index, 1);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), new_capacity);
+    ASSERT_EQ(hnswIndex->indexCapacity(), new_capacity);
     // Nor the size.
     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
 
@@ -2070,7 +2070,7 @@ TYPED_TEST(HNSWTest, markDelete) {
             ASSERT_EQ(this->CastToHNSW(index)->markDelete(label), std::vector<idType>(1, label));
 
     ASSERT_EQ(this->CastToHNSW(index)->getNumMarkedDeleted(), n / 2);
-    ASSERT_EQ(VecSimIndex_IndexSize(index), n / 2);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
 
     // Search for k results around the middle. expect to find only even results.
     auto verify_res_half = [&](size_t id, double score, size_t index) {
@@ -2097,14 +2097,14 @@ TYPED_TEST(HNSWTest, markDelete) {
         }
     }
 
-    // Re-add the previously marked vectors.
+    // Re-add the previously marked vectors (under new internal ids).
     for (labelType label = 0; label < n; label++) {
         if (label % 2 == ep_reminder) {
             GenerateAndAddVector<TEST_DATA_T>(index, dim, label, label);
         }
     }
 
-    ASSERT_EQ(VecSimIndex_IndexSize(index), n + 1);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n + n / 2 + 1);
 
     // Search for k results around the middle again. expect to find the same results we
     // found in the first search.

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -2105,6 +2105,7 @@ TYPED_TEST(HNSWTest, markDelete) {
     }
 
     ASSERT_EQ(VecSimIndex_IndexSize(index), n + n / 2 + 1);
+    ASSERT_EQ(this->CastToHNSW(index)->getNumMarkedDeleted(), n / 2);
 
     // Search for k results around the middle again. expect to find the same results we
     // found in the first search.

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -951,6 +951,11 @@ TYPED_TEST(HNSWTest, hnsw_override) {
     }
     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
 
+    // Try to override when overriding is not allowed.
+    TEST_DATA_T vec[dim];
+    GenerateVector<TEST_DATA_T>(vec, dim, n);
+    ASSERT_EQ(this->CastToHNSW_Single(index)->addVector(vec, 0, false), -1);
+
     // Insert again 300 vectors, the first 100 will be overwritten (deleted first).
     n = 300;
     for (size_t i = 0; i < n; i++) {

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -875,9 +875,9 @@ TYPED_TEST(HNSWMultiTest, resize_and_align_index) {
     }
     // The size and the capacity should be equal.
     HNSWIndex<TEST_DATA_T, TEST_DIST_T> *hnswIndex = this->CastToHNSW(index);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), VecSimIndex_IndexSize(index));
+    ASSERT_EQ(hnswIndex->indexCapacity(), VecSimIndex_IndexSize(index));
     // The capacity shouldn't be changed.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+    ASSERT_EQ(hnswIndex->indexCapacity(), n);
 
     // Add another vector to exceed the initial capacity.
     GenerateAndAddVector<TEST_DATA_T>(index, dim, n);
@@ -885,7 +885,7 @@ TYPED_TEST(HNSWMultiTest, resize_and_align_index) {
     // The capacity should be now aligned with the block size.
     // bs = 3, size = 11 -> capacity = 12
     // New capacity = initial capacity + blockSize - initial capacity % blockSize.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n + bs - n % bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), n + bs - n % bs);
     VecSimIndex_Free(index);
 }
 
@@ -911,7 +911,7 @@ TYPED_TEST(HNSWMultiTest, resize_and_align_index_largeInitialCapacity) {
 
     // The capacity shouldn't change, should remain n.
     HNSWIndex<TEST_DATA_T, TEST_DIST_T> *hnswIndex = this->CastToHNSW(index);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+    ASSERT_EQ(hnswIndex->indexCapacity(), n);
 
     // Delete last vector, to get size % block_size == 0. size = 3
     VecSimIndex_DeleteVector(index, bs);
@@ -921,7 +921,7 @@ TYPED_TEST(HNSWMultiTest, resize_and_align_index_largeInitialCapacity) {
 
     // New capacity = initial capacity - block_size - number_of_vectors_to_align =
     // 10  - 3 - 10 % 3 (1) = 6
-    size_t curr_capacity = hnswIndex->getIndexCapacity();
+    size_t curr_capacity = hnswIndex->indexCapacity();
     ASSERT_EQ(curr_capacity, n - bs - n % bs);
 
     // Delete all the vectors to decrease capacity by another bs.
@@ -930,20 +930,20 @@ TYPED_TEST(HNSWMultiTest, resize_and_align_index_largeInitialCapacity) {
         VecSimIndex_DeleteVector(index, i);
         ++i;
     }
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), bs);
     // Add and delete a vector to achieve:
     // size % block_size == 0 && size + bs <= capacity(3).
     // the capacity should be resized to zero
     GenerateAndAddVector<TEST_DATA_T>(index, dim, 0);
     VecSimIndex_DeleteVector(index, 0);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), 0);
+    ASSERT_EQ(hnswIndex->indexCapacity(), 0);
 
     // Do it again. This time after adding a vector the capacity is increased by bs.
     // Upon deletion it will be resized to zero again.
     GenerateAndAddVector<TEST_DATA_T>(index, dim, 0);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), bs);
     VecSimIndex_DeleteVector(index, 0);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), 0);
+    ASSERT_EQ(hnswIndex->indexCapacity(), 0);
 
     VecSimIndex_Free(index);
 }
@@ -969,7 +969,7 @@ TYPED_TEST(HNSWMultiTest, resize_and_align_index_largerBlockSize) {
 
     HNSWIndex<TEST_DATA_T, TEST_DIST_T> *hnswIndex = this->CastToHNSW(index);
     // The capacity shouldn't change.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), n);
+    ASSERT_EQ(hnswIndex->indexCapacity(), n);
 
     // Size equals capacity.
     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
@@ -977,7 +977,7 @@ TYPED_TEST(HNSWMultiTest, resize_and_align_index_largerBlockSize) {
     // Add another vector - > the capacity is increased to a multiplication of block_size.
     GenerateAndAddVector<TEST_DATA_T>(index, dim, n);
 
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), bs);
 
     // Size increased by 1.
     ASSERT_EQ(VecSimIndex_IndexSize(index), n + 1);
@@ -986,7 +986,7 @@ TYPED_TEST(HNSWMultiTest, resize_and_align_index_largerBlockSize) {
     VecSimIndex_DeleteVector(index, 1);
 
     // The capacity should remain the same.
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), bs);
+    ASSERT_EQ(hnswIndex->indexCapacity(), bs);
 
     VecSimIndex_Free(index);
 }
@@ -1014,7 +1014,7 @@ TYPED_TEST(HNSWMultiTest, emptyIndex) {
     // The capacity should change to be aligned with the block size.
 
     HNSWIndex<TEST_DATA_T, TEST_DIST_T> *hnswIndex = this->CastToHNSW(index);
-    size_t new_capacity = hnswIndex->getIndexCapacity();
+    size_t new_capacity = hnswIndex->indexCapacity();
     ASSERT_EQ(new_capacity, n - n % bs - bs);
 
     // Size equals 0.
@@ -1023,7 +1023,7 @@ TYPED_TEST(HNSWMultiTest, emptyIndex) {
     // Try to remove it again.
     // The capacity should remain unchanged, as we are trying to delete a label that doesn't exist.
     VecSimIndex_DeleteVector(index, 1);
-    ASSERT_EQ(hnswIndex->getIndexCapacity(), new_capacity);
+    ASSERT_EQ(hnswIndex->indexCapacity(), new_capacity);
     // Nor the size.
     ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
 
@@ -1695,7 +1695,7 @@ TYPED_TEST(HNSWMultiTest, markDelete) {
     }
 
     ASSERT_EQ(this->CastToHNSW(index)->getNumMarkedDeleted(), n / 2);
-    ASSERT_EQ(VecSimIndex_IndexSize(index), n / 2);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
 
     // Add a new vector, make sure it has no link to a deleted vector (id/per_label should be even)
     // This value is very close to a deleted vector

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -1689,7 +1689,7 @@ TYPED_TEST(HNSWMultiTest, markDelete) {
         if (label % 2 == ep_reminder) {
             std::vector<idType> expected_deleted_ids;
             for (size_t j = 0; j < per_label; j++)
-                expected_deleted_ids.push_back(label*per_label + j);
+                expected_deleted_ids.push_back(label * per_label + j);
             ASSERT_EQ(this->CastToHNSW(index)->markDelete(label), expected_deleted_ids);
         }
     }

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -43,10 +43,9 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
             // Move the vector from the temp flat index into the HNSW index.
             // Note that we access the vector via its internal id since in index of type MULTI,
             // this is the only way to do so (knowing the label is not enough...)
-            ASSERT_EQ(
-                my_index->addVector(my_index->flatBuffer->getDataByInternalId(my_insert_job->id),
-                                    my_insert_job->label, false),
-                1);
+            VecSimIndex_AddVector(my_index,
+                                  my_index->flatBuffer->getDataByInternalId(my_insert_job->id),
+                                  my_insert_job->label);
             // TODO: enable deleting vectors by internal id for the case of moving a single vector
             //  from the flat buffer in MULTI.
             VecSimIndex_DeleteVector(my_index->flatBuffer, my_insert_job->label);

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -43,8 +43,10 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
             // Move the vector from the temp flat index into the HNSW index.
             // Note that we access the vector via its internal id since in index of type MULTI,
             // this is the only way to do so (knowing the label is not enough...)
-            ASSERT_EQ(my_index->addVector(my_index->flatBuffer->getDataByInternalId(my_insert_job->id),
-                                my_insert_job->label, false), 1);
+            ASSERT_EQ(
+                my_index->addVector(my_index->flatBuffer->getDataByInternalId(my_insert_job->id),
+                                    my_insert_job->label, false),
+                1);
             // TODO: enable deleting vectors by internal id for the case of moving a single vector
             //  from the flat buffer in MULTI.
             VecSimIndex_DeleteVector(my_index->flatBuffer, my_insert_job->label);

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -43,8 +43,8 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
             // Move the vector from the temp flat index into the HNSW index.
             // Note that we access the vector via its internal id since in index of type MULTI,
             // this is the only way to do so (knowing the label is not enough...)
-            my_index->addVector(my_index->flatBuffer->getDataByInternalId(my_insert_job->id),
-                                my_insert_job->label);
+            ASSERT_EQ(my_index->addVector(my_index->flatBuffer->getDataByInternalId(my_insert_job->id),
+                                my_insert_job->label, false), 1);
             // TODO: enable deleting vectors by internal id for the case of moving a single vector
             //  from the flat buffer in MULTI.
             VecSimIndex_DeleteVector(my_index->flatBuffer, my_insert_job->label);


### PR DESCRIPTION
 - Remove "unmark deleted" API, as it is currently redundant for our async index
 - Let add and delete vector APIs in the index interface to return the number of vectors added/deleted (and take into consideration overwrites).
 - Add an `override_allowed` flag to `addVector` interface, so we can enforce that the internal HNSW index within the tiered index will not be able to override existing vectors (rather than creating a delete job in advance).
 - Add `indexCapacity()` and `resize()` to index interface and adjust the existing indexes accordingly. Call resize *before* we add new vectors externally in `vec_sim.cpp` 