### PR TITLE
Tiered index add vector MOD-4316

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -199,7 +199,6 @@ public:
     inline size_t getEfConstruction() const;
     inline size_t getM() const;
     inline size_t getMaxLevel() const;
-    inline std::shared_ptr<VecSimAllocator> getIndexAllocator();
     inline labelType getEntryPointLabel() const;
     inline labelType getExternalLabel(idType internal_id) const;
     // Check if the given label exists in the labels lookup while holding the index data lock.
@@ -305,11 +304,6 @@ size_t HNSWIndex<DataType, DistType>::getM() const {
 template <typename DataType, typename DistType>
 size_t HNSWIndex<DataType, DistType>::getMaxLevel() const {
     return maxlevel_;
-}
-
-template <typename DataType, typename DistType>
-std::shared_ptr<VecSimAllocator> HNSWIndex<DataType, DistType>::getIndexAllocator() {
-    return this->getAllocator();
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -199,6 +199,7 @@ public:
     inline size_t getEfConstruction() const;
     inline size_t getM() const;
     inline size_t getMaxLevel() const;
+    inline std::shared_ptr<VecSimAllocator> getIndexAllocator();
     inline labelType getEntryPointLabel() const;
     inline labelType getExternalLabel(idType internal_id) const;
     // Check if the given label exists in the labels lookup while holding the index data lock.
@@ -304,6 +305,11 @@ size_t HNSWIndex<DataType, DistType>::getM() const {
 template <typename DataType, typename DistType>
 size_t HNSWIndex<DataType, DistType>::getMaxLevel() const {
     return maxlevel_;
+}
+
+template <typename DataType, typename DistType>
+std::shared_ptr<VecSimAllocator> HNSWIndex<DataType, DistType>::getIndexAllocator() {
+    return this->getAllocator();
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -179,9 +179,9 @@ int TieredHNSWIndex<DataType, DistType>::addVector(const void *blob, labelType l
         HNSWInsertJob(this->allocator, label, new_id, executeInsertJobWrapper, this);
     // Save a pointer to the job, so that if the vector is overwritten, we'll have an indication.
     if (this->labelToInsertJobs.find(label) != this->labelToInsertJobs.end()) {
-        // There's already a pending insert job for this label, add another one
-        // (only possible in multi index)
-        assert(this->index->isMulti);
+        // There's already a pending insert job for this label, add another one (without overwrite,
+        // only possible in multi index)
+        assert(this->index->isMultiValue());
         this->labelToInsertJobs.at(label).push_back((HNSWInsertJob *)new_insert_job);
     } else {
         auto new_jobs_vec = vecsim_stl::vector<HNSWInsertJob *>(1, (HNSWInsertJob *)new_insert_job,

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -185,7 +185,7 @@ int TieredHNSWIndex<DataType, DistType>::addVector(const void *blob, labelType l
         this->labelToInsertJobs.at(label).push_back((HNSWInsertJob *)new_insert_job);
     } else {
         vecsim_stl::vector<HNSWInsertJob *> new_jobs_vec(1, (HNSWInsertJob *)new_insert_job,
-                                                                this->allocator);
+                                                         this->allocator);
         this->labelToInsertJobs.insert({label, new_jobs_vec});
     }
     this->flatIndexGuard.unlock();

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -9,12 +9,12 @@
  * Definition of a job that inserts a new vector from flat into HNSW Index.
  */
 struct HNSWInsertJob : public AsyncJob {
-    void *index;
+    VecSimIndex *index;
     labelType label;
     idType id;
 
     HNSWInsertJob(std::shared_ptr<VecSimAllocator> allocator, labelType label_, idType id_,
-                  JobCallback insertCb, void *index_)
+                  JobCallback insertCb, VecSimIndex *index_)
         : AsyncJob(allocator, HNSW_INSERT_VECTOR_JOB, insertCb), index(index_), label(label_),
           id(id_) {}
 };
@@ -23,7 +23,7 @@ struct HNSWInsertJob : public AsyncJob {
  * Definition of a job that swaps last id with a deleted id in HNSW Index after delete operation.
  */
 struct HNSWSwapJob : public AsyncJob {
-    void *index;
+    VecSimIndex *index;
     idType deleted_id;
     long pending_repair_jobs_counter; // number of repair jobs left to complete before this job
                                       // is ready to be executed (atomic counter).
@@ -35,7 +35,7 @@ struct HNSWSwapJob : public AsyncJob {
  * operation.
  */
 struct HNSWRepairJob : public AsyncJob {
-    void *index;
+    VecSimIndex *index;
     idType node_id;
     unsigned short level;
     HNSWSwapJob *associated_swap_job;

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -184,7 +184,7 @@ int TieredHNSWIndex<DataType, DistType>::addVector(const void *blob, labelType l
         assert(this->index->isMultiValue());
         this->labelToInsertJobs.at(label).push_back((HNSWInsertJob *)new_insert_job);
     } else {
-        auto new_jobs_vec = vecsim_stl::vector<HNSWInsertJob *>(1, (HNSWInsertJob *)new_insert_job,
+        vecsim_stl::vector<HNSWInsertJob *> new_jobs_vec(1, (HNSWInsertJob *)new_insert_job,
                                                                 this->allocator);
         this->labelToInsertJobs.insert({label, new_jobs_vec});
     }

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered_tests_friends.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered_tests_friends.h
@@ -1,2 +1,3 @@
 #include "VecSim/friend_test_decl.h"
 INDEX_TEST_FRIEND_CLASS(HNSWTieredIndexTest_CreateIndexInstance_Test)
+INDEX_TEST_FRIEND_CLASS(HNSWTieredIndexTest_addVector_Test)

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -130,47 +130,6 @@ typedef enum {
     INVALID_JOB // to indicate that finding a JobType >= INVALID_JOB is an error
 } JobType;
 
-/**
- * Definition of generic job structure for asynchronous tiered index.
- */
-typedef struct AsyncJob {
-    JobType jobType;
-    JobCallback Execute; // A callback that receives a job as its input and executes the job.
-} AsyncJob;
-
-/**
- * Definition of a job that inserts a new vector from flat into HNSW Index.
- */
-typedef struct HNSWInsertJob {
-    AsyncJob base;
-    void *index;
-    labelType label;
-    idType id;
-} HNSWInsertJob;
-
-/**
- * Definition of a job that swaps last id with a deleted id in HNSW Index after delete operation.
- */
-typedef struct HNSWSwapJob {
-    AsyncJob base;
-    void *index;
-    idType deleted_id;
-    long pending_repair_jobs_counter; // number of repair jobs left to complete before this job
-                                      // is ready to be executed (atomic counter).
-} HNSWSwapJob;
-
-/**
- * Definition of a job that repairs a certain node's connection in HNSW Index after delete
- * operation.
- */
-typedef struct HNSWRepairJob {
-    AsyncJob base;
-    void *index;
-    idType node_id;
-    unsigned short level;
-    HNSWSwapJob *assosiated_swap_job;
-} HNSWRepairJob;
-
 typedef struct {
     size_t efRuntime; // EF parameter for HNSW graph accuracy/latency for search.
     double epsilon;   // Epsilon parameter for HNSW graph accuracy/latency for range search.

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -33,6 +33,13 @@ protected:
     std::shared_mutex flatIndexGuard;
     std::shared_mutex mainIndexGuard;
 
+    void submitSingleJob(AsyncJob *job) {
+        auto **jobs = array_new<AsyncJob *>(1);
+        jobs = array_append(jobs, job);
+        this->SubmitJobsToQueue(this->jobQueue, (void **)jobs, 1);
+        array_free(jobs);
+    }
+
 public:
     VecSimTieredIndex(VecSimIndexAbstract<DistType> *index_, TieredIndexParams tieredParams)
         : VecSimIndexInterface(index_->getAllocator()), index(index_),

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -5,6 +5,20 @@
 
 #include <shared_mutex>
 
+/**
+ * Definition of generic job structure for asynchronous tiered index.
+ */
+struct AsyncJob : public VecsimBaseObject {
+    JobType jobType;
+    JobCallback Execute; // A callback that receives a job as its input and executes the job.
+
+    AsyncJob(std::shared_ptr<VecSimAllocator> allocator, JobType type, JobCallback callback)
+        : VecsimBaseObject(allocator) {
+        jobType = type;
+        Execute = callback;
+    }
+};
+
 template <typename DataType, typename DistType>
 class VecSimTieredIndex : public VecSimIndexInterface {
 protected:

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -13,10 +13,7 @@ struct AsyncJob : public VecsimBaseObject {
     JobCallback Execute; // A callback that receives a job as its input and executes the job.
 
     AsyncJob(std::shared_ptr<VecSimAllocator> allocator, JobType type, JobCallback callback)
-        : VecsimBaseObject(allocator) {
-        jobType = type;
-        Execute = callback;
-    }
+        : VecsimBaseObject(allocator), jobType(type), Execute(callback) {}
 };
 
 template <typename DataType, typename DistType>

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -58,10 +58,7 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
                                         my_index->getAllocator()->getAllocationSize());
         };
 
-        HNSWInsertJob job = {
-            .base = AsyncJob{.jobType = HNSW_INSERT_VECTOR_JOB, .Execute = insert_to_index},
-            .index = tiered_index,
-            .label = vector_label};
+        HNSWInsertJob job(tiered_index->allocator, vector_label, 0, insert_to_index, tiered_index);
         auto jobs_vec = vecsim_stl::vector<HNSWInsertJob *>(1, &job, allocator);
         tiered_index->labelToInsertJobs.insert({vector_label, jobs_vec});
 
@@ -141,6 +138,8 @@ TYPED_TEST(HNSWTieredIndexTest, addVector) {
             sizeof(void *) + sizeof(size_t);
         // Account for the inner buffer of the std::vector<HNSWInsertJob *> in the map.
         expected_mem += sizeof(void *) + sizeof(size_t);
+        // Account for the insert job that was created.
+        expected_mem += sizeof(HNSWInsertJob) + sizeof(size_t);
         ASSERT_GE(expected_mem * 1.02, memory_ctx);
         ASSERT_LE(expected_mem, memory_ctx);
 

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -107,11 +107,14 @@ TYPED_TEST(HNSWTieredIndexTest, addVector) {
                               .metric = VecSimMetric_L2,
                               .multi = is_multi};
 
-        // Validate that memory upon creating the tiered index is as expected.
+        // Validate that memory upon creating the tiered index is as expected (no more than 2%
+        // above te expected, since in different platforms there are some minor additional
+        // allocations).
         size_t expected_mem = HNSWFactory::EstimateInitialSize(&params) +
                               BruteForceFactory::EstimateInitialSize(&bf_params) +
                               sizeof(*tiered_index);
-        ASSERT_EQ(expected_mem, memory_ctx);
+        ASSERT_LE(expected_mem, memory_ctx);
+        ASSERT_GE(expected_mem * 1.02, memory_ctx);
 
         // Create a vector and add it to the tiered index.
         labelType vec_label = 1;

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -49,11 +49,11 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
             // TODO: enable deleting vectors by internal id for the case of moving a single vector
             //  from the flat buffer in MULTI.
             VecSimIndex_DeleteVector(my_index->flatBuffer, my_insert_job->label);
-            auto it = my_index->labelToInsertJobs[my_insert_job->label].begin();
+            auto it = my_index->labelToInsertJobs.at(my_insert_job->label).begin();
             ASSERT_EQ(job, *it); // Assert pointers equation
             // Here we update labelToInsertJobs mapping, as we except that for every insert job
             // there will be a corresponding item in the map.
-            my_index->labelToInsertJobs[my_insert_job->label].erase(it);
+            my_index->labelToInsertJobs.at(my_insert_job->label).erase(it);
             my_index->UpdateIndexMemory(my_index->memoryCtx,
                                         my_index->getAllocator()->getAllocationSize());
         };
@@ -62,14 +62,13 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
             .base = AsyncJob{.jobType = HNSW_INSERT_VECTOR_JOB, .Execute = insert_to_index},
             .index = tiered_index,
             .label = vector_label};
-        tiered_index->labelToInsertJobs[vector_label].push_back(&job);
+        auto jobs_vec = vecsim_stl::vector<HNSWInsertJob *>(1, &job, allocator);
+        tiered_index->labelToInsertJobs.insert({vector_label, jobs_vec});
 
         // Wrap this job with an array and submit the jobs to the queue.
         // TODO: in the future this should be part of the tiered index "add_vector" flow, and
         //  we can replace this to avoid the breaking of the abstraction.
-        auto **jobs = array_new<AsyncJob *>(1);
-        jobs = array_append(jobs, (AsyncJob *)&job);
-        tiered_index->SubmitJobsToQueue(tiered_index->jobQueue, (void **)jobs, 1);
+        tiered_index->submitSingleJob((AsyncJob *)&job);
         ASSERT_EQ(jobQ->size(), 1);
 
         // Execute the job from the queue and validate that the index was updated properly.
@@ -78,11 +77,10 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
         ASSERT_EQ(tiered_index->getDistanceFrom(1, vector), 0);
         ASSERT_EQ(memory_ctx, tiered_index->getAllocator()->getAllocationSize());
         ASSERT_EQ(tiered_index->flatBuffer->indexSize(), 0);
-        ASSERT_EQ(tiered_index->labelToInsertJobs[vector_label].size(), 0);
+        ASSERT_EQ(tiered_index->labelToInsertJobs.at(vector_label).size(), 0);
 
         // Cleanup.
         delete jobQ;
-        array_free(jobs);
         VecSimIndex_Free(tiered_index);
     }
 }
@@ -92,7 +90,7 @@ TYPED_TEST(HNSWTieredIndexTest, addVector) {
 
     // Create TieredHNSW index instance with a mock queue.
     size_t dim = 4;
-    for (auto is_multi : {true, false}) {
+    for (auto is_multi : {false, true}) {
         HNSWParams params = {.type = TypeParam::get_index_type(),
                              .dim = dim,
                              .metric = VecSimMetric_L2,
@@ -107,20 +105,44 @@ TYPED_TEST(HNSWTieredIndexTest, addVector) {
         auto *tiered_index = reinterpret_cast<TieredHNSWIndex<TEST_DATA_T, TEST_DIST_T> *>(
             HNSWFactory::NewTieredIndex(&tiered_hnsw_params, allocator));
 
-        // Create a vector and add it to the tiered index.
-        TEST_DATA_T vector[dim];
-        GenerateVector<TEST_DATA_T>(vector, dim);
-        labelType vector_label = 1;
-        VecSimIndex_AddVector(tiered_index, vector, vector_label);
+        BFParams bf_params = {.type = TypeParam::get_index_type(),
+                              .dim = dim,
+                              .metric = VecSimMetric_L2,
+                              .multi = is_multi};
 
-        // Validate that the vector was inserted to the flat buffer
+        // Validate that memory upon creating the tiered index is as expected.
+        size_t expected_mem = HNSWFactory::EstimateInitialSize(&params) +
+                              BruteForceFactory::EstimateInitialSize(&bf_params) +
+                              sizeof(*tiered_index);
+        ASSERT_EQ(expected_mem, memory_ctx);
+
+        // Create a vector and add it to the tiered index.
+        labelType vec_label = 1;
+        TEST_DATA_T vector[dim];
+        GenerateVector<TEST_DATA_T>(vector, dim, vec_label);
+        VecSimIndex_AddVector(tiered_index, vector, vec_label);
+        // Validate that the vector was inserted to the flat buffer properly.
         ASSERT_EQ(tiered_index->indexSize(), 1);
-        ASSERT_EQ(tiered_index->flatBuffer->indexSize(), 1);
         ASSERT_EQ(tiered_index->index->indexSize(), 0);
-        ASSERT_EQ(tiered_index->labelToInsertJobs[vector_label].size(), 1);
-        ASSERT_EQ(tiered_index->flatBuffer->getDistanceFrom(vector_label, vector), 0);
-        ASSERT_EQ(memory_ctx, tiered_index->getAllocator()->getAllocationSize());
-        // todo: validate that memory ctx is as expected.
+        ASSERT_EQ(tiered_index->flatBuffer->indexSize(), 1);
+        ASSERT_EQ(tiered_index->flatBuffer->indexCapacity(), DEFAULT_BLOCK_SIZE);
+        ASSERT_EQ(tiered_index->indexCapacity(), DEFAULT_BLOCK_SIZE);
+        ASSERT_EQ(tiered_index->flatBuffer->getDistanceFrom(vec_label, vector), 0);
+
+        // Account for the allocation of a new block due to the vector insertion.
+        expected_mem += (BruteForceFactory::EstimateElementSize(&bf_params)) * DEFAULT_BLOCK_SIZE;
+        // Account for the memory that was allocated in the labelToId map (approx.)
+        expected_mem += sizeof(vecsim_stl::unordered_map<labelType, idType>::value_type) +
+                        sizeof(void *) + sizeof(size_t);
+        // Account for the memory that was allocated in the labelToInsertJobs map (approx.)
+        expected_mem +=
+            sizeof(vecsim_stl::unordered_map<labelType,
+                                             vecsim_stl::vector<HNSWInsertJob *>>::value_type) +
+            sizeof(void *) + sizeof(size_t);
+        // Account for the inner buffer of the std::vector<HNSWInsertJob *> in the map.
+        expected_mem += sizeof(void *) + sizeof(size_t);
+        ASSERT_GE(expected_mem * 1.02, memory_ctx);
+        ASSERT_LE(expected_mem, memory_ctx);
 
         // Cleanup.
         delete jobQ;


### PR DESCRIPTION
Implement `addVector` for the tiered index, where we **assume that there are no overwrites** (for now). Insertion is done into the flat buffer, the insert job callback that is responsible for adding the vector into HNSW graph is not part of this PR scope.
This includes some refactoring of the tiered index structures - among them, making the `AsyncJob` and its derivatives jobs structs inherit from `VecSimObjectBase`, so we can account for the memory that is allocated for the jobs