### PR TITLE
Set an external index context for tiered index - for ownership management MOD-4875

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw_tiered_tests_friends.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered_tests_friends.h
@@ -1,3 +1,4 @@
 #include "VecSim/friend_test_decl.h"
 INDEX_TEST_FRIEND_CLASS(HNSWTieredIndexTest_CreateIndexInstance_Test)
 INDEX_TEST_FRIEND_CLASS(HNSWTieredIndexTest_addVector_Test)
+INDEX_TEST_FRIEND_CLASS(HNSWTieredIndexTest_manageIndexOwnership_Test)

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -63,12 +63,14 @@ typedef enum {
     VecSimParamResolverErr_InvalidPolicy_AdHoc_With_EfRuntime
 } VecSimResolveCode;
 
+typedef struct AsyncJob AsyncJob; // forward declaration.
+
 /**
  * Callback signatures for asynchronous tiered index.
  */
-typedef int (*SubmitCB)(void *job_queue, void **jobs, size_t jobs_len);
+typedef int (*SubmitCB)(void *job_queue, AsyncJob **jobs, size_t jobs_len, void *index_ctx);
 typedef int (*UpdateMemoryCB)(void *memory_ctx, size_t memory);
-typedef void (*JobCallback)(void *);
+typedef void (*JobCallback)(AsyncJob *);
 
 /**
  * @brief Index initialization parameters.
@@ -99,6 +101,7 @@ typedef struct {
 // A struct that contains the common tiered index params.
 typedef struct {
     void *jobQueue;             // External queue that holds the jobs.
+    void *indexCtx;             // External context to be sent to the submit callback.
     SubmitCB submitCb;          // A callback that submits an array of jobs into a given jobQueue.
     void *memoryCtx;            // External context that stores the index memory consumption.
     UpdateMemoryCB UpdateMemCb; // A callback that updates the memoryCtx

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -101,7 +101,7 @@ typedef struct {
 // A struct that contains the common tiered index params.
 typedef struct {
     void *jobQueue;             // External queue that holds the jobs.
-    void *indexCtx;             // External context to be sent to the submit callback.
+    void *jobQueueCtx;          // External context to be sent to the submit callback.
     SubmitCB submitCb;          // A callback that submits an array of jobs into a given jobQueue.
     void *memoryCtx;            // External context that stores the index memory consumption.
     UpdateMemoryCB UpdateMemCb; // A callback that updates the memoryCtx

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -25,7 +25,7 @@ protected:
     VecSimIndexAbstract<DistType> *index;
 
     void *jobQueue;
-    void *indexCtx; // External context to be sent to the submit callback.
+    void *jobQueueCtx; // External context to be sent to the submit callback.
     SubmitCB SubmitJobsToQueue;
 
     void *memoryCtx;
@@ -37,14 +37,14 @@ protected:
     void submitSingleJob(AsyncJob *job) {
         auto **jobs = array_new<AsyncJob *>(1);
         jobs = array_append(jobs, job);
-        this->SubmitJobsToQueue(this->jobQueue, (AsyncJob **)jobs, 1, this->indexCtx);
+        this->SubmitJobsToQueue(this->jobQueue, (AsyncJob **)jobs, 1, this->jobQueueCtx);
         array_free(jobs);
     }
 
 public:
     VecSimTieredIndex(VecSimIndexAbstract<DistType> *index_, TieredIndexParams tieredParams)
         : VecSimIndexInterface(index_->getAllocator()), index(index_),
-          jobQueue(tieredParams.jobQueue), indexCtx(tieredParams.indexCtx),
+          jobQueue(tieredParams.jobQueue), jobQueueCtx(tieredParams.jobQueueCtx),
           SubmitJobsToQueue(tieredParams.submitCb), memoryCtx(tieredParams.memoryCtx),
           UpdateIndexMemory(tieredParams.UpdateMemCb) {
         BFParams bf_params = {.type = index_->getType(),

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -230,6 +230,7 @@ TYPED_TEST(HNSWTieredIndexTest, manageIndexOwnership) {
                 EXPECT_EQ(jobQ->front().relatedIndex.use_count(), 2);
                 reinterpret_cast<AsyncJob *>(jobQ->front().job)->Execute(jobQ->front().job);
             }
+            jobQ->pop();
         };
         std::thread t1(run_fn);
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -239,7 +240,6 @@ TYPED_TEST(HNSWTieredIndexTest, manageIndexOwnership) {
         // Expect that the first job will succeed.
         ASSERT_GE(memory_ctx, initial_mem);
         size_t cur_mem = memory_ctx;
-        jobQ->pop();
 
         // The second job should not run, since the weak reference is not supposed to become a
         // strong references now.

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -2,6 +2,8 @@
 #include "VecSim/algorithms/hnsw/hnsw_factory.h"
 #include "test_utils.h"
 
+#include <thread>
+
 using namespace tiered_index_mock;
 
 template <typename index_type_t>
@@ -19,14 +21,18 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
                              .metric = VecSimMetric_L2,
                              .multi = is_multi};
         auto *jobQ = new JobQueue();
+        auto index_ctx = IndexExtCtx();
         size_t memory_ctx = 0;
         TieredIndexParams tiered_params = {.jobQueue = jobQ,
+                                           .indexCtx = &index_ctx,
                                            .submitCb = submit_callback,
                                            .memoryCtx = &memory_ctx,
                                            .UpdateMemCb = update_mem_callback};
         TieredHNSWParams tiered_hnsw_params = {.hnswParams = params, .tieredParams = tiered_params};
         auto *tiered_index = reinterpret_cast<TieredHNSWIndex<TEST_DATA_T, TEST_DIST_T> *>(
             HNSWFactory::NewTieredIndex(&tiered_hnsw_params, allocator));
+        // Set the created tiered index in the index external context.
+        index_ctx.index_ref.reset(tiered_index);
 
         // Add a vector to the flat index.
         TEST_DATA_T vector[tiered_index->index->getDim()];
@@ -35,7 +41,7 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
         VecSimIndex_AddVector(tiered_index->flatBuffer, vector, vector_label);
 
         // Create a mock job that inserts some vector into the HNSW index.
-        auto insert_to_index = [](void *job) {
+        auto insert_to_index = [](AsyncJob *job) {
             auto *my_insert_job = reinterpret_cast<HNSWInsertJob *>(job);
             auto my_index =
                 reinterpret_cast<TieredHNSWIndex<TEST_DATA_T, TEST_DIST_T> *>(my_insert_job->index);
@@ -69,7 +75,7 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
         ASSERT_EQ(jobQ->size(), 1);
 
         // Execute the job from the queue and validate that the index was updated properly.
-        reinterpret_cast<AsyncJob *>(jobQ->front())->Execute(jobQ->front());
+        reinterpret_cast<AsyncJob *>(jobQ->front().job)->Execute(jobQ->front().job);
         ASSERT_EQ(tiered_index->indexSize(), 1);
         ASSERT_EQ(tiered_index->getDistanceFrom(1, vector), 0);
         ASSERT_EQ(memory_ctx, tiered_index->getAllocator()->getAllocationSize());
@@ -78,7 +84,6 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
 
         // Cleanup.
         delete jobQ;
-        VecSimIndex_Free(tiered_index);
     }
 }
 
@@ -93,14 +98,18 @@ TYPED_TEST(HNSWTieredIndexTest, addVector) {
                              .metric = VecSimMetric_L2,
                              .multi = is_multi};
         auto *jobQ = new JobQueue();
+        auto index_ctx = IndexExtCtx();
         size_t memory_ctx = 0;
         TieredIndexParams tiered_params = {.jobQueue = jobQ,
+                                           .indexCtx = &index_ctx,
                                            .submitCb = submit_callback,
                                            .memoryCtx = &memory_ctx,
                                            .UpdateMemCb = update_mem_callback};
         TieredHNSWParams tiered_hnsw_params = {.hnswParams = params, .tieredParams = tiered_params};
         auto *tiered_index = reinterpret_cast<TieredHNSWIndex<TEST_DATA_T, TEST_DIST_T> *>(
             HNSWFactory::NewTieredIndex(&tiered_hnsw_params, allocator));
+        // Set the created tiered index in the index external context.
+        index_ctx.index_ref.reset(tiered_index);
 
         BFParams bf_params = {.type = TypeParam::get_index_type(),
                               .dim = dim,
@@ -165,6 +174,81 @@ TYPED_TEST(HNSWTieredIndexTest, addVector) {
 
         // Cleanup.
         delete jobQ;
-        VecSimIndex_Free(tiered_index);
+    }
+}
+
+TYPED_TEST(HNSWTieredIndexTest, manageIndexOwnership) {
+    std::shared_ptr<VecSimAllocator> allocator = VecSimAllocator::newVecsimAllocator();
+
+    // Create TieredHNSW index instance with a mock queue.
+    for (auto is_multi : {true, false}) {
+        size_t dim = 4;
+        HNSWParams params = {.type = TypeParam::get_index_type(),
+                             .dim = dim,
+                             .metric = VecSimMetric_L2,
+                             .multi = is_multi};
+        auto *jobQ = new JobQueue();
+        auto *index_ctx = new IndexExtCtx();
+        size_t memory_ctx = 0;
+        TieredIndexParams tiered_params = {.jobQueue = jobQ,
+                                           .indexCtx = index_ctx,
+                                           .submitCb = submit_callback,
+                                           .memoryCtx = &memory_ctx,
+                                           .UpdateMemCb = update_mem_callback};
+        TieredHNSWParams tiered_hnsw_params = {.hnswParams = params, .tieredParams = tiered_params};
+        auto *tiered_index = reinterpret_cast<TieredHNSWIndex<TEST_DATA_T, TEST_DIST_T> *>(
+            HNSWFactory::NewTieredIndex(&tiered_hnsw_params, allocator));
+        // Set the created tiered index in the index external context.
+        index_ctx->index_ref.reset(tiered_index);
+        EXPECT_EQ(index_ctx->index_ref.use_count(), 1);
+        size_t initial_mem = memory_ctx;
+
+        // Create a dummy job callback that insert one vector to the underline HNSW index.
+        auto dummy_job = [](AsyncJob *job) {
+            auto *my_index =
+                reinterpret_cast<TieredHNSWIndex<TEST_DATA_T, TEST_DIST_T> *>(job->index);
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            size_t dim = 4;
+            TEST_DATA_T vector[dim];
+            GenerateVector<TEST_DATA_T>(vector, dim);
+            if (my_index->index->indexCapacity() == my_index->index->indexSize()) {
+                my_index->index->increaseCapacity();
+            }
+            my_index->index->addVector(vector, my_index->index->indexSize(), false);
+        };
+
+        AsyncJob job(tiered_index->allocator, HNSW_INSERT_VECTOR_JOB, dummy_job, tiered_index);
+
+        // Wrap this job with an array and submit the jobs to the queue.
+        tiered_index->submitSingleJob((AsyncJob *)&job);
+        tiered_index->submitSingleJob((AsyncJob *)&job);
+        ASSERT_EQ(jobQ->size(), 2);
+
+        // Execute the job from the queue asynchronously, delete the index in the meantime.
+        auto run_fn = [&jobQ]() {
+            if (auto temp_ref = jobQ->front().relatedIndex.lock()) {
+                EXPECT_EQ(jobQ->front().relatedIndex.use_count(), 2);
+                reinterpret_cast<AsyncJob *>(jobQ->front().job)->Execute(jobQ->front().job);
+            }
+        };
+        std::thread t1(run_fn);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        delete index_ctx;
+        EXPECT_EQ(jobQ->front().relatedIndex.use_count(), 1);
+        t1.join();
+        // Expect that the first job will succeed.
+        ASSERT_GE(memory_ctx, initial_mem);
+        size_t cur_mem = memory_ctx;
+        jobQ->pop();
+
+        // The second job should not run, since the weak reference is not supposed to become a
+        // strong references now.
+        ASSERT_EQ(jobQ->front().relatedIndex.use_count(), 0);
+        std::thread t2(run_fn);
+        t2.join();
+        ASSERT_EQ(memory_ctx, cur_mem);
+
+        // Cleanup.
+        delete jobQ;
     }
 }

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -256,8 +256,9 @@ int tiered_index_mock::submit_callback(void *job_queue, AsyncJob **jobs, size_t 
                                        void *index_ctx) {
     for (size_t i = 0; i < len; i++) {
         // Wrap the job with a struct that contains a weak reference to the related index.
-        auto owned_job = OwnedJob{
-            .job = jobs[i], .relatedIndex = reinterpret_cast<IndexExtCtx *>(index_ctx)->index_ref};
+        auto owned_job = RefManagedJob{
+            .job = jobs[i],
+            .index_weak_ref = reinterpret_cast<IndexExtCtx *>(index_ctx)->index_strong_ref};
         static_cast<JobQueue *>(job_queue)->push(owned_job);
     }
     return VecSim_OK;

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -129,7 +129,18 @@ inline double GetInfVal(VecSimType type) {
     }
 
 namespace tiered_index_mock {
-using JobQueue = std::queue<void *>;
-int submit_callback(void *job_queue, void **jobs, size_t len);
+
+typedef struct OwnedJob {
+    AsyncJob *job;
+    std::weak_ptr<VecSimIndex> relatedIndex;
+} OwnedJob;
+
+using JobQueue = std::queue<OwnedJob>;
+int submit_callback(void *job_queue, AsyncJob **jobs, size_t len, void *index_ctx);
 int update_mem_callback(void *mem_ctx, size_t mem);
+
+typedef struct IndexExtCtx {
+    std::shared_ptr<VecSimIndex> index_ref;
+} IndexExtCtx;
+
 } // namespace tiered_index_mock

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -130,17 +130,17 @@ inline double GetInfVal(VecSimType type) {
 
 namespace tiered_index_mock {
 
-typedef struct OwnedJob {
+typedef struct RefManagedJob {
     AsyncJob *job;
-    std::weak_ptr<VecSimIndex> relatedIndex;
-} OwnedJob;
+    std::weak_ptr<VecSimIndex> index_weak_ref;
+} RefManagedJob;
 
-using JobQueue = std::queue<OwnedJob>;
+using JobQueue = std::queue<RefManagedJob>;
 int submit_callback(void *job_queue, AsyncJob **jobs, size_t len, void *index_ctx);
 int update_mem_callback(void *mem_ctx, size_t mem);
 
 typedef struct IndexExtCtx {
-    std::shared_ptr<VecSimIndex> index_ref;
+    std::shared_ptr<VecSimIndex> index_strong_ref;
 } IndexExtCtx;
 
 } // namespace tiered_index_mock


### PR DESCRIPTION
**Describe the changes in the pull request**

Let the tiered index receive an external opaque index context, and send this context in turn to the submit callback upon submitting a job to be executed asynchronously. The purpose is that the caller would have the option to create a weak reference to the underline index (or the index spec, in RediSearch case) and associate it with the job. When the job is executed, the weak reference is promoted as long as the index has not been deleted. Hence, if the index is deleted while the job is being executed, it is guarded. 

This includes small refactor - moving the pointer to the index to the base `AsyncJob`