### PR TITLE
disable fp64 index unit tests by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ make clean         # remove binary files
 make unit_test     # run unit tests
   CTEST_ARGS=args    # extra CTest arguments
   VG|VALGRIND=1      # run tests with valgrind
+  FP_64=1			# run tests with 64-bit floating point
 make valgrind      # build for Valgrind and run tests
 make flow_test     # run flow tests (with pytest)
   TEST=file::name    # run specific test
@@ -122,6 +123,11 @@ endif
 
 ifeq ($(VERBOSE),1)
 CMAKE_FLAGS += -DCMAKE_VERBOSE_MAKEFILE=on
+endif
+
+# CMake flags for fp64 unit tests
+ifeq ($(FP_64),1)
+CMAKE_FLAGS += -DFP64_TESTS=on
 endif
 
 CMAKE_FLAGS += \

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -21,6 +21,12 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${LLVM_LD_FLAGS}")
 
 enable_testing()
 
+option(FP64_TESTS "Build fp 64 tests" OFF)
+
+if(FP64_TESTS)
+	add_definitions(-DFP64_TESTS)
+endif()
+
 add_executable(test_hnsw test_hnsw.cpp test_hnsw_multi.cpp test_hnsw_tiered.cpp test_utils.cpp)
 add_executable(test_bruteforce test_bruteforce.cpp test_bruteforce_multi.cpp test_utils.cpp)
 add_executable(test_allocator test_allocator.cpp test_utils.cpp)

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -25,12 +25,12 @@ struct IndexType {
 #define TEST_DATA_T typename TypeParam::data_t
 #define TEST_DIST_T typename TypeParam::dist_t
 
-using DataTypeSet =
-    ::testing::Types<IndexType<VecSimType_FLOAT32, float>
+using DataTypeSet = ::testing::Types<IndexType<VecSimType_FLOAT32, float>
 #ifdef FP64_TESTS
-    , IndexType<VecSimType_FLOAT64, double>
+                                     ,
+                                     IndexType<VecSimType_FLOAT64, double>
 #endif
-    >;
+                                     >;
 
 template <typename data_t>
 static void GenerateVector(data_t *output, size_t dim, data_t value = 1.0) {

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -26,7 +26,11 @@ struct IndexType {
 #define TEST_DIST_T typename TypeParam::dist_t
 
 using DataTypeSet =
-    ::testing::Types<IndexType<VecSimType_FLOAT32, float>, IndexType<VecSimType_FLOAT64, double>>;
+    ::testing::Types<IndexType<VecSimType_FLOAT32, float>
+#ifdef FP64_TESTS
+    , IndexType<VecSimType_FLOAT64, double>
+#endif
+    >;
 
 template <typename data_t>
 static void GenerateVector(data_t *output, size_t dim, data_t value = 1.0) {


### PR DESCRIPTION

**Describe the changes in the pull request**

This PR disables FP64 unit tests for indexing algorithms, but keeps distance metric tests.
To trigger the full tests we can call `make unit_test FP_64=1`.
This is done due to long running valgrind tests

