### PR TITLE
Stringify password token for benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,7 +75,7 @@ jobs:
           ./tests/benchmark/benchmarks.sh ${{ github.event.label.name }} | xargs -I {} redisbench-admin export     \
           --redistimeseries_host      ${{ secrets.PERFORMANCE_RTS_HOST }}           \
           --redistimeseries_port      ${{ secrets.PERFORMANCE_RTS_PORT }}           \
-          --redistimeseries_pass      ${{ secrets.PERFORMANCE_RTS_AUTH }}           \
+          --redistimeseries_pass      "${{ secrets.PERFORMANCE_RTS_AUTH }}"         \
           --github_repo               ${{ github.event.repository.name }}           \
           --github_org                ${{ github.repository_owner }}                \
           --github_branch             ${{ github.head_ref || github.ref_name }}     \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,7 +75,8 @@ jobs:
           ./tests/benchmark/benchmarks.sh ${{ github.event.label.name }} | xargs -I {} redisbench-admin export     \
           --redistimeseries_host      ${{ secrets.PERFORMANCE_RTS_HOST }}           \
           --redistimeseries_port      ${{ secrets.PERFORMANCE_RTS_PORT }}           \
-          --redistimeseries_pass      "${{ secrets.PERFORMANCE_RTS_AUTH }}"         \
+          --redistimeseries_user      default                                       \
+          --redistimeseries_pass      '${{ secrets.PERFORMANCE_RTS_AUTH }}'         \
           --github_repo               ${{ github.event.repository.name }}           \
           --github_org                ${{ github.repository_owner }}                \
           --github_branch             ${{ github.head_ref || github.ref_name }}     \


### PR DESCRIPTION
**Describe the changes in the pull request**

The `redistimeseries_pass` argument is sent to redisbench-admin export command as raw characters, and when special characters are part of the password token (such as `*`), it may not be read properly. Hence, we turn the argument into a string. 