### PR TITLE
fix download files script in the docs

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -22,7 +22,7 @@ The serialized indices files that are used for micro-benchmarking and running an
 `tests/benchmark/data/hnsw_indices.txt`.  
 To download all the required files, run from the repository root directory:
 ```sh
-wget -q -i tests/benchmark/data/hnsw_indices_all/hnsw_indices_all.txt -P tests/benchmark/data
+wget --no-check-certificate -q -i tests/benchmark/data/hnsw_indices/hnsw_indices_all.txt -P tests/benchmark/data
 ```
 To run all test sets, call the following commands from the project root dir:
 ```sh


### PR DESCRIPTION
**Describe the changes in the pull request**

The path to the required files to run benchmarks was broken. 
Also, added `--no-check-certificate` flag.

**Which issues this PR fixes**
1. Broken file path
2. Missing flag in the script


**Main objects this PR modified**
1. docs/benchmarks.md

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
