### PR TITLE
Tiered HNSW - API update - [MOD-5099]

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -361,6 +361,10 @@ VecSimInfoIterator *BruteForceIndex<DataType, DistType>::infoIterator() const {
         .fieldType = INFOFIELD_STRING,
         .fieldValue = {FieldValue{.stringValue = VecSimAlgo_ToString(info.algo)}}});
     this->addCommonInfoToIterator(infoIterator, info.commonInfo);
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::BLOCK_SIZE_STRING,
+                         .fieldType = INFOFIELD_UINT64,
+                         .fieldValue = {FieldValue{.uintegerValue = info.commonInfo.blockSize}}});
     return infoIterator;
 }
 

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -45,14 +45,14 @@ public:
         return (DataType *)vectorBlocks.at(id / this->blockSize)->getVector(id % this->blockSize);
     }
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
-                                             VecSimQueryParams *queryParams) override;
+                                             VecSimQueryParams *queryParams) const override;
     virtual VecSimQueryResult_List rangeQuery(const void *queryBlob, double radius,
-                                              VecSimQueryParams *queryParams) override;
+                                              VecSimQueryParams *queryParams) const override;
     virtual VecSimIndexInfo info() const override;
     virtual VecSimInfoIterator *infoIterator() const override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob,
                                                   VecSimQueryParams *queryParams) const override;
-    bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) override;
+    bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override;
     inline labelType getVectorLabel(idType id) const { return idToLabelMapping.at(id); }
 
     inline vecsim_stl::vector<VectorBlock *> getVectorBlocks() const { return vectorBlocks; }
@@ -101,7 +101,7 @@ protected:
     }
     // inline priority queue getter that need to be implemented by derived class
     virtual inline vecsim_stl::abstract_priority_queue<DistType, labelType> *
-    getNewMaxPriorityQueue() = 0;
+    getNewMaxPriorityQueue() const = 0;
 
     // inline label to id setters that need to be implemented by derived class
     virtual inline std::unique_ptr<vecsim_stl::abstract_results_container>
@@ -259,7 +259,7 @@ vecsim_stl::vector<DistType> BruteForceIndex<DataType, DistType>::computeBlockSc
 template <typename DataType, typename DistType>
 VecSimQueryResult_List
 BruteForceIndex<DataType, DistType>::topKQuery(const void *queryBlob, size_t k,
-                                               VecSimQueryParams *queryParams) {
+                                               VecSimQueryParams *queryParams) const {
 
     VecSimQueryResult_List rl = {0};
     void *timeoutCtx = queryParams ? queryParams->timeoutCtx : NULL;
@@ -310,7 +310,7 @@ BruteForceIndex<DataType, DistType>::topKQuery(const void *queryBlob, size_t k,
 template <typename DataType, typename DistType>
 VecSimQueryResult_List
 BruteForceIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double radius,
-                                                VecSimQueryParams *queryParams) {
+                                                VecSimQueryParams *queryParams) const {
     auto rl = (VecSimQueryResult_List){0};
     void *timeoutCtx = queryParams ? queryParams->timeoutCtx : nullptr;
     this->last_mode = RANGE_QUERY;
@@ -376,7 +376,7 @@ BruteForceIndex<DataType, DistType>::newBatchIterator(const void *queryBlob,
 
 template <typename DataType, typename DistType>
 bool BruteForceIndex<DataType, DistType>::preferAdHocSearch(size_t subsetSize, size_t k,
-                                                            bool initial_check) {
+                                                            bool initial_check) const {
     // This heuristic is based on sklearn decision tree classifier (with 10 leaves nodes) -
     // see scripts/BF_batches_clf.py
     size_t index_size = this->indexSize();

--- a/src/VecSim/algorithms/brute_force/brute_force_multi.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_multi.h
@@ -70,7 +70,7 @@ private:
     };
 
     inline vecsim_stl::abstract_priority_queue<DistType, labelType> *
-    getNewMaxPriorityQueue() override {
+    getNewMaxPriorityQueue() const override {
         return new (this->allocator)
             vecsim_stl::updatable_max_heap<DistType, labelType>(this->allocator);
     }

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -85,7 +85,7 @@ protected:
     };
 
     inline vecsim_stl::abstract_priority_queue<DistType, labelType> *
-    getNewMaxPriorityQueue() override {
+    getNewMaxPriorityQueue() const override {
         return new (this->allocator)
             vecsim_stl::max_priority_queue<DistType, labelType>(this->allocator);
     }

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -240,7 +240,7 @@ public:
     inline void returnVisitedList(VisitedNodesHandler *visited_nodes_handler) const;
     VecSimIndexInfo info() const override;
     VecSimInfoIterator *infoIterator() const override;
-    bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) override;
+    bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override;
     char *getDataByInternalId(idType internal_id) const;
     inline idType *getNodeNeighborsAtLevel(idType internal_id, size_t level) const;
     inline linkListSize getNodeNeighborsCount(const idType *list) const;
@@ -248,9 +248,9 @@ public:
                                       VecSimQueryResult_Code *rc) const;
 
     VecSimQueryResult_List topKQuery(const void *query_data, size_t k,
-                                     VecSimQueryParams *queryParams) override;
+                                     VecSimQueryParams *queryParams) const override;
     VecSimQueryResult_List rangeQuery(const void *query_data, double radius,
-                                      VecSimQueryParams *queryParams) override;
+                                      VecSimQueryParams *queryParams) const override;
 
     inline void markDeletedInternal(idType internalId);
     inline bool isMarkedDeleted(idType internalId) const;
@@ -1978,7 +1978,7 @@ HNSWIndex<DataType, DistType>::searchBottomLayer_WithTimeout(idType ep_id, const
 
 template <typename DataType, typename DistType>
 VecSimQueryResult_List HNSWIndex<DataType, DistType>::topKQuery(const void *query_data, size_t k,
-                                                                VecSimQueryParams *queryParams) {
+                                                                VecSimQueryParams *queryParams) const {
 
     VecSimQueryResult_List rl = {0};
     this->last_mode = STANDARD_KNN;
@@ -2106,7 +2106,7 @@ VecSimQueryResult *HNSWIndex<DataType, DistType>::searchRangeBottomLayer_WithTim
 template <typename DataType, typename DistType>
 VecSimQueryResult_List HNSWIndex<DataType, DistType>::rangeQuery(const void *query_data,
                                                                  double radius,
-                                                                 VecSimQueryParams *queryParams) {
+                                                                 VecSimQueryParams *queryParams) const {
 
     VecSimQueryResult_List rl = {0};
     this->last_mode = RANGE_QUERY;
@@ -2218,7 +2218,7 @@ VecSimInfoIterator *HNSWIndex<DataType, DistType>::infoIterator() const {
 
 template <typename DataType, typename DistType>
 bool HNSWIndex<DataType, DistType>::preferAdHocSearch(size_t subsetSize, size_t k,
-                                                      bool initial_check) {
+                                                      bool initial_check) const {
     // This heuristic is based on sklearn decision tree classifier (with 20 leaves nodes) -
     // see scripts/HNSW_batches_clf.py
     size_t index_size = this->indexSize();

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -1977,8 +1977,9 @@ HNSWIndex<DataType, DistType>::searchBottomLayer_WithTimeout(idType ep_id, const
 }
 
 template <typename DataType, typename DistType>
-VecSimQueryResult_List HNSWIndex<DataType, DistType>::topKQuery(const void *query_data, size_t k,
-                                                                VecSimQueryParams *queryParams) const {
+VecSimQueryResult_List
+HNSWIndex<DataType, DistType>::topKQuery(const void *query_data, size_t k,
+                                         VecSimQueryParams *queryParams) const {
 
     VecSimQueryResult_List rl = {0};
     this->last_mode = STANDARD_KNN;
@@ -2104,9 +2105,9 @@ VecSimQueryResult *HNSWIndex<DataType, DistType>::searchRangeBottomLayer_WithTim
 }
 
 template <typename DataType, typename DistType>
-VecSimQueryResult_List HNSWIndex<DataType, DistType>::rangeQuery(const void *query_data,
-                                                                 double radius,
-                                                                 VecSimQueryParams *queryParams) const {
+VecSimQueryResult_List
+HNSWIndex<DataType, DistType>::rangeQuery(const void *query_data, double radius,
+                                          VecSimQueryParams *queryParams) const {
 
     VecSimQueryResult_List rl = {0};
     this->last_mode = RANGE_QUERY;
@@ -2177,6 +2178,11 @@ VecSimInfoIterator *HNSWIndex<DataType, DistType>::infoIterator() const {
         .fieldValue = {FieldValue{.stringValue = VecSimAlgo_ToString(info.algo)}}});
 
     this->addCommonInfoToIterator(infoIterator, info.commonInfo);
+
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::BLOCK_SIZE_STRING,
+                         .fieldType = INFOFIELD_UINT64,
+                         .fieldValue = {FieldValue{.uintegerValue = info.commonInfo.blockSize}}});
 
     infoIterator->addInfoField(
         VecSim_InfoField{.fieldName = VecSimCommonStrings::HNSW_M_STRING,

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -296,7 +296,7 @@ int TieredHNSWIndex<DataType, DistType>::deleteLabelFromHNSW(labelType label) {
 
     for (size_t i = 0; i < internal_ids.size(); i++) {
         idType id = internal_ids[i];
-        vecsim_stl::vector<HNSWRepairJob *> repair_jobs(this->allocator);
+        vecsim_stl::vector<AsyncJob *> repair_jobs(this->allocator);
         auto *swap_job = new (this->allocator) HNSWSwapJob(this->allocator, id);
 
         // Go over all the deleted element links in every level and create repair jobs.
@@ -336,8 +336,7 @@ int TieredHNSWIndex<DataType, DistType>::deleteLabelFromHNSW(labelType label) {
         swap_job->setRepairJobsNum(incoming_edges.size());
         this->idToRepairJobsGuard.unlock();
 
-        this->SubmitJobsToQueue(this->jobQueue, (AsyncJob **)repair_jobs.data(), repair_jobs.size(),
-                                this->jobQueueCtx);
+        this->submitJobs(repair_jobs);
         // Insert the swap job into the swap jobs lookup (for fast update in case that the
         // node id is changed due to swap job).
         assert(idToSwapJob.find(id) == idToSwapJob.end());

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -202,7 +202,6 @@ void TieredHNSWIndex<DataType, DistType>::executeInsertJobWrapper(AsyncJob *job)
     auto *insert_job = reinterpret_cast<HNSWInsertJob *>(job);
     auto *job_index = reinterpret_cast<TieredHNSWIndex<DataType, DistType> *>(insert_job->index);
     job_index->executeInsertJob(insert_job);
-    job_index->UpdateIndexMemory(job_index->memoryCtx, job_index->getAllocationSize());
 }
 
 template <typename DataType, typename DistType>
@@ -210,7 +209,6 @@ void TieredHNSWIndex<DataType, DistType>::executeRepairJobWrapper(AsyncJob *job)
     auto *repair_job = reinterpret_cast<HNSWRepairJob *>(job);
     auto *job_index = reinterpret_cast<TieredHNSWIndex<DataType, DistType> *>(repair_job->index);
     job_index->executeRepairJob(repair_job);
-    job_index->UpdateIndexMemory(job_index->memoryCtx, job_index->getAllocationSize());
 }
 
 template <typename DataType, typename DistType>
@@ -513,7 +511,6 @@ void TieredHNSWIndex<DataType, DistType>::executeRepairJob(HNSWRepairJob *job) {
     hnsw_index->repairNodeConnections(job->node_id, job->level);
 
     this->mainIndexGuard.unlock_shared();
-    this->UpdateIndexMemory(this->memoryCtx, this->getAllocationSize());
 }
 
 /******************** Index API ****************************************/
@@ -533,7 +530,6 @@ TieredHNSWIndex<DataType, DistType>::TieredHNSWIndex(HNSWIndex<DataType, DistTyp
             ? DEFAULT_PENDING_SWAP_JOBS_THRESHOLD
             : std::min(tiered_index_params.specificParams.tieredHnswParams.swapJobThreshold,
                        MAX_PENDING_SWAP_JOBS_THRESHOLD);
-    this->UpdateIndexMemory(this->memoryCtx, this->getAllocationSize());
 }
 
 template <typename DataType, typename DistType>
@@ -648,7 +644,6 @@ int TieredHNSWIndex<DataType, DistType>::addVector(const void *blob, labelType l
 
     // Insert job to the queue and signal the workers' updater.
     this->submitSingleJob(new_insert_job);
-    this->UpdateIndexMemory(this->memoryCtx, this->getAllocationSize());
     return ret;
 }
 
@@ -700,7 +695,6 @@ int TieredHNSWIndex<DataType, DistType>::deleteVector(labelType label) {
         this->mainIndexGuard.unlock();
     }
 
-    this->UpdateIndexMemory(this->memoryCtx, this->getAllocationSize());
     return num_deleted_vectors;
 }
 

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -202,7 +202,6 @@ void TieredHNSWIndex<DataType, DistType>::executeInsertJobWrapper(AsyncJob *job)
     auto *insert_job = reinterpret_cast<HNSWInsertJob *>(job);
     auto *job_index = reinterpret_cast<TieredHNSWIndex<DataType, DistType> *>(insert_job->index);
     job_index->executeInsertJob(insert_job);
-    delete insert_job;
     job_index->UpdateIndexMemory(job_index->memoryCtx, job_index->getAllocationSize());
 }
 
@@ -211,7 +210,6 @@ void TieredHNSWIndex<DataType, DistType>::executeRepairJobWrapper(AsyncJob *job)
     auto *repair_job = reinterpret_cast<HNSWRepairJob *>(job);
     auto *job_index = reinterpret_cast<TieredHNSWIndex<DataType, DistType> *>(repair_job->index);
     job_index->executeRepairJob(repair_job);
-    delete repair_job;
     job_index->UpdateIndexMemory(job_index->memoryCtx, job_index->getAllocationSize());
 }
 
@@ -253,7 +251,6 @@ void TieredHNSWIndex<DataType, DistType>::executeSwapJob(HNSWSwapJob *job,
     } else {
         idsToRemove.push_back(job->deleted_id);
     }
-    delete job;
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -167,7 +167,7 @@ public:
                     BruteForceIndex<DataType, DistType> *bf_index,
                     const TieredIndexParams &tieredParams,
                     std::shared_ptr<VecSimAllocator> allocator);
-    virtual ~TieredHNSWIndex();
+    virtual ~TieredHNSWIndex() = default;
 
     int addVector(const void *blob, labelType label, void *auxiliaryCtx = nullptr) override;
     int deleteVector(labelType label) override;
@@ -534,26 +534,6 @@ TieredHNSWIndex<DataType, DistType>::TieredHNSWIndex(HNSWIndex<DataType, DistTyp
             : std::min(tiered_index_params.specificParams.tieredHnswParams.swapJobThreshold,
                        MAX_PENDING_SWAP_JOBS_THRESHOLD);
     this->UpdateIndexMemory(this->memoryCtx, this->getAllocationSize());
-}
-
-template <typename DataType, typename DistType>
-TieredHNSWIndex<DataType, DistType>::~TieredHNSWIndex() {
-    // Delete all the pending insert jobs.
-    for (auto &jobs : this->labelToInsertJobs) {
-        for (auto *job : jobs.second) {
-            delete job;
-        }
-    }
-    // Delete all the pending repair jobs.
-    for (auto &jobs : this->idToRepairJobs) {
-        for (auto *job : jobs.second) {
-            delete job;
-        }
-    }
-    // Delete all the pending swap jobs.
-    for (auto &it : this->idToSwapJob) {
-        delete it.second;
-    }
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -584,7 +584,6 @@ int TieredHNSWIndex<DataType, DistType>::addVector(const void *blob, labelType l
         // may need to increase the capacity when we append the new vector afterwards.
         ret = hnsw_index->addVector(blob, label);
         this->mainIndexGuard.unlock();
-        this->UpdateIndexMemory(this->memoryCtx, this->getAllocationSize());
         return ret;
     }
     if (this->frontendIndex->indexSize() >= this->flatBufferLimit) {
@@ -599,7 +598,6 @@ int TieredHNSWIndex<DataType, DistType>::addVector(const void *blob, labelType l
             // directly to HNSW. Since flat buffer guard was not held, no need to release it
             // internally.
             this->insertVectorToHNSW<false>(hnsw_index, label, blob);
-            this->UpdateIndexMemory(this->memoryCtx, this->getAllocationSize());
             return ret;
         }
         // Otherwise, we fall back to the "regular" insertion into the flat buffer

--- a/src/VecSim/memory/vecsim_base.h
+++ b/src/VecSim/memory/vecsim_base.h
@@ -28,7 +28,7 @@ public:
     static void operator delete[](void *p, size_t size, std::shared_ptr<VecSimAllocator> allocator);
 
     std::shared_ptr<VecSimAllocator> getAllocator() const;
-    virtual inline int64_t getAllocationSize() const {
+    virtual inline uint64_t getAllocationSize() const {
         return this->allocator->getAllocationSize();
     }
 

--- a/src/VecSim/memory/vecsim_malloc.cpp
+++ b/src/VecSim/memory/vecsim_malloc.cpp
@@ -77,4 +77,4 @@ void *VecSimAllocator::operator new[](size_t size) { return vecsim_malloc(size);
 void VecSimAllocator::operator delete(void *p, size_t size) { vecsim_free(p); }
 void VecSimAllocator::operator delete[](void *p, size_t size) { vecsim_free(p); }
 
-int64_t VecSimAllocator::getAllocationSize() const { return this->allocated; }
+uint64_t VecSimAllocator::getAllocationSize() const { return this->allocated; }

--- a/src/VecSim/memory/vecsim_malloc.h
+++ b/src/VecSim/memory/vecsim_malloc.h
@@ -40,7 +40,7 @@ public:
     void operator delete(void *p, size_t size);
     void operator delete[](void *p, size_t size);
 
-    int64_t getAllocationSize() const;
+    uint64_t getAllocationSize() const;
     inline friend bool operator==(const VecSimAllocator &a, const VecSimAllocator &b) {
         return a.allocated == b.allocated;
     }

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -111,21 +111,17 @@ extern "C" size_t VecSimIndex_EstimateInitialSize(const VecSimParams *params) {
     return VecSimFactory::EstimateInitialSize(params);
 }
 
-extern "C" int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id) {
-    int64_t before = index->getAllocationSize();
+extern "C" size_t VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id) {
     if (index->indexSize() == index->indexCapacity()) {
         index->increaseCapacity();
     }
     index->addVectorWrapper(blob, id);
-    int64_t after = index->getAllocationSize();
-    return after - before;
+    return index->getAllocationSize();
 }
 
-extern "C" int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id) {
-    int64_t before = index->getAllocationSize();
+extern "C" size_t VecSimIndex_DeleteVector(VecSimIndex *index, size_t id) {
     index->deleteVector(id);
-    int64_t after = index->getAllocationSize();
-    return after - before;
+    return index->getAllocationSize();
 }
 
 extern "C" double VecSimIndex_GetDistanceFrom(VecSimIndex *index, size_t id, const void *blob) {

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -111,17 +111,15 @@ extern "C" size_t VecSimIndex_EstimateInitialSize(const VecSimParams *params) {
     return VecSimFactory::EstimateInitialSize(params);
 }
 
-extern "C" size_t VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id) {
+extern "C" int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id) {
     if (index->indexSize() == index->indexCapacity()) {
         index->increaseCapacity();
     }
-    index->addVectorWrapper(blob, id);
-    return index->getAllocationSize();
+    return index->addVectorWrapper(blob, id);
 }
 
-extern "C" size_t VecSimIndex_DeleteVector(VecSimIndex *index, size_t id) {
-    index->deleteVector(id);
-    return index->getAllocationSize();
+extern "C" int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id) {
+    return index->deleteVector(id);
 }
 
 extern "C" double VecSimIndex_GetDistanceFrom(VecSimIndex *index, size_t id, const void *blob) {

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -148,6 +148,11 @@ extern "C" VecSimResolveCode VecSimIndex_ResolveParams(VecSimIndex *index, VecSi
         return VecSimParamResolverErr_NullParam;
     }
     VecSimAlgo index_type = index->info().algo;
+    // Treat tiered index as the backend index type.
+    if (index_type == VecSimAlgo_TIERED) {
+        index_type = index->info().tieredInfo.backendAlgo;
+    }
+
     bzero(qparams, sizeof(VecSimQueryParams));
     auto res = VecSimParamResolver_OK;
     for (int i = 0; i < paramNum; i++) {

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -111,19 +111,19 @@ extern "C" size_t VecSimIndex_EstimateInitialSize(const VecSimParams *params) {
     return VecSimFactory::EstimateInitialSize(params);
 }
 
-extern "C" int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id) {
+extern "C" int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t label) {
     if (index->indexSize() == index->indexCapacity()) {
         index->increaseCapacity();
     }
-    return index->addVectorWrapper(blob, id);
+    return index->addVectorWrapper(blob, label);
 }
 
-extern "C" int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id) {
-    return index->deleteVector(id);
+extern "C" int VecSimIndex_DeleteVector(VecSimIndex *index, size_t label) {
+    return index->deleteVector(label);
 }
 
-extern "C" double VecSimIndex_GetDistanceFrom(VecSimIndex *index, size_t id, const void *blob) {
-    return index->getDistanceFrom(id, blob);
+extern "C" double VecSimIndex_GetDistanceFrom(VecSimIndex *index, size_t label, const void *blob) {
+    return index->getDistanceFrom(label, blob);
 }
 
 extern "C" size_t VecSimIndex_EstimateElementSize(const VecSimParams *params) {

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -53,17 +53,17 @@ void VecSimIndex_Free(VecSimIndex *index);
  * @param blob binary representation of the vector. Blob size should match the index data type and
  * dimension.
  * @param id the id of the added vector
- * @return always returns true
+ * @return the current size of the index after the removal (in bytes)
  */
-int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id);
+size_t VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id);
 
 /**
  * @brief Remove a vector from an index.
  * @param index the index from which the vector is removed.
  * @param id the id of the removed vector
- * @return always returns true
+ * @return the current size of the index after the removal (in bytes)
  */
-int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id);
+size_t VecSimIndex_DeleteVector(VecSimIndex *index, size_t id);
 
 /**
  * @brief Calculate the distance of a vector from an index to a vector. This function assumes that

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -53,17 +53,17 @@ void VecSimIndex_Free(VecSimIndex *index);
  * @param blob binary representation of the vector. Blob size should match the index data type and
  * dimension.
  * @param id the id of the added vector
- * @return the current size of the index after the removal (in bytes)
+ * @return the number of new vectors inserted (1 for new insertion, 0 for override).
  */
-size_t VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id);
+int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id);
 
 /**
  * @brief Remove a vector from an index.
  * @param index the index from which the vector is removed.
  * @param id the id of the removed vector
- * @return the current size of the index after the removal (in bytes)
+ * @return the number of vectors removed (0 if the id was not found)
  */
-size_t VecSimIndex_DeleteVector(VecSimIndex *index, size_t id);
+int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id);
 
 /**
  * @brief Calculate the distance of a vector from an index to a vector. This function assumes that

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -52,18 +52,18 @@ void VecSimIndex_Free(VecSimIndex *index);
  * @param index the index to which the vector is added.
  * @param blob binary representation of the vector. Blob size should match the index data type and
  * dimension.
- * @param id the id of the added vector
+ * @param label the label of the added vector
  * @return the number of new vectors inserted (1 for new insertion, 0 for override).
  */
-int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t id);
+int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t label);
 
 /**
  * @brief Remove a vector from an index.
  * @param index the index from which the vector is removed.
- * @param id the id of the removed vector
- * @return the number of vectors removed (0 if the id was not found)
+ * @param label the label of the removed vector
+ * @return the number of vectors removed (0 if the label was not found)
  */
-int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id);
+int VecSimIndex_DeleteVector(VecSimIndex *index, size_t label);
 
 /**
  * @brief Calculate the distance of a vector from an index to a vector. This function assumes that
@@ -71,13 +71,13 @@ int VecSimIndex_DeleteVector(VecSimIndex *index, size_t id);
  * index's distance metric is cosine, the vector is already normalized.
  * @param index the index from which the first vector is located, and that defines the distance
  * metric.
- * @param id the id of the vector in the index.
+ * @param label the label of the vector in the index.
  * @param blob binary representation of the second vector. Blob size should match the index data
  * type and dimension, and pre-normalized if needed.
  * @return The distance (according to the index's distance metric) between `blob` and the vector
- * with id `id`.
+ * with label  label`.
  */
-double VecSimIndex_GetDistanceFrom(VecSimIndex *index, size_t id, const void *blob);
+double VecSimIndex_GetDistanceFrom(VecSimIndex *index, size_t label, const void *blob);
 
 /**
  * @brief normalize the vector blob in place.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -120,12 +120,9 @@ typedef struct {
 
 // A struct that contains the common tiered index params.
 typedef struct {
-    void *jobQueue;             // External queue that holds the jobs.
-    void *jobQueueCtx;          // External context to be sent to the submit callback.
-    SubmitCB submitCb;          // A callback that submits an array of jobs into a given jobQueue.
-    void *memoryCtx;            // External context that stores the index memory consumption.
-    UpdateMemoryCB UpdateMemCb; // A callback that updates the memoryCtx
-                                // with a given memory (number).
+    void *jobQueue;         // External queue that holds the jobs.
+    void *jobQueueCtx;      // External context to be sent to the submit callback.
+    SubmitCB submitCb;      // A callback that submits an array of jobs into a given jobQueue.
     size_t flatBufferLimit; // Maximum size allowed for the flat buffer. If flat buffer is full, use
                             // in-place insertion.
     VecSimParams *primaryIndexParams; // Parameters to initialize the index.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -79,9 +79,10 @@ typedef enum { VecSim_WriteAsync, VecSim_WriteInPlace } VecSimWriteMode;
 /**
  * Callback signatures for asynchronous tiered index.
  */
-typedef int (*SubmitCB)(void *job_queue, AsyncJob **jobs, size_t jobs_len, void *index_ctx);
-typedef int (*UpdateMemoryCB)(void *memory_ctx, size_t memory);
 typedef void (*JobCallback)(AsyncJob *);
+typedef int (*SubmitCB)(void *job_queue, void *index_ctx, AsyncJob **jobs, JobCallback *CBs,
+                        JobCallback *freeCBs, size_t jobs_len);
+typedef int (*UpdateMemoryCB)(void *memory_ctx, size_t memory);
 
 /**
  * @brief Index initialization parameters.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -83,7 +83,6 @@ typedef enum { VecSim_WriteAsync, VecSim_WriteInPlace } VecSimWriteMode;
 typedef void (*JobCallback)(AsyncJob *);
 typedef int (*SubmitCB)(void *job_queue, void *index_ctx, AsyncJob **jobs, JobCallback *CBs,
                         JobCallback *freeCBs, size_t jobs_len);
-typedef int (*UpdateMemoryCB)(void *memory_ctx, size_t memory);
 
 /**
  * @brief Index initialization parameters.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -11,6 +11,7 @@ extern "C" {
 #endif
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 // Common definitions
 #define INVALID_ID    UINT_MAX

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -53,7 +53,7 @@ protected:
                          // resizing)
     dist_func_t<DistType>
         dist_func;           // Index's distance function. Chosen by the type, metric and dimension.
-    VecSearchMode last_mode; // The last search mode in RediSearch (used for debug/testing).
+    mutable VecSearchMode last_mode; // The last search mode in RediSearch (used for debug/testing).
     bool isMulti;            // Determines if the index should multi-index or not.
     void *logCallbackCtx;    // Context for the log callback.
 
@@ -109,10 +109,10 @@ public:
     inline size_t getDataSize() const { return data_size; }
 
     virtual VecSimQueryResult_List rangeQuery(const void *queryBlob, double radius,
-                                              VecSimQueryParams *queryParams) = 0;
+                                              VecSimQueryParams *queryParams) const = 0;
     VecSimQueryResult_List rangeQuery(const void *queryBlob, double radius,
                                       VecSimQueryParams *queryParams,
-                                      VecSimQueryResult_Order order) override {
+                                      VecSimQueryResult_Order order) const override {
         auto results = rangeQuery(queryBlob, radius, queryParams);
         sort_results(results, order);
         return results;
@@ -196,7 +196,7 @@ protected:
     }
 
     virtual VecSimQueryResult_List topKQueryWrapper(const void *queryBlob, size_t k,
-                                                    VecSimQueryParams *queryParams) override {
+                                                    VecSimQueryParams *queryParams) const override {
         char processed_blob[this->data_size];
         const void *query_to_send = processBlob(queryBlob, processed_blob);
 
@@ -205,7 +205,7 @@ protected:
 
     virtual VecSimQueryResult_List rangeQueryWrapper(const void *queryBlob, double radius,
                                                      VecSimQueryParams *queryParams,
-                                                     VecSimQueryResult_Order order) override {
+                                                     VecSimQueryResult_Order order) const override {
         char processed_blob[this->data_size];
         const void *query_to_send = processBlob(queryBlob, processed_blob);
 

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -52,10 +52,10 @@ protected:
     size_t blockSize;    // Index's vector block size (determines by how many vectors to resize when
                          // resizing)
     dist_func_t<DistType>
-        dist_func;           // Index's distance function. Chosen by the type, metric and dimension.
+        dist_func; // Index's distance function. Chosen by the type, metric and dimension.
     mutable VecSearchMode last_mode; // The last search mode in RediSearch (used for debug/testing).
-    bool isMulti;            // Determines if the index should multi-index or not.
-    void *logCallbackCtx;    // Context for the log callback.
+    bool isMulti;                    // Determines if the index should multi-index or not.
+    void *logCallbackCtx;            // Context for the log callback.
 
     /**
      * @brief Get the common info object
@@ -134,6 +134,7 @@ public:
         }
     }
 
+    // Adds all common info to the info iterator, besides the block size.
     void addCommonInfoToIterator(VecSimInfoIterator *infoIterator, const CommonInfo &info) const {
         infoIterator->addInfoField(VecSim_InfoField{
             .fieldName = VecSimCommonStrings::TYPE_STRING,
@@ -159,10 +160,6 @@ public:
             VecSim_InfoField{.fieldName = VecSimCommonStrings::INDEX_LABEL_COUNT_STRING,
                              .fieldType = INFOFIELD_UINT64,
                              .fieldValue = {FieldValue{.uintegerValue = info.indexLabelCount}}});
-        infoIterator->addInfoField(
-            VecSim_InfoField{.fieldName = VecSimCommonStrings::BLOCK_SIZE_STRING,
-                             .fieldType = INFOFIELD_UINT64,
-                             .fieldValue = {FieldValue{.uintegerValue = info.blockSize}}});
         infoIterator->addInfoField(
             VecSim_InfoField{.fieldName = VecSimCommonStrings::MEMORY_STRING,
                              .fieldType = INFOFIELD_UINT64,

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -114,7 +114,7 @@ public:
      * blob.
      */
     virtual VecSimQueryResult_List topKQueryWrapper(const void *queryBlob, size_t k,
-                                                    VecSimQueryParams *queryParams) = 0;
+                                                    VecSimQueryParams *queryParams) const = 0;
 
     /**
      * @brief Search for the k closest vectors to a given vector in the index.
@@ -128,7 +128,7 @@ public:
      * VecSimQueryResult_Iterator.
      */
     virtual VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
-                                             VecSimQueryParams *queryParams) = 0;
+                                             VecSimQueryParams *queryParams) const = 0;
 
     /**
      * @brief This Function prepares the blob before sending it to rangeQuery.
@@ -139,7 +139,7 @@ public:
      */
     virtual VecSimQueryResult_List rangeQueryWrapper(const void *queryBlob, double radius,
                                                      VecSimQueryParams *queryParams,
-                                                     VecSimQueryResult_Order order) = 0;
+                                                     VecSimQueryResult_Order order) const = 0;
     /**
      * @brief Search for the vectors that are in a given range in the index with respect to a given
      * vector. The results can be ordered by their score or id.
@@ -155,7 +155,7 @@ public:
      */
     virtual VecSimQueryResult_List rangeQuery(const void *queryBlob, double radius,
                                               VecSimQueryParams *queryParams,
-                                              VecSimQueryResult_Order order) = 0;
+                                              VecSimQueryResult_Order order) const = 0;
 
     /**
      * @brief Return index information.
@@ -203,7 +203,7 @@ public:
      * creating the hybrid iterator), or after running batches.
      */
 
-    virtual bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) = 0;
+    virtual bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const = 0;
 
     /**
      * @brief Set the latest search mode in the index data (for info/debugging).

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -297,7 +297,7 @@ template <typename DataType, typename DistType>
 VecSimInfoIterator *VecSimTieredIndex<DataType, DistType>::infoIterator() const {
     VecSimIndexInfo info = this->info();
     // For readability. Update this number when needed.
-    size_t numberOfInfoFields = 14;
+    size_t numberOfInfoFields = 13;
     VecSimInfoIterator *infoIterator = new VecSimInfoIterator(numberOfInfoFields);
 
     infoIterator->addInfoField(VecSim_InfoField{

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -75,7 +75,11 @@ public:
     }
 
     VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
-                                     VecSimQueryParams *queryParams) override;
+                                     VecSimQueryParams *queryParams) const override;
+
+    VecSimQueryResult_List rangeQuery(const void *queryBlob, double radius,
+                                      VecSimQueryParams *queryParams,
+                                      VecSimQueryResult_Order order) const override;
 
     virtual inline uint64_t getAllocationSize() const override {
         return this->allocator->getAllocationSize() + this->backendIndex->getAllocationSize() +
@@ -85,11 +89,7 @@ public:
     virtual VecSimIndexInfo info() const override;
     virtual VecSimInfoIterator *infoIterator() const override;
 
-    VecSimQueryResult_List rangeQuery(const void *queryBlob, double radius,
-                                      VecSimQueryParams *queryParams,
-                                      VecSimQueryResult_Order order) override;
-
-    bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) override {
+    bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override {
         // For now, decide according to the bigger index.
         return this->backendIndex->indexSize() > this->frontendIndex->indexSize()
                    ? this->backendIndex->preferAdHocSearch(subsetSize, k, initial_check)
@@ -108,7 +108,7 @@ private:
     }
 
     virtual VecSimQueryResult_List topKQueryWrapper(const void *queryBlob, size_t k,
-                                                    VecSimQueryParams *queryParams) override {
+                                                    VecSimQueryParams *queryParams) const override {
         // Will be used only if a processing stage is needed
         char processed_blob[this->backendIndex->getDataSize()];
         const void *query_to_send = this->backendIndex->processBlob(queryBlob, processed_blob);
@@ -117,7 +117,7 @@ private:
 
     virtual VecSimQueryResult_List rangeQueryWrapper(const void *queryBlob, double radius,
                                                      VecSimQueryParams *queryParams,
-                                                     VecSimQueryResult_Order order) override {
+                                                     VecSimQueryResult_Order order) const override {
         // Will be used only if a processing stage is needed
         char processed_blob[this->backendIndex->getDataSize()];
         const void *query_to_send = this->backendIndex->processBlob(queryBlob, processed_blob);
@@ -138,7 +138,7 @@ private:
 template <typename DataType, typename DistType>
 VecSimQueryResult_List
 VecSimTieredIndex<DataType, DistType>::topKQuery(const void *queryBlob, size_t k,
-                                                 VecSimQueryParams *queryParams) {
+                                                 VecSimQueryParams *queryParams) const {
     this->flatIndexGuard.lock_shared();
 
     // If the flat buffer is empty, we can simply query the main index.
@@ -187,7 +187,77 @@ VecSimTieredIndex<DataType, DistType>::topKQuery(const void *queryBlob, size_t k
 }
 
 template <typename DataType, typename DistType>
+VecSimQueryResult_List
+VecSimTieredIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double radius,
+                                                  VecSimQueryParams *queryParams,
+                                                  VecSimQueryResult_Order order) const {
+    this->flatIndexGuard.lock_shared();
 
+    // If the flat buffer is empty, we can simply query the main index.
+    if (this->frontendIndex->indexSize() == 0) {
+        // Release the flat lock and acquire the main lock.
+        this->flatIndexGuard.unlock_shared();
+
+        // Simply query the main index and return the results while holding the lock.
+        this->mainIndexGuard.lock_shared();
+        auto res = this->backendIndex->rangeQuery(queryBlob, radius, queryParams);
+        this->mainIndexGuard.unlock_shared();
+
+        // We could have passed the order to the main index, but we can sort them here after
+        // unlocking it instead.
+        sort_results(res, order);
+        return res;
+    } else {
+        // No luck... first query the flat buffer and release the lock.
+        auto flat_results = this->frontendIndex->rangeQuery(queryBlob, radius, queryParams);
+        this->flatIndexGuard.unlock_shared();
+
+        // If the query failed (currently only on timeout), return the error code and the partial
+        // results.
+        if (flat_results.code != VecSim_QueryResult_OK) {
+            return flat_results;
+        }
+
+        // Lock the main index and query it.
+        this->mainIndexGuard.lock_shared();
+        auto main_results = this->backendIndex->rangeQuery(queryBlob, radius, queryParams);
+        this->mainIndexGuard.unlock_shared();
+
+        // Merge the results and return, avoiding duplicates.
+        // At this point, the return code of the FLAT index is OK, and the return code of the MAIN
+        // index is either OK or TIMEOUT. Make sure to return the return code of the MAIN index.
+        if (BY_SCORE == order) {
+            sort_results_by_score_then_id(main_results);
+            sort_results_by_score_then_id(flat_results);
+
+            // Keep the return code of the main index.
+            auto code = main_results.code;
+
+            // Merge the sorted results with no limit (all the results are valid).
+            VecSimQueryResult_List ret;
+            if (this->backendIndex->isMultiValue()) {
+                ret = merge_result_lists<true>(main_results, flat_results, -1);
+            } else {
+                ret = merge_result_lists<false>(main_results, flat_results, -1);
+            }
+            // Restore the return code and return.
+            ret.code = code;
+            return ret;
+
+        } else { // BY_ID
+            // Notice that we don't modify the return code of the main index in any step.
+            concat_results(main_results, flat_results);
+            if (this->backendIndex->isMultiValue()) {
+                filter_results_by_id<true>(main_results);
+            } else {
+                filter_results_by_id<false>(main_results);
+            }
+            return main_results;
+        }
+    }
+}
+
+template <typename DataType, typename DistType>
 VecSimIndexInfo VecSimTieredIndex<DataType, DistType>::info() const {
     VecSimIndexInfo info;
     VecSimIndexInfo backendInfo = this->backendIndex->info();
@@ -259,74 +329,3 @@ VecSimInfoIterator *VecSimTieredIndex<DataType, DistType>::infoIterator() const 
 
     return infoIterator;
 };
-
-template <typename DataType, typename DistType>
-VecSimQueryResult_List
-VecSimTieredIndex<DataType, DistType>::rangeQuery(const void *queryBlob, double radius,
-                                                  VecSimQueryParams *queryParams,
-                                                  VecSimQueryResult_Order order) {
-    this->flatIndexGuard.lock_shared();
-
-    // If the flat buffer is empty, we can simply query the main index.
-    if (this->frontendIndex->indexSize() == 0) {
-        // Release the flat lock and acquire the main lock.
-        this->flatIndexGuard.unlock_shared();
-
-        // Simply query the main index and return the results while holding the lock.
-        this->mainIndexGuard.lock_shared();
-        auto res = this->backendIndex->rangeQuery(queryBlob, radius, queryParams);
-        this->mainIndexGuard.unlock_shared();
-
-        // We could have passed the order to the main index, but we can sort them here after
-        // unlocking it instead.
-        sort_results(res, order);
-        return res;
-    } else {
-        // No luck... first query the flat buffer and release the lock.
-        auto flat_results = this->frontendIndex->rangeQuery(queryBlob, radius, queryParams);
-        this->flatIndexGuard.unlock_shared();
-
-        // If the query failed (currently only on timeout), return the error code and the partial
-        // results.
-        if (flat_results.code != VecSim_QueryResult_OK) {
-            return flat_results;
-        }
-
-        // Lock the main index and query it.
-        this->mainIndexGuard.lock_shared();
-        auto main_results = this->backendIndex->rangeQuery(queryBlob, radius, queryParams);
-        this->mainIndexGuard.unlock_shared();
-
-        // Merge the results and return, avoiding duplicates.
-        // At this point, the return code of the FLAT index is OK, and the return code of the MAIN
-        // index is either OK or TIMEOUT. Make sure to return the return code of the MAIN index.
-        if (BY_SCORE == order) {
-            sort_results_by_score_then_id(main_results);
-            sort_results_by_score_then_id(flat_results);
-
-            // Keep the return code of the main index.
-            auto code = main_results.code;
-
-            // Merge the sorted results with no limit (all the results are valid).
-            VecSimQueryResult_List ret;
-            if (this->backendIndex->isMultiValue()) {
-                ret = merge_result_lists<true>(main_results, flat_results, -1);
-            } else {
-                ret = merge_result_lists<false>(main_results, flat_results, -1);
-            }
-            // Restore the return code and return.
-            ret.code = code;
-            return ret;
-
-        } else { // BY_ID
-            // Notice that we don't modify the return code of the main index in any step.
-            concat_results(main_results, flat_results);
-            if (this->backendIndex->isMultiValue()) {
-                filter_results_by_id<true>(main_results);
-            } else {
-                filter_results_by_id<false>(main_results);
-            }
-            return main_results;
-        }
-    }
-}

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -77,7 +77,7 @@ public:
     VecSimQueryResult_List topKQuery(const void *queryBlob, size_t k,
                                      VecSimQueryParams *queryParams) override;
 
-    virtual inline int64_t getAllocationSize() const override {
+    virtual inline uint64_t getAllocationSize() const override {
         return this->allocator->getAllocationSize() + this->backendIndex->getAllocationSize() +
                this->frontendIndex->getAllocationSize();
     }

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -20,7 +20,10 @@ struct AsyncJob : public VecsimBaseObject {
         : VecsimBaseObject(allocator), jobType(type), Execute(callback), index(index_ref) {}
 };
 
-static void AsyncJobDestructor(AsyncJob *job) { delete job; }
+static void AsyncJobDestructor(AsyncJob *job) {
+    auto allocator = job->getAllocator();
+    delete job;
+}
 
 // All read operations (including KNN, range, batch iterators and get-distance-from) are guaranteed
 // to consider all vectors that were added to the index before the query was submitted. The results

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -21,6 +21,7 @@ struct AsyncJob : public VecsimBaseObject {
 };
 
 static void AsyncJobDestructor(AsyncJob *job) {
+    // Holding the allocator so it will not deallocate itself before the job is destroyed.
     auto allocator = job->getAllocator();
     delete job;
 }

--- a/tests/benchmark/bm_vecsim_basics.h
+++ b/tests/benchmark/bm_vecsim_basics.h
@@ -52,29 +52,29 @@ void BM_VecSimBasics<index_type_t>::AddLabel(benchmark::State &st) {
         added_vec_count += vec_per_label;
         label++;
     }
-    memory_delta = INDICES[st.range(0)]->getAllocationSize() - memory_delta;
+    memory_delta = index->getAllocationSize() - memory_delta;
 
     st.counters["memory_per_vector"] = (double)memory_delta / (double)added_vec_count;
     st.counters["vectors_per_label"] = vec_per_label;
 
-    assert(VecSimIndex_IndexSize(INDICES[st.range(0)]) == N_VECTORS + added_vec_count);
+    assert(VecSimIndex_IndexSize(index) == N_VECTORS + added_vec_count);
 
     // Clean-up all the new vectors to restore the index size to its original value.
     // Note we loop over the new labels and not the internal ids. This way in multi indices BM all
     // the new vectors added under the same label will be removed in one call.
-    size_t new_label_count = (INDICES[st.range(0)])->indexLabelCount();
+    size_t new_label_count = index->indexLabelCount();
     for (size_t label = initial_label_count; label < new_label_count; label++) {
-        VecSimIndex_DeleteVector(INDICES[st.range(0)], label);
+        VecSimIndex_DeleteVector(index, label);
     }
 
-    assert(VecSimIndex_IndexSize(INDICES[st.range(0)]) == N_VECTORS);
+    assert(VecSimIndex_IndexSize(index) == N_VECTORS);
 }
 template <typename index_type_t>
 template <typename algo_t>
 void BM_VecSimBasics<index_type_t>::DeleteLabel(algo_t *index, benchmark::State &st) {
     // Remove a different vector in every execution.
     size_t label_to_remove = 0;
-    double memory_delta = 0;
+    double memory_delta, memory_before = index->getAllocationSize();
     size_t removed_vectors_count = 0;
     std::vector<LabelData> removed_labels_data;
 
@@ -90,9 +90,9 @@ void BM_VecSimBasics<index_type_t>::DeleteLabel(algo_t *index, benchmark::State 
         st.ResumeTiming();
 
         // Delete label
-        auto delta = (double)VecSimIndex_DeleteVector(index, label_to_remove++);
-        memory_delta += delta;
+        VecSimIndex_DeleteVector(index, label_to_remove++);
     }
+    memory_delta = index->getAllocationSize() - memory_before;
 
     // Avg. memory delta per vector equals the total memory delta divided by the number
     // of deleted vectors.

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -106,9 +106,9 @@ TYPED_TEST(IndexAllocatorTest, test_bf_index_block_size_1) {
     VecSimIndexInfo info = bfIndex->info();
     ASSERT_EQ(allocator->getAllocationSize(), info.commonInfo.memory);
 
-    int addCommandAllocationDelta = -allocator->getAllocationSize();
+    int before = allocator->getAllocationSize();
     VecSimIndex_AddVector(bfIndex, vec, 1);
-    addCommandAllocationDelta += allocator->getAllocationSize();
+    int addCommandAllocationDelta = allocator->getAllocationSize() - before;
     int64_t expectedAllocationDelta = 0;
     expectedAllocationDelta +=
         sizeof(labelType) + vecsimAllocationOverhead; // resize idToLabelMapping
@@ -131,9 +131,9 @@ TYPED_TEST(IndexAllocatorTest, test_bf_index_block_size_1) {
     expectedAllocationSize = info.commonInfo.memory;
     expectedAllocationDelta = 0;
 
-    addCommandAllocationDelta = -allocator->getAllocationSize();
+    before = allocator->getAllocationSize();
     VecSimIndex_AddVector(bfIndex, vec, 2);
-    addCommandAllocationDelta += allocator->getAllocationSize();
+    addCommandAllocationDelta = allocator->getAllocationSize() - before;
     expectedAllocationDelta += sizeof(VectorBlock) + vecsimAllocationOverhead; // New vector block
     expectedAllocationDelta += sizeof(labelType); // resize idToLabelMapping
     expectedAllocationDelta +=
@@ -154,9 +154,9 @@ TYPED_TEST(IndexAllocatorTest, test_bf_index_block_size_1) {
     expectedAllocationSize = info.commonInfo.memory;
     expectedAllocationDelta = 0;
 
-    int deleteCommandAllocationDelta = -allocator->getAllocationSize();
+    before = allocator->getAllocationSize();
     VecSimIndex_DeleteVector(bfIndex, 2);
-    deleteCommandAllocationDelta += allocator->getAllocationSize();
+    int deleteCommandAllocationDelta = allocator->getAllocationSize() - before;
     expectedAllocationDelta -=
         (sizeof(VectorBlock) + vecsimAllocationOverhead); // Free the vector block
     expectedAllocationDelta -=
@@ -180,9 +180,9 @@ TYPED_TEST(IndexAllocatorTest, test_bf_index_block_size_1) {
     expectedAllocationSize = info.commonInfo.memory;
     expectedAllocationDelta = 0;
 
-    deleteCommandAllocationDelta = -allocator->getAllocationSize();
+    before = allocator->getAllocationSize();
     VecSimIndex_DeleteVector(bfIndex, 1);
-    deleteCommandAllocationDelta += allocator->getAllocationSize();
+    deleteCommandAllocationDelta = allocator->getAllocationSize() - before;
     expectedAllocationDelta -=
         (sizeof(VectorBlock) + vecsimAllocationOverhead); // Free the vector block
     expectedAllocationDelta -=
@@ -227,17 +227,17 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw) {
     ASSERT_EQ(allocator->getAllocationSize(), info.commonInfo.memory);
     expectedAllocationSize = info.commonInfo.memory;
 
-    int addCommandAllocationDelta = -allocator->getAllocationSize();
+    int before = allocator->getAllocationSize();
     VecSimIndex_AddVector(hnswIndex, vec, 1);
-    addCommandAllocationDelta += allocator->getAllocationSize();
+    int addCommandAllocationDelta = allocator->getAllocationSize() - before;
     ASSERT_EQ(allocator->getAllocationSize(), expectedAllocationSize + addCommandAllocationDelta);
     info = hnswIndex->info();
     ASSERT_EQ(allocator->getAllocationSize(), info.commonInfo.memory);
     expectedAllocationSize = info.commonInfo.memory;
 
-    addCommandAllocationDelta = -allocator->getAllocationSize();
+    before = allocator->getAllocationSize();
     VecSimIndex_AddVector(hnswIndex, vec, 2);
-    addCommandAllocationDelta += allocator->getAllocationSize();
+    addCommandAllocationDelta = allocator->getAllocationSize() - before;
 
     ASSERT_EQ(allocator->getAllocationSize(), expectedAllocationSize + addCommandAllocationDelta);
     info = hnswIndex->info();
@@ -245,9 +245,9 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw) {
 
     expectedAllocationSize = info.commonInfo.memory;
 
-    int deleteCommandAllocationDelta = -allocator->getAllocationSize();
+    before = allocator->getAllocationSize();
     VecSimIndex_DeleteVector(hnswIndex, 2);
-    deleteCommandAllocationDelta += allocator->getAllocationSize();
+    int deleteCommandAllocationDelta = allocator->getAllocationSize() - before;
 
     ASSERT_EQ(expectedAllocationSize + deleteCommandAllocationDelta,
               allocator->getAllocationSize());
@@ -255,9 +255,9 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw) {
     ASSERT_EQ(allocator->getAllocationSize(), info.commonInfo.memory);
     expectedAllocationSize = info.commonInfo.memory;
 
-    deleteCommandAllocationDelta = -allocator->getAllocationSize();
+    before = allocator->getAllocationSize();
     VecSimIndex_DeleteVector(hnswIndex, 1);
-    deleteCommandAllocationDelta += allocator->getAllocationSize();
+    deleteCommandAllocationDelta = allocator->getAllocationSize() - before;
 
     ASSERT_EQ(expectedAllocationSize + deleteCommandAllocationDelta,
               allocator->getAllocationSize());
@@ -285,9 +285,9 @@ TYPED_TEST(IndexAllocatorTest, testIncomingEdgesSet) {
 
     // Add another vector and validate it's exact memory allocation delta.
     TEST_DATA_T vec1[] = {1.0, 0.0};
-    int allocation_delta = -allocator->getAllocationSize();
+    int before = allocator->getAllocationSize();
     VecSimIndex_AddVector(hnswIndex, vec1, 1);
-    allocation_delta += allocator->getAllocationSize();
+    int allocation_delta = allocator->getAllocationSize() - before;
     size_t vec_max_level = hnswIndex->element_levels_[1];
 
     // Expect the creation of an empty incoming edges set in every level (+ the allocator header
@@ -322,9 +322,9 @@ TYPED_TEST(IndexAllocatorTest, testIncomingEdgesSet) {
     // set.
     TEST_DATA_T vec5[] = {0.5f, 0.0f};
     size_t buckets_num_before = hnswIndex->label_lookup_.bucket_count();
-    allocation_delta = -allocator->getAllocationSize();
+    before = allocator->getAllocationSize();
     VecSimIndex_AddVector(hnswIndex, vec5, 5);
-    allocation_delta += allocator->getAllocationSize();
+    allocation_delta = allocator->getAllocationSize() - before;
     vec_max_level = hnswIndex->element_levels_[5];
 
     /* Compute the expected allocation delta:

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -1383,7 +1383,8 @@ TYPED_TEST(BruteForceTest, testSizeEstimation) {
 
     estimation = EstimateElementSize(params) * bs;
 
-    actual = GenerateAndAddVector<TEST_DATA_T>(index, dim, 0);
+    GenerateAndAddVector<TEST_DATA_T>(index, dim, 0);
+    actual = index->getAllocationSize() - actual; // get the delta
     ASSERT_GE(estimation * 1.01, actual);
     ASSERT_LE(estimation * 0.99, actual);
 

--- a/tests/unit/test_bruteforce_multi.cpp
+++ b/tests/unit/test_bruteforce_multi.cpp
@@ -1126,7 +1126,8 @@ TYPED_TEST(BruteForceMultiTest, testSizeEstimation) {
     ASSERT_EQ(estimation, actual);
 
     estimation = EstimateElementSize(params) * bs;
-    actual = GenerateAndAddVector<TEST_DATA_T>(index, dim, 0);
+    GenerateAndAddVector<TEST_DATA_T>(index, dim, 0);
+    actual = index->getAllocationSize() - actual; // get the delta
 
     ASSERT_GE(estimation * 1.01, actual);
     ASSERT_LE(estimation * 0.99, actual);

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -1594,10 +1594,11 @@ TYPED_TEST(HNSWTest, testSizeEstimation) {
     // Note we are adding vectors with ascending values. This causes the number of
     // unidirectional edges (incoming edges),
     // which are not taken into account in EstimateElementSize, to be zero
-    actual = 0;
+    actual = index->getAllocationSize();
     for (size_t i = 0; i < bs; i++) {
-        actual += GenerateAndAddVector<TEST_DATA_T>(index, dim, bs + i, i + bs);
+        GenerateAndAddVector<TEST_DATA_T>(index, dim, bs + i, bs + i);
     }
+    actual = index->getAllocationSize() - actual;
     ASSERT_GE(estimation * 1.02, actual);
     ASSERT_LE(estimation * 0.98, actual);
 

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -888,10 +888,11 @@ TYPED_TEST(HNSWMultiTest, testSizeEstimation) {
     // Note we are adding vectors with ascending values. This causes the numbers of
     // double connections, which are not taking into account in EstimateElementSize,
     // to be zero
-    actual = 0;
+    actual = index->getAllocationSize();
     for (size_t i = 0; i < bs; i++) {
-        actual += GenerateAndAddVector<TEST_DATA_T>(index, dim, bs + i, bs + i);
+        GenerateAndAddVector<TEST_DATA_T>(index, dim, bs + i, bs + i);
     }
+    actual = index->getAllocationSize() - actual;
     ASSERT_GE(estimation * 1.02, actual);
     ASSERT_LE(estimation * 0.98, actual);
 

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -960,7 +960,7 @@ TYPED_TEST(HNSWTieredIndexTestBasic, deleteFromHNSWMulti) {
 
     auto jobQ = JobQueue();
     auto index_ctx = new IndexExtCtx();
-    auto unhandledJobs = std::vector<AsyncJob *>(3);
+    auto unhandledJobs = std::vector<AsyncJob *>();
 
     auto *tiered_index = this->CreateTieredHNSWIndex(hnsw_params, &jobQ, index_ctx);
     auto allocator = tiered_index->getAllocator();

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -960,6 +960,9 @@ TYPED_TEST(HNSWTieredIndexTestBasic, deleteFromHNSWMulti) {
 
     auto jobQ = JobQueue();
     auto index_ctx = new IndexExtCtx();
+    // In this test we check the created jobs in the queue, and we want to go over them without
+    // executing or deleting them. We therefore pop them into this vector and manually delete them
+    // at the end.
     auto unhandledJobs = std::vector<AsyncJob *>();
 
     auto *tiered_index = this->CreateTieredHNSWIndex(hnsw_params, &jobQ, index_ctx);

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -2862,7 +2862,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
     VecSimIndexInfo backendIndexInfo = tiered_index->backendIndex->info();
 
     VecSimInfoIterator *infoIterator = tiered_index->infoIterator();
-    EXPECT_EQ(infoIterator->numberOfFields(), 14);
+    EXPECT_EQ(infoIterator->numberOfFields(), 13);
 
     while (infoIterator->hasNext()) {
         VecSim_InfoField *infoField = VecSimInfoIterator_NextField(infoIterator);
@@ -2902,10 +2902,6 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
             // Is the index multi value.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
             ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.isMulti);
-        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::BLOCK_SIZE_STRING)) {
-            // Block size.
-            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
-            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.blockSize);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::MEMORY_STRING)) {
             // Memory.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -311,8 +311,8 @@ std::mutex tiered_index_mock::queue_guard;
 std::condition_variable tiered_index_mock::queue_cond;
 std::vector<std::thread> tiered_index_mock::thread_pool;
 
-int tiered_index_mock::submit_callback(void *job_queue, AsyncJob **jobs, size_t len,
-                                       void *index_ctx) {
+int tiered_index_mock::submit_callback(void *job_queue, void *index_ctx, AsyncJob **jobs,
+                                       JobCallback *CBs, JobCallback *freeCBs, size_t len) {
     {
         std::unique_lock<std::mutex> lock(queue_guard);
         for (size_t i = 0; i < len; i++) {
@@ -354,6 +354,8 @@ void tiered_index_mock::thread_main_loop(JobQueue &jobQ, bool &run_thread) {
         if (auto temp_ref = managed_job.index_weak_ref.lock()) {
             managed_job.job->Execute(managed_job.job);
         }
+        // Free the job.
+        AsyncJobDestructor(managed_job.job);
     }
 }
 

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -331,17 +331,13 @@ int tiered_index_mock::submit_callback(void *job_queue, void *index_ctx, AsyncJo
     return VecSim_OK;
 }
 
-int tiered_index_mock::update_mem_callback(void *mem_ctx, size_t mem) {
-    *(size_t *)mem_ctx = mem;
-    return VecSim_OK;
-}
-
 // A single iteration of the thread main loop.
 void tiered_index_mock::thread_iteration(JobQueue &jobQ, bool *run_thread) {
     std::unique_lock<std::mutex> lock(queue_guard);
     // Wake up and acquire the lock (atomically) ONLY if the job queue is not empty at that
     // point, or if the thread should not run anymore (and quit in that case).
-    queue_cond.wait(lock, [&jobQ, &run_thread]() { return !jobQ.empty() || (run_thread && !*run_thread); });
+    queue_cond.wait(
+        lock, [&jobQ, &run_thread]() { return !jobQ.empty() || (run_thread && !*run_thread); });
     if (run_thread && !*run_thread)
         return;
     auto managed_job = jobQ.front();

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -331,7 +331,7 @@ int tiered_index_mock::submit_callback(void *job_queue, void *index_ctx, AsyncJo
     return VecSim_OK;
 }
 
-// A single iteration of the thread main loop.
+// If `run_thread` is null, treat it as `true`.
 void tiered_index_mock::thread_iteration(JobQueue &jobQ, bool *run_thread) {
     std::unique_lock<std::mutex> lock(queue_guard);
     // Wake up and acquire the lock (atomically) ONLY if the job queue is not empty at that

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -181,7 +181,6 @@ struct SearchJobMock : public AsyncJob {
 using JobQueue = std::queue<RefManagedJob>;
 int submit_callback(void *job_queue, void *index_ctx, AsyncJob **jobs, JobCallback *CBs,
                     JobCallback *freeCBs, size_t jobs_len);
-int update_mem_callback(void *mem_ctx, size_t mem);
 
 typedef struct IndexExtCtx {
     std::shared_ptr<VecSimIndex> index_strong_ref;

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -179,7 +179,8 @@ struct SearchJobMock : public AsyncJob {
 };
 
 using JobQueue = std::queue<RefManagedJob>;
-int submit_callback(void *job_queue, AsyncJob **jobs, size_t len, void *index_ctx);
+int submit_callback(void *job_queue, void *index_ctx, AsyncJob **jobs, JobCallback *CBs,
+                    JobCallback *freeCBs, size_t jobs_len);
 int update_mem_callback(void *mem_ctx, size_t mem);
 
 typedef struct IndexExtCtx {

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -202,6 +202,7 @@ extern std::vector<std::thread> thread_pool;
 extern std::mutex queue_guard;
 extern std::condition_variable queue_cond;
 
+// A single iteration of the thread main loop.
 void thread_iteration(JobQueue &jobQ, bool *run_thread = nullptr);
 void thread_main_loop(JobQueue &jobQ, bool &run_thread);
 

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -178,7 +178,18 @@ struct SearchJobMock : public AsyncJob {
     ~SearchJobMock() { this->allocator->free_allocation(query); }
 };
 
-using JobQueue = std::queue<RefManagedJob>;
+struct JobQueue : public std::queue<RefManagedJob> {
+    // Pops and destroys the job at the front of the queue.
+    inline void kick() {
+        AsyncJobDestructor(this->front().job);
+        this->pop();
+    }
+    ~JobQueue() {
+        while (!this->empty()) {
+            this->kick();
+        }
+    }
+};
 int submit_callback(void *job_queue, void *index_ctx, AsyncJob **jobs, JobCallback *CBs,
                     JobCallback *freeCBs, size_t jobs_len);
 

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -192,6 +192,7 @@ extern std::vector<std::thread> thread_pool;
 extern std::mutex queue_guard;
 extern std::condition_variable queue_cond;
 
+void thread_iteration(JobQueue &jobQ, bool *run_thread = nullptr);
 void thread_main_loop(JobQueue &jobQ, bool &run_thread);
 
 void thread_pool_join(JobQueue &jobQ, bool &run_thread);


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR refreshes the API functions needed for getting an external job queue submit function and removes the expected "update memory" function and context.
It also changes the `VecSimIndex_AddVector` and `VecSimIndex_DeleteVector`'s API so they return the number of vectors added/deleted (like the C++ API does), instead of the memory delta. the memory consumption should be retrieved using the info function (TBD in another PR).

This PR also moved the ownership of a job to the job queue once it is submitted. This way it's the user's external queue's responsibility to handle leftover jobs after the index itself was deleted. This change is also present in the job queue mock.

Finally, some additional functionality was added to the test utils, such as `.kick()` for the job queue mock (pop and destroy), and `thread_iteration` for executing a single iteration of a job queue's thread directly.

**Main objects this PR modified**
1. changed the `submitJobs` signature
2. removed `updateMemory` and its context from the repo
3. Add/Delete API

**Mark if applicable**

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes
