### PR TITLE
Call shrink to fit for id to label mapping in flat index

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -135,6 +135,7 @@ void BruteForceIndex<DataType, DistType>::appendVector(const void *vector_data, 
         size_t last_block_vectors_count = id % this->blockSize;
         this->idToLabelMapping.resize(
             idToLabelMapping_size + this->blockSize - last_block_vectors_count, 0);
+        this->idToLabelMapping.shrink_to_fit();
     }
 
     // add label to idToLabelMapping
@@ -188,6 +189,7 @@ void BruteForceIndex<DataType, DistType>::removeVector(idType id_to_delete) {
         if (this->count + this->blockSize <= idToLabel_size) {
             size_t vector_to_align_count = idToLabel_size % this->blockSize;
             this->idToLabelMapping.resize(idToLabel_size - this->blockSize - vector_to_align_count);
+            this->idToLabelMapping.shrink_to_fit();
         }
     }
 }

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -166,8 +166,8 @@ TYPED_TEST(IndexAllocatorTest, test_bf_index_block_size_1) {
     // collection allocate additional structures for their internal implementation.
     ASSERT_EQ(allocator->getAllocationSize(),
               expectedAllocationSize + deleteCommandAllocationDelta);
-    ASSERT_LE(expectedAllocationSize + expectedAllocationDelta, allocator->getAllocationSize());
-    ASSERT_LE(expectedAllocationDelta, deleteCommandAllocationDelta);
+    ASSERT_GE(expectedAllocationSize + expectedAllocationDelta, allocator->getAllocationSize());
+    ASSERT_GE(expectedAllocationDelta, deleteCommandAllocationDelta);
 
     info = bfIndex->info();
     ASSERT_EQ(allocator->getAllocationSize(), info.bfInfo.memory);


### PR DESCRIPTION
**Describe the changes in the pull request**

`id_to_label_mapping` in brute force index is a std::vector, and whenever we `resize` it, its capacity is determined according to this container's policy. Then, when we add a block and call for `resize`, the capacity is doubled (rather than increased by block size). The fix is calling `shring_to_fit()` which deallocates unnecessary memory from the container (so its capacity matches its size). 

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
