### PR TITLE
optimize swap jobs handling

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -543,15 +543,6 @@ TieredHNSWIndex<DataType, DistType>::TieredHNSWIndex(HNSWIndex<DataType, DistTyp
             ? DEFAULT_PENDING_SWAP_JOBS_THRESHOLD
             : std::min(tiered_index_params.specificParams.tieredHnswParams.swapJobThreshold,
                        MAX_PENDING_SWAP_JOBS_THRESHOLD);
-
-    // Set HNSW r/w lock to prefer writers, to avoid starvation that may occur upon acquiring
-    // the lock exclusively (for periodically resize / applying swap jobs clean up).
-    pthread_rwlock_t rwlock_prefer_writers_main;
-    pthread_rwlockattr_t attr_main;
-    pthread_rwlockattr_setkind_np(&attr_main, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
-    pthread_rwlock_init(&rwlock_prefer_writers_main, &attr_main);
-    auto *handle_main = (pthread_rwlock_t *)this->mainIndexGuard.native_handle();
-    *handle_main = rwlock_prefer_writers_main;
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -29,9 +29,10 @@ struct HNSWSwapJob : public VecsimBaseObject {
     HNSWSwapJob(std::shared_ptr<VecSimAllocator> allocator, idType deletedId)
         : VecsimBaseObject(allocator), deleted_id(deletedId), pending_repair_jobs_counter(0) {}
     void setRepairJobsNum(long num_repair_jobs) { pending_repair_jobs_counter = num_repair_jobs; }
-    void atomicDecreasePendingJobsNum() {
-        pending_repair_jobs_counter--;
+    int atomicDecreasePendingJobsNum() {
+        int ret = --pending_repair_jobs_counter;
         assert(pending_repair_jobs_counter >= 0);
+        return ret;
     }
 };
 
@@ -74,6 +75,7 @@ private:
     // vectors reached this limit, we apply swap jobs *only for vectors that has no more pending
     // repair jobs*, and are ready to be removed from the graph.
     size_t pendingSwapJobsThreshold;
+    size_t readySwapJobs;
 
     // Protect the both idToRepairJobs lookup and the pending_repair_jobs_counter for the
     // associated swap jobs.
@@ -224,7 +226,9 @@ void TieredHNSWIndex<DataType, DistType>::executeSwapJob(HNSWSwapJob *job,
         for (auto &job_it : idToRepairJobs.at(job->deleted_id)) {
             job_it->node_id = INVALID_JOB_ID;
             for (auto &swap_job_it : job_it->associatedSwapJobs) {
-                swap_job_it->atomicDecreasePendingJobsNum();
+                if (swap_job_it->atomicDecreasePendingJobsNum() == 0) {
+                    readySwapJobs++;
+                }
             }
         }
         idToRepairJobs.erase(job->deleted_id);
@@ -260,7 +264,7 @@ template <typename DataType, typename DistType>
 void TieredHNSWIndex<DataType, DistType>::executeReadySwapJobs() {
     // If swapJobs size is equal or larger than a threshold, go over the swap jobs and execute every
     // job for which all of its pending repair jobs were executed (otherwise finish and return).
-    if (idToSwapJob.size() < this->pendingSwapJobsThreshold) {
+    if (readySwapJobs < this->pendingSwapJobsThreshold) {
         return;
     }
     // Execute swap jobs - acquire hnsw write lock.
@@ -279,6 +283,7 @@ void TieredHNSWIndex<DataType, DistType>::executeReadySwapJobs() {
     for (idType id : idsToRemove) {
         idToSwapJob.erase(id);
     }
+    readySwapJobs -= idsToRemove.size();
     this->mainIndexGuard.unlock();
 }
 
@@ -331,6 +336,10 @@ int TieredHNSWIndex<DataType, DistType>::deleteLabelFromHNSW(labelType label) {
             }
         }
         swap_job->setRepairJobsNum(incoming_edges.size());
+        if (incoming_edges.size() == 0) {
+            // No pending repair jobs, so swap jobs is ready from the beginning.
+            readySwapJobs++;
+        }
         this->idToRepairJobsGuard.unlock();
 
         this->submitJobs(repair_jobs);
@@ -506,7 +515,9 @@ void TieredHNSWIndex<DataType, DistType>::executeRepairJob(HNSWRepairJob *job) {
         repair_jobs.pop_back();
     }
     for (auto &it : job->associatedSwapJobs) {
-        it->atomicDecreasePendingJobsNum();
+        if (it->atomicDecreasePendingJobsNum() == 0) {
+            readySwapJobs++;
+        }
     }
     this->idToRepairJobsGuard.unlock();
 
@@ -524,7 +535,7 @@ TieredHNSWIndex<DataType, DistType>::TieredHNSWIndex(HNSWIndex<DataType, DistTyp
                                                      std::shared_ptr<VecSimAllocator> allocator)
     : VecSimTieredIndex<DataType, DistType>(hnsw_index, bf_index, tiered_index_params, allocator),
       labelToInsertJobs(this->allocator), idToRepairJobs(this->allocator),
-      idToSwapJob(this->allocator) {
+      idToSwapJob(this->allocator), readySwapJobs(0) {
     // If the param for swapJobThreshold is 0 use the default value, if it exceeds the maximum
     // allowed, use the maximum value.
     this->pendingSwapJobsThreshold =
@@ -532,6 +543,15 @@ TieredHNSWIndex<DataType, DistType>::TieredHNSWIndex(HNSWIndex<DataType, DistTyp
             ? DEFAULT_PENDING_SWAP_JOBS_THRESHOLD
             : std::min(tiered_index_params.specificParams.tieredHnswParams.swapJobThreshold,
                        MAX_PENDING_SWAP_JOBS_THRESHOLD);
+
+    // Set HNSW r/w lock to prefer writers, to avoid starvation that may occur upon acquiring
+    // the lock exclusively (for periodically resize / applying swap jobs clean up).
+    pthread_rwlock_t rwlock_prefer_writers_main;
+    pthread_rwlockattr_t attr_main;
+    pthread_rwlockattr_setkind_np(&attr_main, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+    pthread_rwlock_init(&rwlock_prefer_writers_main, &attr_main);
+    auto *handle_main = (pthread_rwlock_t *)this->mainIndexGuard.native_handle();
+    *handle_main = rwlock_prefer_writers_main;
 }
 
 template <typename DataType, typename DistType>


### PR DESCRIPTION
**Describe the changes in the pull request**

Minor change for optimizing swap jobs execution: hold a `readySwapJobs` counter, and try to acquire HNSW lock for write ONLY IF IT REACHES THE THRESHOLD, rather than when the number of existing swap jobs reaches the threshold. Hence, we save contention over the lock in case there are many swap jobs, but many of them are not ready yet (due to associated repair jobs that haven't finished yet)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
