### PR TITLE
Add static info API

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -50,6 +50,7 @@ public:
                                               VecSimQueryParams *queryParams) const override;
     virtual VecSimIndexInfo info() const override;
     virtual VecSimInfoIterator *infoIterator() const override;
+    VecSimIndexStaticInfo staticInfo() const override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob,
                                                   VecSimQueryParams *queryParams) const override;
     bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override;
@@ -344,8 +345,17 @@ template <typename DataType, typename DistType>
 VecSimIndexInfo BruteForceIndex<DataType, DistType>::info() const {
 
     VecSimIndexInfo info;
-    info.algo = VecSimAlgo_BF;
     info.commonInfo = this->getCommonInfo();
+    info.commonInfo.basicInfo.algo = VecSimAlgo_BF;
+
+    return info;
+}
+
+template <typename DataType, typename DistType>
+VecSimIndexStaticInfo BruteForceIndex<DataType, DistType>::staticInfo() const {
+
+    VecSimIndexStaticInfo info = this->getStaticInfo();
+    info.algo = VecSimAlgo_BF;
     return info;
 }
 
@@ -356,15 +366,16 @@ VecSimInfoIterator *BruteForceIndex<DataType, DistType>::infoIterator() const {
     size_t numberOfInfoFields = 10;
     VecSimInfoIterator *infoIterator = new VecSimInfoIterator(numberOfInfoFields);
 
-    infoIterator->addInfoField(VecSim_InfoField{
-        .fieldName = VecSimCommonStrings::ALGORITHM_STRING,
-        .fieldType = INFOFIELD_STRING,
-        .fieldValue = {FieldValue{.stringValue = VecSimAlgo_ToString(info.algo)}}});
-    this->addCommonInfoToIterator(infoIterator, info.commonInfo);
     infoIterator->addInfoField(
-        VecSim_InfoField{.fieldName = VecSimCommonStrings::BLOCK_SIZE_STRING,
-                         .fieldType = INFOFIELD_UINT64,
-                         .fieldValue = {FieldValue{.uintegerValue = info.commonInfo.blockSize}}});
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::ALGORITHM_STRING,
+                         .fieldType = INFOFIELD_STRING,
+                         .fieldValue = {FieldValue{
+                             .stringValue = VecSimAlgo_ToString(info.commonInfo.basicInfo.algo)}}});
+    this->addCommonInfoToIterator(infoIterator, info.commonInfo);
+    infoIterator->addInfoField(VecSim_InfoField{
+        .fieldName = VecSimCommonStrings::BLOCK_SIZE_STRING,
+        .fieldType = INFOFIELD_UINT64,
+        .fieldValue = {FieldValue{.uintegerValue = info.commonInfo.basicInfo.blockSize}}});
     return infoIterator;
 }
 

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -50,7 +50,7 @@ public:
                                               VecSimQueryParams *queryParams) const override;
     virtual VecSimIndexInfo info() const override;
     virtual VecSimInfoIterator *infoIterator() const override;
-    VecSimIndexStaticInfo staticInfo() const override;
+    VecSimIndexBasicInfo basicInfo() const override;
     virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob,
                                                   VecSimQueryParams *queryParams) const override;
     bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override;
@@ -352,10 +352,11 @@ VecSimIndexInfo BruteForceIndex<DataType, DistType>::info() const {
 }
 
 template <typename DataType, typename DistType>
-VecSimIndexStaticInfo BruteForceIndex<DataType, DistType>::staticInfo() const {
+VecSimIndexBasicInfo BruteForceIndex<DataType, DistType>::basicInfo() const {
 
-    VecSimIndexStaticInfo info = this->getStaticInfo();
+    VecSimIndexBasicInfo info = this->getBasicInfo();
     info.algo = VecSimAlgo_BF;
+    info.isTiered = false;
     return info;
 }
 

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -239,6 +239,7 @@ public:
     inline VisitedNodesHandler *getVisitedList() const;
     inline void returnVisitedList(VisitedNodesHandler *visited_nodes_handler) const;
     VecSimIndexInfo info() const override;
+    VecSimIndexStaticInfo staticInfo() const override;
     VecSimInfoIterator *infoIterator() const override;
     bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override;
     char *getDataByInternalId(idType internal_id) const;
@@ -2153,7 +2154,7 @@ VecSimIndexInfo HNSWIndex<DataType, DistType>::info() const {
     VecSimIndexInfo info;
     info.commonInfo = this->getCommonInfo();
 
-    info.algo = VecSimAlgo_HNSWLIB;
+    info.commonInfo.basicInfo.algo = VecSimAlgo_HNSWLIB;
     info.hnswInfo.M = this->getM();
     info.hnswInfo.efConstruction = this->getEfConstruction();
     info.hnswInfo.efRuntime = this->getEf();
@@ -2166,23 +2167,31 @@ VecSimIndexInfo HNSWIndex<DataType, DistType>::info() const {
 }
 
 template <typename DataType, typename DistType>
+VecSimIndexStaticInfo HNSWIndex<DataType, DistType>::staticInfo() const {
+    VecSimIndexStaticInfo info = this->getStaticInfo();
+    info.algo = VecSimAlgo_HNSWLIB;
+    return info;
+}
+
+template <typename DataType, typename DistType>
 VecSimInfoIterator *HNSWIndex<DataType, DistType>::infoIterator() const {
     VecSimIndexInfo info = this->info();
     // For readability. Update this number when needed.
     size_t numberOfInfoFields = 17;
     VecSimInfoIterator *infoIterator = new VecSimInfoIterator(numberOfInfoFields);
 
-    infoIterator->addInfoField(VecSim_InfoField{
-        .fieldName = VecSimCommonStrings::ALGORITHM_STRING,
-        .fieldType = INFOFIELD_STRING,
-        .fieldValue = {FieldValue{.stringValue = VecSimAlgo_ToString(info.algo)}}});
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::ALGORITHM_STRING,
+                         .fieldType = INFOFIELD_STRING,
+                         .fieldValue = {FieldValue{
+                             .stringValue = VecSimAlgo_ToString(info.commonInfo.basicInfo.algo)}}});
 
     this->addCommonInfoToIterator(infoIterator, info.commonInfo);
 
-    infoIterator->addInfoField(
-        VecSim_InfoField{.fieldName = VecSimCommonStrings::BLOCK_SIZE_STRING,
-                         .fieldType = INFOFIELD_UINT64,
-                         .fieldValue = {FieldValue{.uintegerValue = info.commonInfo.blockSize}}});
+    infoIterator->addInfoField(VecSim_InfoField{
+        .fieldName = VecSimCommonStrings::BLOCK_SIZE_STRING,
+        .fieldType = INFOFIELD_UINT64,
+        .fieldValue = {FieldValue{.uintegerValue = info.commonInfo.basicInfo.blockSize}}});
 
     infoIterator->addInfoField(
         VecSim_InfoField{.fieldName = VecSimCommonStrings::HNSW_M_STRING,

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -239,7 +239,7 @@ public:
     inline VisitedNodesHandler *getVisitedList() const;
     inline void returnVisitedList(VisitedNodesHandler *visited_nodes_handler) const;
     VecSimIndexInfo info() const override;
-    VecSimIndexStaticInfo staticInfo() const override;
+    VecSimIndexBasicInfo basicInfo() const override;
     VecSimInfoIterator *infoIterator() const override;
     bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override;
     char *getDataByInternalId(idType internal_id) const;
@@ -2167,9 +2167,10 @@ VecSimIndexInfo HNSWIndex<DataType, DistType>::info() const {
 }
 
 template <typename DataType, typename DistType>
-VecSimIndexStaticInfo HNSWIndex<DataType, DistType>::staticInfo() const {
-    VecSimIndexStaticInfo info = this->getStaticInfo();
+VecSimIndexBasicInfo HNSWIndex<DataType, DistType>::basicInfo() const {
+    VecSimIndexBasicInfo info = this->getBasicInfo();
     info.algo = VecSimAlgo_HNSWLIB;
+    info.isTiered = false;
     return info;
 }
 

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -1041,7 +1041,7 @@ VecSimInfoIterator *TieredHNSWIndex<DataType, DistType>::infoIterator() const {
         .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.backgroundIndexing}}});
 
     infoIterator->addInfoField(
-        VecSim_InfoField{.fieldName = VecSimCommonStrings::TIERED_BUFFER_LIMIT,
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::TIERED_BUFFER_LIMIT_STRING,
                          .fieldType = INFOFIELD_UINT64,
                          .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.bufferLimit}}});
 

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -180,7 +180,9 @@ public:
     // Do nothing here, each tier (flat buffer and HNSW) should increase capacity for itself when
     // needed.
     void increaseCapacity() override {}
-
+    VecSimIndexInfo info() const override;
+    VecSimIndexStaticInfo staticInfo() const override;
+    VecSimInfoIterator *infoIterator() const override;
     VecSimBatchIterator *newBatchIterator(const void *queryBlob,
                                           VecSimQueryParams *queryParams) const override {
         size_t blobSize = this->backendIndex->getDim() * sizeof(DataType);
@@ -1001,3 +1003,73 @@ void TieredHNSWIndex<DataType, DistType>::TieredHNSW_BatchIterator::filter_irrel
     // Update number of results (pop the tail)
     array_pop_back_n(rl.results, end - cur_end);
 }
+
+template <typename DataType, typename DistType>
+VecSimIndexInfo TieredHNSWIndex<DataType, DistType>::info() const {
+    auto info = VecSimTieredIndex<DataType, DistType>::info();
+    info.tieredInfo.backendAlgo = VecSimAlgo_HNSWLIB;
+    info.tieredInfo.backendInfo.hnswInfo = this->backendIndex->info().hnswInfo;
+    HnswTieredInfo hnswTieredInfo = {.pendingSwapJobsThreshold = this->pendingSwapJobsThreshold};
+    info.tieredInfo.specificTieredBackendInfo.hnswTieredInfo = hnswTieredInfo;
+
+    return info;
+}
+
+template <typename DataType, typename DistType>
+VecSimInfoIterator *TieredHNSWIndex<DataType, DistType>::infoIterator() const {
+    VecSimIndexInfo info = this->info();
+    // For readability. Update this number when needed.
+    size_t numberOfInfoFields = 15;
+    auto *infoIterator = new VecSimInfoIterator(numberOfInfoFields);
+
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::ALGORITHM_STRING,
+                         .fieldType = INFOFIELD_STRING,
+                         .fieldValue = {FieldValue{
+                             .stringValue = VecSimAlgo_ToString(info.commonInfo.basicInfo.algo)}}});
+
+    this->backendIndex->addCommonInfoToIterator(infoIterator, info.commonInfo);
+
+    infoIterator->addInfoField(VecSim_InfoField{
+        .fieldName = VecSimCommonStrings::TIERED_MANAGEMENT_MEMORY_STRING,
+        .fieldType = INFOFIELD_UINT64,
+        .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.management_layer_memory}}});
+
+    infoIterator->addInfoField(VecSim_InfoField{
+        .fieldName = VecSimCommonStrings::TIERED_BACKGROUND_INDEXING_STRING,
+        .fieldType = INFOFIELD_UINT64,
+        .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.backgroundIndexing}}});
+
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::TIERED_BUFFER_LIMIT,
+                         .fieldType = INFOFIELD_UINT64,
+                         .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.bufferLimit}}});
+
+    infoIterator->addInfoField(VecSim_InfoField{
+        .fieldName = VecSimCommonStrings::FRONTEND_INDEX_STRING,
+        .fieldType = INFOFIELD_ITERATOR,
+        .fieldValue = {FieldValue{.iteratorValue = this->frontendIndex->infoIterator()}}});
+
+    infoIterator->addInfoField(VecSim_InfoField{
+        .fieldName = VecSimCommonStrings::BACKEND_INDEX_STRING,
+        .fieldType = INFOFIELD_ITERATOR,
+        .fieldValue = {FieldValue{.iteratorValue = this->backendIndex->infoIterator()}}});
+
+    // Tiered HNSW specific param.
+    infoIterator->addInfoField(VecSim_InfoField{
+        .fieldName = VecSimCommonStrings::TIERED_HNSW_SWAP_JOBS_THRESHOLD_STRING,
+        .fieldType = INFOFIELD_UINT64,
+        .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.specificTieredBackendInfo
+                                                       .hnswTieredInfo.pendingSwapJobsThreshold}}});
+
+    return infoIterator;
+}
+
+template <typename DataType, typename DistType>
+VecSimIndexStaticInfo TieredHNSWIndex<DataType, DistType>::staticInfo() const {
+    VecSimIndexStaticInfo info = this->backendIndex->getStaticInfo();
+    info.blockSize = INVALID_INFO;
+    info.algo = VecSimAlgo_TIERED;
+    info.tieredBackendAlgo = VecSimAlgo_HNSWLIB;
+    return info;
+};

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -53,11 +53,11 @@ const char *VecSimCommonStrings::BATCH_SIZE_STRING = "BATCH_SIZE";
 
 const char *VecSimCommonStrings::TIERED_MANAGEMENT_MEMORY_STRING = "MANAGEMENT_LAYER_MEMORY";
 const char *VecSimCommonStrings::TIERED_BACKGROUND_INDEXING_STRING = "BACKGROUND_INDEXING";
-const char *VecSimCommonStrings::TIERED_BUFFER_LIMIT = "TIERED_BUFFER_LIMIT";
+const char *VecSimCommonStrings::TIERED_BUFFER_LIMIT_STRING = "TIERED_BUFFER_LIMIT";
 const char *VecSimCommonStrings::FRONTEND_INDEX_STRING = "FRONTEND_INDEX";
 const char *VecSimCommonStrings::BACKEND_INDEX_STRING = "BACKEND_INDEX";
 const char *VecSimCommonStrings::TIERED_HNSW_SWAP_JOBS_THRESHOLD_STRING =
-    "TIERED_HNSW_SWAP_JOBS_THRESHOLD_STRING";
+    "TIERED_HNSW_SWAP_JOBS_THRESHOLD";
 
 void sort_results_by_id(VecSimQueryResult_List rl) {
     qsort(rl.results, VecSimQueryResult_Len(rl), sizeof(VecSimQueryResult),

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -53,8 +53,11 @@ const char *VecSimCommonStrings::BATCH_SIZE_STRING = "BATCH_SIZE";
 
 const char *VecSimCommonStrings::TIERED_MANAGEMENT_MEMORY_STRING = "MANAGEMENT_LAYER_MEMORY";
 const char *VecSimCommonStrings::TIERED_BACKGROUND_INDEXING_STRING = "BACKGROUND_INDEXING";
+const char *VecSimCommonStrings::TIERED_BUFFER_LIMIT = "TIERED_BUFFER_LIMIT";
 const char *VecSimCommonStrings::FRONTEND_INDEX_STRING = "FRONTEND_INDEX";
 const char *VecSimCommonStrings::BACKEND_INDEX_STRING = "BACKEND_INDEX";
+const char *VecSimCommonStrings::TIERED_HNSW_SWAP_JOBS_THRESHOLD_STRING =
+    "TIERED_HNSW_SWAP_JOBS_THRESHOLD_STRING";
 
 void sort_results_by_id(VecSimQueryResult_List rl) {
     qsort(rl.results, VecSimQueryResult_Len(rl), sizeof(VecSimQueryResult),

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -61,7 +61,7 @@ public:
 
     static const char *TIERED_MANAGEMENT_MEMORY_STRING;
     static const char *TIERED_BACKGROUND_INDEXING_STRING;
-    static const char *TIERED_BUFFER_LIMIT;
+    static const char *TIERED_BUFFER_LIMIT_STRING;
     static const char *FRONTEND_INDEX_STRING;
     static const char *BACKEND_INDEX_STRING;
     static const char *TIERED_HNSW_SWAP_JOBS_THRESHOLD_STRING;

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -61,8 +61,10 @@ public:
 
     static const char *TIERED_MANAGEMENT_MEMORY_STRING;
     static const char *TIERED_BACKGROUND_INDEXING_STRING;
+    static const char *TIERED_BUFFER_LIMIT;
     static const char *FRONTEND_INDEX_STRING;
     static const char *BACKEND_INDEX_STRING;
+    static const char *TIERED_HNSW_SWAP_JOBS_THRESHOLD_STRING;
 };
 
 inline int cmpVecSimQueryResultById(const VecSimQueryResult *res1, const VecSimQueryResult *res2) {

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -147,11 +147,7 @@ extern "C" VecSimResolveCode VecSimIndex_ResolveParams(VecSimIndex *index, VecSi
     if (!qparams || (!rparams && (paramNum != 0))) {
         return VecSimParamResolverErr_NullParam;
     }
-    VecSimAlgo index_type = index->staticInfo().algo;
-    // Treat tiered index as the backend index type.
-    if (index_type == VecSimAlgo_TIERED) {
-        index_type = index->staticInfo().tieredBackendAlgo;
-    }
+    VecSimAlgo index_type = index->basicInfo().algo;
 
     bzero(qparams, sizeof(VecSimQueryParams));
     auto res = VecSimParamResolver_OK;
@@ -235,7 +231,9 @@ extern "C" VecSimInfoIterator *VecSimIndex_InfoIterator(VecSimIndex *index) {
     return index->infoIterator();
 }
 
-VecSimIndexStaticInfo VecSimIndex_StaticInfo(VecSimIndex *index) { return index->staticInfo(); }
+extern "C" VecSimIndexBasicInfo VecSimIndex_BasicInfo(VecSimIndex *index) {
+    return index->basicInfo();
+}
 
 extern "C" VecSimBatchIterator *VecSimBatchIterator_New(VecSimIndex *index, const void *queryBlob,
                                                         VecSimQueryParams *queryParams) {

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -147,10 +147,10 @@ extern "C" VecSimResolveCode VecSimIndex_ResolveParams(VecSimIndex *index, VecSi
     if (!qparams || (!rparams && (paramNum != 0))) {
         return VecSimParamResolverErr_NullParam;
     }
-    VecSimAlgo index_type = index->info().algo;
+    VecSimAlgo index_type = index->staticInfo().algo;
     // Treat tiered index as the backend index type.
     if (index_type == VecSimAlgo_TIERED) {
-        index_type = index->info().tieredInfo.backendAlgo;
+        index_type = index->staticInfo().tieredBackendAlgo;
     }
 
     bzero(qparams, sizeof(VecSimQueryParams));
@@ -234,6 +234,8 @@ extern "C" VecSimIndexInfo VecSimIndex_Info(VecSimIndex *index) { return index->
 extern "C" VecSimInfoIterator *VecSimIndex_InfoIterator(VecSimIndex *index) {
     return index->infoIterator();
 }
+
+VecSimIndexStaticInfo VecSimIndex_StaticInfo(VecSimIndex *index) { return index->staticInfo(); }
 
 extern "C" VecSimBatchIterator *VecSimBatchIterator_New(VecSimIndex *index, const void *queryBlob,
                                                         VecSimQueryParams *queryParams) {

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -149,6 +149,13 @@ VecSimQueryResult_List VecSimIndex_RangeQuery(VecSimIndex *index, const void *qu
 VecSimIndexInfo VecSimIndex_Info(VecSimIndex *index);
 
 /**
+ * @brief Return basic immutable index information.
+ * @param index the index to return its info.
+ * @return Index basic meta-data.
+ */
+VecSimIndexStaticInfo VecSimIndex_StaticInfo(VecSimIndex *index);
+
+/**
  * @brief Returns an info iterator for generic reply purposes.
  *
  * @param index this index to return its info.

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -153,7 +153,7 @@ VecSimIndexInfo VecSimIndex_Info(VecSimIndex *index);
  * @param index the index to return its info.
  * @return Index basic meta-data.
  */
-VecSimIndexStaticInfo VecSimIndex_StaticInfo(VecSimIndex *index);
+VecSimIndexBasicInfo VecSimIndex_BasicInfo(VecSimIndex *index);
 
 /**
  * @brief Returns an info iterator for generic reply purposes.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -204,15 +204,15 @@ typedef struct {
     bool isMulti;        // Determines if the index should multi-index or not.
     size_t dim;          // Vector size (dimension).
 
-    VecSimAlgo tieredBackendAlgo; // The algorithm for the tiered index (if algo is tiered).
-} VecSimIndexStaticInfo;
+    bool isTiered; // The algorithm for the tiered index (if algo is tiered).
+} VecSimIndexBasicInfo;
 
 typedef struct {
-    VecSimIndexStaticInfo basicInfo; // Index immutable meta-data.
-    size_t indexSize;                // Current count of vectors.
-    size_t indexLabelCount;          // Current unique count of labels.
-    uint64_t memory;                 // Index memory consumption.
-    VecSearchMode last_mode;         // The mode in which the last query ran.
+    VecSimIndexBasicInfo basicInfo; // Index immutable meta-data.
+    size_t indexSize;               // Current count of vectors.
+    size_t indexLabelCount;         // Current unique count of labels.
+    uint64_t memory;                // Index memory consumption.
+    VecSearchMode last_mode;        // The mode in which the last query ran.
 } CommonInfo;
 
 typedef struct {
@@ -244,7 +244,6 @@ typedef struct {
         HnswTieredInfo hnswTieredInfo;
     } specificTieredBackendInfo;   // Info relevant for tiered index with a specific backend.
     CommonInfo backendCommonInfo;  // Common index info.
-    VecSimAlgo backendAlgo;        // The algorithm used in the backend.
     CommonInfo frontendCommonInfo; // Common index info.
     bfInfoStruct bfInfo;           // The brute force index info.
 

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -64,7 +64,7 @@ protected:
      */
     CommonInfo getCommonInfo() const {
         CommonInfo info;
-        info.basicInfo = this->getStaticInfo();
+        info.basicInfo = this->getBasicInfo();
         info.last_mode = this->last_mode;
         info.memory = this->getAllocationSize();
         info.indexSize = this->indexSize();
@@ -184,15 +184,15 @@ public:
     /**
      * @brief Get the basic static info object
      *
-     * @return StaticInfo
+     * @return basicInfo
      */
-    VecSimIndexStaticInfo getStaticInfo() const {
-        VecSimIndexStaticInfo s_info{.blockSize = this->blockSize,
-                                     .metric = this->metric,
-                                     .type = this->vecType,
-                                     .isMulti = this->isMulti,
-                                     .dim = this->dim};
-        return s_info;
+    VecSimIndexBasicInfo getBasicInfo() const {
+        VecSimIndexBasicInfo info{.blockSize = this->blockSize,
+                                  .metric = this->metric,
+                                  .type = this->vecType,
+                                  .isMulti = this->isMulti,
+                                  .dim = this->dim};
+        return info;
     }
 
 protected:

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -64,12 +64,8 @@ protected:
      */
     CommonInfo getCommonInfo() const {
         CommonInfo info;
-        info.dim = this->dim;
-        info.type = this->vecType;
-        info.metric = this->metric;
-        info.blockSize = this->blockSize;
+        info.basicInfo = this->getStaticInfo();
         info.last_mode = this->last_mode;
-        info.isMulti = this->isMulti;
         info.memory = this->getAllocationSize();
         info.indexSize = this->indexSize();
         info.indexLabelCount = this->indexLabelCount();
@@ -139,19 +135,20 @@ public:
         infoIterator->addInfoField(VecSim_InfoField{
             .fieldName = VecSimCommonStrings::TYPE_STRING,
             .fieldType = INFOFIELD_STRING,
-            .fieldValue = {FieldValue{.stringValue = VecSimType_ToString(info.type)}}});
+            .fieldValue = {FieldValue{.stringValue = VecSimType_ToString(info.basicInfo.type)}}});
         infoIterator->addInfoField(
             VecSim_InfoField{.fieldName = VecSimCommonStrings::DIMENSION_STRING,
                              .fieldType = INFOFIELD_UINT64,
-                             .fieldValue = {FieldValue{.uintegerValue = info.dim}}});
-        infoIterator->addInfoField(VecSim_InfoField{
-            .fieldName = VecSimCommonStrings::METRIC_STRING,
-            .fieldType = INFOFIELD_STRING,
-            .fieldValue = {FieldValue{.stringValue = VecSimMetric_ToString(info.metric)}}});
+                             .fieldValue = {FieldValue{.uintegerValue = info.basicInfo.dim}}});
+        infoIterator->addInfoField(
+            VecSim_InfoField{.fieldName = VecSimCommonStrings::METRIC_STRING,
+                             .fieldType = INFOFIELD_STRING,
+                             .fieldValue = {FieldValue{
+                                 .stringValue = VecSimMetric_ToString(info.basicInfo.metric)}}});
         infoIterator->addInfoField(
             VecSim_InfoField{.fieldName = VecSimCommonStrings::IS_MULTI_STRING,
                              .fieldType = INFOFIELD_UINT64,
-                             .fieldValue = {FieldValue{.uintegerValue = info.isMulti}}});
+                             .fieldValue = {FieldValue{.uintegerValue = info.basicInfo.isMulti}}});
         infoIterator->addInfoField(
             VecSim_InfoField{.fieldName = VecSimCommonStrings::INDEX_SIZE_STRING,
                              .fieldType = INFOFIELD_UINT64,
@@ -182,6 +179,20 @@ public:
 
         // Else no process is needed, return the original blob
         return original_blob;
+    }
+
+    /**
+     * @brief Get the basic static info object
+     *
+     * @return StaticInfo
+     */
+    VecSimIndexStaticInfo getStaticInfo() const {
+        VecSimIndexStaticInfo s_info{.blockSize = this->blockSize,
+                                     .metric = this->metric,
+                                     .type = this->vecType,
+                                     .isMulti = this->isMulti,
+                                     .dim = this->dim};
+        return s_info;
     }
 
 protected:

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -171,7 +171,7 @@ public:
      *
      * @return Index general and specific meta-data (for quick and lock-less data retrieval)_
      */
-    virtual VecSimIndexStaticInfo staticInfo() const = 0;
+    virtual VecSimIndexBasicInfo basicInfo() const = 0;
 
     /**
      * @brief Returns an index information in an iterable structure.

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -160,9 +160,18 @@ public:
     /**
      * @brief Return index information.
      *
-     * @return Index general and specific meta-data.
+     * @return Index general and specific meta-data. Note that this operation might
+     * be time consuming (specially for tiered index where computing label count required
+     * locking and going over the labels sets). So this should be used carefully.
      */
     virtual VecSimIndexInfo info() const = 0;
+
+    /**
+     * @brief Return index static information.
+     *
+     * @return Index general and specific meta-data (for quick and lock-less data retrieval)_
+     */
+    virtual VecSimIndexStaticInfo staticInfo() const = 0;
 
     /**
      * @brief Returns an index information in an iterable structure.

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -305,11 +305,12 @@ VecSimInfoIterator *VecSimTieredIndex<DataType, DistType>::infoIterator() const 
     size_t numberOfInfoFields = 14;
     auto *infoIterator = new VecSimInfoIterator(numberOfInfoFields);
 
+    // Set tiered explicitly as algo name for root iterator.
     infoIterator->addInfoField(
         VecSim_InfoField{.fieldName = VecSimCommonStrings::ALGORITHM_STRING,
                          .fieldType = INFOFIELD_STRING,
                          .fieldValue = {FieldValue{
-                             .stringValue = VecSimAlgo_ToString(info.commonInfo.basicInfo.algo)}}});
+                             .stringValue = VecSimCommonStrings::TIERED_STRING}}});
 
     this->backendIndex->addCommonInfoToIterator(infoIterator, info.commonInfo);
 

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -306,11 +306,10 @@ VecSimInfoIterator *VecSimTieredIndex<DataType, DistType>::infoIterator() const 
     auto *infoIterator = new VecSimInfoIterator(numberOfInfoFields);
 
     // Set tiered explicitly as algo name for root iterator.
-    infoIterator->addInfoField(
-        VecSim_InfoField{.fieldName = VecSimCommonStrings::ALGORITHM_STRING,
-                         .fieldType = INFOFIELD_STRING,
-                         .fieldValue = {FieldValue{
-                             .stringValue = VecSimCommonStrings::TIERED_STRING}}});
+    infoIterator->addInfoField(VecSim_InfoField{
+        .fieldName = VecSimCommonStrings::ALGORITHM_STRING,
+        .fieldType = INFOFIELD_STRING,
+        .fieldValue = {FieldValue{.stringValue = VecSimCommonStrings::TIERED_STRING}}});
 
     this->backendIndex->addCommonInfoToIterator(infoIterator, info.commonInfo);
 

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -88,7 +88,6 @@ public:
     }
 
     virtual VecSimIndexInfo info() const override;
-    virtual VecSimInfoIterator *infoIterator() const override;
 
     bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override {
         // For now, decide according to the bigger index.
@@ -263,26 +262,17 @@ VecSimIndexInfo VecSimTieredIndex<DataType, DistType>::info() const {
     VecSimIndexInfo info;
     VecSimIndexInfo backendInfo = this->backendIndex->info();
     VecSimIndexInfo frontendInfo = this->frontendIndex->info();
-    info.algo = VecSimAlgo_TIERED;
+    VecSimIndexStaticInfo s_info{.algo = VecSimAlgo_TIERED,
+                                 .blockSize = INVALID_INFO,
+                                 .metric = backendInfo.commonInfo.basicInfo.metric,
+                                 .type = backendInfo.commonInfo.basicInfo.type,
+                                 .isMulti = this->backendIndex->isMultiValue(),
+                                 .dim = backendInfo.commonInfo.basicInfo.dim};
+    info.commonInfo.basicInfo = s_info;
     info.commonInfo.indexLabelCount = this->indexLabelCount();
     info.commonInfo.indexSize = this->indexSize();
     info.commonInfo.memory = this->getAllocationSize();
-    info.commonInfo.isMulti = this->backendIndex->isMultiValue();
-    info.commonInfo.type = backendInfo.commonInfo.type;
-    info.commonInfo.metric = backendInfo.commonInfo.metric;
-    info.commonInfo.dim = backendInfo.commonInfo.dim;
-    info.commonInfo.blockSize = INVALID_INFO;
     info.commonInfo.last_mode = backendInfo.commonInfo.last_mode;
-
-    info.tieredInfo.backendAlgo = backendInfo.algo;
-    switch (backendInfo.algo) {
-    case VecSimAlgo_HNSWLIB:
-        info.tieredInfo.backendInfo.hnswInfo = backendInfo.hnswInfo;
-        break;
-    case VecSimAlgo_BF:
-    case VecSimAlgo_TIERED:
-        assert(false && "Invalid backend algorithm");
-    }
 
     info.tieredInfo.backendCommonInfo = backendInfo.commonInfo;
     // For now, this is hard coded to FLAT
@@ -291,42 +281,6 @@ VecSimIndexInfo VecSimTieredIndex<DataType, DistType>::info() const {
 
     info.tieredInfo.backgroundIndexing = this->frontendIndex->indexSize() > 0;
     info.tieredInfo.management_layer_memory = this->allocator->getAllocationSize();
+    info.tieredInfo.bufferLimit = this->flatBufferLimit;
     return info;
-}
-
-template <typename DataType, typename DistType>
-VecSimInfoIterator *VecSimTieredIndex<DataType, DistType>::infoIterator() const {
-    VecSimIndexInfo info = this->info();
-    // For readability. Update this number when needed.
-    size_t numberOfInfoFields = 13;
-    VecSimInfoIterator *infoIterator = new VecSimInfoIterator(numberOfInfoFields);
-
-    infoIterator->addInfoField(VecSim_InfoField{
-        .fieldName = VecSimCommonStrings::ALGORITHM_STRING,
-        .fieldType = INFOFIELD_STRING,
-        .fieldValue = {FieldValue{.stringValue = VecSimAlgo_ToString(info.algo)}}});
-
-    this->backendIndex->addCommonInfoToIterator(infoIterator, info.commonInfo);
-
-    infoIterator->addInfoField(VecSim_InfoField{
-        .fieldName = VecSimCommonStrings::TIERED_MANAGEMENT_MEMORY_STRING,
-        .fieldType = INFOFIELD_UINT64,
-        .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.management_layer_memory}}});
-
-    infoIterator->addInfoField(VecSim_InfoField{
-        .fieldName = VecSimCommonStrings::TIERED_BACKGROUND_INDEXING_STRING,
-        .fieldType = INFOFIELD_UINT64,
-        .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.backgroundIndexing}}});
-
-    infoIterator->addInfoField(VecSim_InfoField{
-        .fieldName = VecSimCommonStrings::FRONTEND_INDEX_STRING,
-        .fieldType = INFOFIELD_ITERATOR,
-        .fieldValue = {FieldValue{.iteratorValue = this->frontendIndex->infoIterator()}}});
-
-    infoIterator->addInfoField(VecSim_InfoField{
-        .fieldName = VecSimCommonStrings::BACKEND_INDEX_STRING,
-        .fieldType = INFOFIELD_ITERATOR,
-        .fieldValue = {FieldValue{.iteratorValue = this->backendIndex->infoIterator()}}});
-
-    return infoIterator;
 };

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -94,7 +94,7 @@ private:
     template <typename DataType>
     inline py::object rawVectorsAsNumpy(labelType label, size_t dim) {
         std::vector<std::vector<DataType>> vectors;
-        if (index->staticInfo().algo == VecSimAlgo_BF) {
+        if (index->basicInfo().algo == VecSimAlgo_BF) {
             reinterpret_cast<BruteForceIndex<DataType, DataType> *>(this->index.get())
                 ->getDataByLabel(label, vectors);
         } else {

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -94,7 +94,7 @@ private:
     template <typename DataType>
     inline py::object rawVectorsAsNumpy(labelType label, size_t dim) {
         std::vector<std::vector<DataType>> vectors;
-        if (index->info().algo == VecSimAlgo_BF) {
+        if (index->staticInfo().algo == VecSimAlgo_BF) {
             reinterpret_cast<BruteForceIndex<DataType, DataType> *>(this->index.get())
                 ->getDataByLabel(label, vectors);
         } else {
@@ -182,10 +182,10 @@ public:
 
     py::object getVector(labelType label) {
         VecSimIndexInfo info = index->info();
-        size_t dim = info.commonInfo.dim;
-        if (info.commonInfo.type == VecSimType_FLOAT32) {
+        size_t dim = info.commonInfo.basicInfo.dim;
+        if (info.commonInfo.basicInfo.type == VecSimType_FLOAT32) {
             return rawVectorsAsNumpy<float>(label, dim);
-        } else if (info.commonInfo.type == VecSimType_FLOAT64) {
+        } else if (info.commonInfo.basicInfo.type == VecSimType_FLOAT64) {
             return rawVectorsAsNumpy<double>(label, dim);
         } else {
             throw std::runtime_error("Invalid vector data type");
@@ -345,7 +345,7 @@ public:
     }
 
     bool checkIntegrity() {
-        auto type = VecSimIndex_Info(this->index.get()).commonInfo.type;
+        auto type = VecSimIndex_Info(this->index.get()).commonInfo.basicInfo.type;
         if (type == VecSimType_FLOAT32) {
             return reinterpret_cast<HNSWIndex<float, float> *>(this->index.get())
                 ->checkIntegrity()

--- a/tests/module/memory_test.c
+++ b/tests/module/memory_test.c
@@ -27,7 +27,7 @@ long long _get_memory_usage(RedisModuleCtx *ctx) {
 // Adds 'amount' vectors to the index. could be 0.
 void _add_vectors(VecSimIndex *index, long long amount) {
     VecSimIndexInfo indexInfo = VecSimIndex_Info(index);
-    size_t dim = indexInfo.commonInfo.dim;
+    size_t dim = indexInfo.commonInfo.basicInfo.dim;
     double vec[dim];
     for (int i = 0; i < dim; i++)
         vec[i] = i;
@@ -112,7 +112,7 @@ int _VecSim_memory_create_check_impl(RedisModuleCtx *ctx, VecSimAlgo algo, long 
 
     // Actual test: verify that memory usage known to the server is at least the memory amount used
     // by the index.
-    int64_t memory = indexInfo.commonInfo.memory;
+    uint64_t memory = indexInfo.commonInfo.memory;
 
     if (memory <= endMemory - startMemory)
         RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -375,7 +375,7 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw_reclaim_memory) {
                                        2 * vecsimAllocationOverhead);
 
     // Add vectors up to the size of a whole block, and calculate the total memory delta.
-    size_t block_size = hnswIndex->info().commonInfo.blockSize;
+    size_t block_size = hnswIndex->info().commonInfo.basicInfo.blockSize;
 
     size_t accumulated_mem_delta = allocator->getAllocationSize();
     for (size_t i = 0; i < block_size; i++) {

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -547,18 +547,21 @@ TYPED_TEST(BruteForceTest, test_bf_info) {
     ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_BF);
     ASSERT_EQ(info.commonInfo.basicInfo.dim, d);
     ASSERT_FALSE(info.commonInfo.basicInfo.isMulti);
+    ASSERT_FALSE(info.commonInfo.basicInfo.isTiered);
+
     // User args.
     ASSERT_EQ(info.commonInfo.basicInfo.blockSize, 1);
     ASSERT_EQ(info.commonInfo.indexSize, 0);
 
     // Validate that Static info returns the right restricted info as well.
-    VecSimIndexStaticInfo s_info = VecSimIndex_StaticInfo(index);
+    VecSimIndexBasicInfo s_info = VecSimIndex_BasicInfo(index);
     ASSERT_EQ(info.commonInfo.basicInfo.algo, s_info.algo);
     ASSERT_EQ(info.commonInfo.basicInfo.dim, s_info.dim);
     ASSERT_EQ(info.commonInfo.basicInfo.blockSize, s_info.blockSize);
     ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
     ASSERT_EQ(info.commonInfo.basicInfo.isMulti, s_info.isMulti);
     ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    ASSERT_EQ(info.commonInfo.basicInfo.isTiered, s_info.isTiered);
 
     VecSimIndex_Free(index);
 }

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -529,11 +529,11 @@ TYPED_TEST(BruteForceTest, test_bf_info) {
     VecSimIndex *index = this->CreateNewIndex(params);
 
     VecSimIndexInfo info = VecSimIndex_Info(index);
-    ASSERT_EQ(info.algo, VecSimAlgo_BF);
-    ASSERT_EQ(info.commonInfo.dim, d);
-    ASSERT_FALSE(info.commonInfo.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_BF);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, d);
+    ASSERT_FALSE(info.commonInfo.basicInfo.isMulti);
     // Default args.
-    ASSERT_EQ(info.commonInfo.blockSize, DEFAULT_BLOCK_SIZE);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(info.commonInfo.indexSize, 0);
     VecSimIndex_Free(index);
 
@@ -544,12 +544,22 @@ TYPED_TEST(BruteForceTest, test_bf_info) {
     index = this->CreateNewIndex(params);
 
     info = VecSimIndex_Info(index);
-    ASSERT_EQ(info.algo, VecSimAlgo_BF);
-    ASSERT_EQ(info.commonInfo.dim, d);
-    ASSERT_FALSE(info.commonInfo.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_BF);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, d);
+    ASSERT_FALSE(info.commonInfo.basicInfo.isMulti);
     // User args.
-    ASSERT_EQ(info.commonInfo.blockSize, 1);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, 1);
     ASSERT_EQ(info.commonInfo.indexSize, 0);
+
+    // Validate that Static info returns the right restricted info as well.
+    VecSimIndexStaticInfo s_info = VecSimIndex_StaticInfo(index);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, s_info.algo);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, s_info.dim);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, s_info.blockSize);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    ASSERT_EQ(info.commonInfo.basicInfo.isMulti, s_info.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+
     VecSimIndex_Free(index);
 }
 
@@ -583,7 +593,7 @@ TYPED_TEST(BruteForceTest, test_dynamic_bf_info_iterator) {
 
     VecSimIndexInfo info = VecSimIndex_Info(index);
     VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(index);
-    ASSERT_EQ(1, info.commonInfo.blockSize);
+    ASSERT_EQ(1, info.commonInfo.basicInfo.blockSize);
     ASSERT_EQ(0, info.commonInfo.indexSize);
     compareFlatIndexInfoToIterator(info, infoIter);
     VecSimInfoIterator_Free(infoIter);
@@ -667,8 +677,8 @@ TYPED_TEST(BruteForceTest, brute_force_vector_search_test_ip) {
         VecSimIndex *index = this->CreateNewIndex(params);
 
         VecSimIndexInfo info = VecSimIndex_Info(index);
-        ASSERT_EQ(info.algo, VecSimAlgo_BF);
-        ASSERT_EQ(info.commonInfo.blockSize, blocksize);
+        ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_BF);
+        ASSERT_EQ(info.commonInfo.basicInfo.blockSize, blocksize);
 
         for (size_t i = 0; i < n; i++) {
             GenerateAndAddVector<TEST_DATA_T>(index, dim, i, i);
@@ -702,8 +712,8 @@ TYPED_TEST(BruteForceTest, brute_force_vector_search_test_l2) {
         VecSimIndex *index = this->CreateNewIndex(params);
 
         VecSimIndexInfo info = VecSimIndex_Info(index);
-        ASSERT_EQ(info.algo, VecSimAlgo_BF);
-        ASSERT_EQ(info.commonInfo.blockSize, blocksize);
+        ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_BF);
+        ASSERT_EQ(info.commonInfo.basicInfo.blockSize, blocksize);
 
         for (size_t i = 0; i < n; i++) {
             GenerateAndAddVector<TEST_DATA_T>(index, dim, i, i);

--- a/tests/unit/test_bruteforce_multi.cpp
+++ b/tests/unit/test_bruteforce_multi.cpp
@@ -487,11 +487,11 @@ TYPED_TEST(BruteForceMultiTest, test_bf_info) {
     VecSimIndex *index = this->CreateNewIndex(params);
 
     VecSimIndexInfo info = VecSimIndex_Info(index);
-    ASSERT_EQ(info.algo, VecSimAlgo_BF);
-    ASSERT_EQ(info.commonInfo.dim, d);
-    ASSERT_TRUE(info.commonInfo.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_BF);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, d);
+    ASSERT_TRUE(info.commonInfo.basicInfo.isMulti);
     // Default args.
-    ASSERT_EQ(info.commonInfo.blockSize, DEFAULT_BLOCK_SIZE);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(info.commonInfo.indexSize, 0);
     VecSimIndex_Free(index);
 
@@ -501,11 +501,11 @@ TYPED_TEST(BruteForceMultiTest, test_bf_info) {
     index = this->CreateNewIndex(params);
 
     info = VecSimIndex_Info(index);
-    ASSERT_EQ(info.algo, VecSimAlgo_BF);
-    ASSERT_EQ(info.commonInfo.dim, d);
-    ASSERT_TRUE(info.commonInfo.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_BF);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, d);
+    ASSERT_TRUE(info.commonInfo.basicInfo.isMulti);
     // User args.
-    ASSERT_EQ(info.commonInfo.blockSize, 1);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, 1);
     ASSERT_EQ(info.commonInfo.indexSize, 0);
     VecSimIndex_Free(index);
 }
@@ -539,7 +539,7 @@ TYPED_TEST(BruteForceMultiTest, test_dynamic_bf_info_iterator) {
 
     VecSimIndexInfo info = VecSimIndex_Info(index);
     VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(index);
-    ASSERT_EQ(1, info.commonInfo.blockSize);
+    ASSERT_EQ(1, info.commonInfo.basicInfo.blockSize);
     ASSERT_EQ(0, info.commonInfo.indexSize);
     compareFlatIndexInfoToIterator(info, infoIter);
     VecSimInfoIterator_Free(infoIter);
@@ -633,8 +633,8 @@ TYPED_TEST(BruteForceMultiTest, vector_search_test_l2) {
         VecSimIndex *index = this->CreateNewIndex(params);
 
         VecSimIndexInfo info = VecSimIndex_Info(index);
-        ASSERT_EQ(info.algo, VecSimAlgo_BF);
-        ASSERT_EQ(info.commonInfo.blockSize, blocksize);
+        ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_BF);
+        ASSERT_EQ(info.commonInfo.basicInfo.blockSize, blocksize);
 
         for (size_t i = 0; i < n; i++) {
             GenerateAndAddVector<TEST_DATA_T>(index, dim, i, i);

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -504,16 +504,16 @@ TYPED_TEST(HNSWTest, test_hnsw_info) {
     VecSimIndex *index = this->CreateNewIndex(params);
 
     VecSimIndexInfo info = VecSimIndex_Info(index);
-    ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
-    ASSERT_EQ(info.commonInfo.dim, d);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, d);
     // Default args.
-    ASSERT_FALSE(info.commonInfo.isMulti);
-    ASSERT_EQ(info.commonInfo.blockSize, DEFAULT_BLOCK_SIZE);
+    ASSERT_FALSE(info.commonInfo.basicInfo.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(info.hnswInfo.M, HNSW_DEFAULT_M);
     ASSERT_EQ(info.hnswInfo.efConstruction, HNSW_DEFAULT_EF_C);
     ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
     ASSERT_DOUBLE_EQ(info.hnswInfo.epsilon, HNSW_DEFAULT_EPSILON);
-    ASSERT_EQ(info.commonInfo.type, params.type);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, params.type);
     VecSimIndex_Free(index);
 
     d = 1280;
@@ -524,16 +524,26 @@ TYPED_TEST(HNSWTest, test_hnsw_info) {
 
     index = this->CreateNewIndex(params);
     info = VecSimIndex_Info(index);
-    ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
-    ASSERT_EQ(info.commonInfo.dim, d);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, d);
     // User args.
-    ASSERT_FALSE(info.commonInfo.isMulti);
-    ASSERT_EQ(info.commonInfo.blockSize, bs);
+    ASSERT_FALSE(info.commonInfo.basicInfo.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, bs);
     ASSERT_EQ(info.hnswInfo.efConstruction, 1000);
     ASSERT_EQ(info.hnswInfo.M, 200);
     ASSERT_EQ(info.hnswInfo.efRuntime, 500);
     ASSERT_EQ(info.hnswInfo.epsilon, 0.005);
-    ASSERT_EQ(info.commonInfo.type, params.type);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, params.type);
+
+    // Validate that Static info returns the right restricted info as well.
+    VecSimIndexStaticInfo s_info = VecSimIndex_StaticInfo(index);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, s_info.algo);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, s_info.dim);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, s_info.blockSize);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    ASSERT_EQ(info.commonInfo.basicInfo.isMulti, s_info.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+
     VecSimIndex_Free(index);
 }
 
@@ -580,7 +590,7 @@ TYPED_TEST(HNSWTest, test_dynamic_hnsw_info_iterator) {
     ASSERT_EQ(0, info.commonInfo.indexSize);
     ASSERT_EQ(-1, info.hnswInfo.max_level);
     ASSERT_EQ(-1, info.hnswInfo.entrypoint);
-    ASSERT_EQ(params.type, info.commonInfo.type);
+    ASSERT_EQ(params.type, info.commonInfo.basicInfo.type);
     compareHNSWIndexInfoToIterator(info, infoIter);
     VecSimInfoIterator_Free(infoIter);
 
@@ -2030,14 +2040,14 @@ TYPED_TEST(HNSWTest, HNSWSerialization_v2) {
 
         // Fetch info after saving, as memory size change during saving.
         VecSimIndexInfo info = VecSimIndex_Info(index);
-        ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
+        ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
         ASSERT_EQ(info.hnswInfo.M, M);
         ASSERT_EQ(info.hnswInfo.efConstruction, ef);
         ASSERT_EQ(info.hnswInfo.efRuntime, ef);
         ASSERT_EQ(info.commonInfo.indexSize, n);
-        ASSERT_EQ(info.commonInfo.metric, VecSimMetric_L2);
-        ASSERT_EQ(info.commonInfo.type, TypeParam::get_index_type());
-        ASSERT_EQ(info.commonInfo.dim, dim);
+        ASSERT_EQ(info.commonInfo.basicInfo.metric, VecSimMetric_L2);
+        ASSERT_EQ(info.commonInfo.basicInfo.type, TypeParam::get_index_type());
+        ASSERT_EQ(info.commonInfo.basicInfo.dim, dim);
         ASSERT_EQ(info.commonInfo.indexLabelCount, n_labels[i]);
 
         VecSimIndex_Free(index);
@@ -2050,16 +2060,16 @@ TYPED_TEST(HNSWTest, HNSWSerialization_v2) {
         ASSERT_TRUE(serialized_hnsw_index->checkIntegrity().valid_state);
 
         VecSimIndexInfo info2 = VecSimIndex_Info(serialized_index);
-        ASSERT_EQ(info2.algo, VecSimAlgo_HNSWLIB);
+        ASSERT_EQ(info2.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
         ASSERT_EQ(info2.hnswInfo.M, M);
-        ASSERT_EQ(info2.commonInfo.isMulti, is_multi[i]);
-        ASSERT_EQ(info2.commonInfo.blockSize, blockSize);
+        ASSERT_EQ(info2.commonInfo.basicInfo.isMulti, is_multi[i]);
+        ASSERT_EQ(info2.commonInfo.basicInfo.blockSize, blockSize);
         ASSERT_EQ(info2.hnswInfo.efConstruction, ef);
         ASSERT_EQ(info2.hnswInfo.efRuntime, ef);
         ASSERT_EQ(info2.commonInfo.indexSize, n);
-        ASSERT_EQ(info2.commonInfo.metric, VecSimMetric_L2);
-        ASSERT_EQ(info2.commonInfo.type, TypeParam::get_index_type());
-        ASSERT_EQ(info2.commonInfo.dim, dim);
+        ASSERT_EQ(info2.commonInfo.basicInfo.metric, VecSimMetric_L2);
+        ASSERT_EQ(info2.commonInfo.basicInfo.type, TypeParam::get_index_type());
+        ASSERT_EQ(info2.commonInfo.basicInfo.dim, dim);
         ASSERT_EQ(info2.commonInfo.indexLabelCount, n_labels[i]);
         ASSERT_EQ(info2.hnswInfo.epsilon, epsilon);
 
@@ -2121,15 +2131,15 @@ TYPED_TEST(HNSWTest, LoadHNSWSerialized_v1) {
         ASSERT_TRUE(serialized_hnsw_index->checkIntegrity().valid_state);
 
         VecSimIndexInfo info2 = VecSimIndex_Info(serialized_index);
-        ASSERT_EQ(info2.algo, VecSimAlgo_HNSWLIB);
+        ASSERT_EQ(info2.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
         // Check that M is taken from file and not from @params.
         ASSERT_EQ(info2.hnswInfo.M, M_serialized);
         ASSERT_NE(info2.hnswInfo.M, M_param);
 
-        ASSERT_EQ(info2.commonInfo.isMulti, is_multi[i]);
+        ASSERT_EQ(info2.commonInfo.basicInfo.isMulti, is_multi[i]);
 
         // Check it was initalized with the default blockSize value.
-        ASSERT_EQ(info2.commonInfo.blockSize, DEFAULT_BLOCK_SIZE);
+        ASSERT_EQ(info2.commonInfo.basicInfo.blockSize, DEFAULT_BLOCK_SIZE);
 
         // Check that ef is taken from file and not from @params.
         ASSERT_EQ(info2.hnswInfo.efConstruction, ef_serialized);
@@ -2138,9 +2148,9 @@ TYPED_TEST(HNSWTest, LoadHNSWSerialized_v1) {
         ASSERT_NE(info2.hnswInfo.efConstruction, ef_param);
 
         ASSERT_EQ(info2.commonInfo.indexSize, n);
-        ASSERT_EQ(info2.commonInfo.metric, VecSimMetric_L2);
-        ASSERT_EQ(info2.commonInfo.type, TypeParam::get_index_type());
-        ASSERT_EQ(info2.commonInfo.dim, dim);
+        ASSERT_EQ(info2.commonInfo.basicInfo.metric, VecSimMetric_L2);
+        ASSERT_EQ(info2.commonInfo.basicInfo.type, TypeParam::get_index_type());
+        ASSERT_EQ(info2.commonInfo.basicInfo.dim, dim);
         ASSERT_EQ(info2.commonInfo.indexLabelCount, n_labels[i]);
         // Check it was initalized with the default epsilon value.
         ASSERT_EQ(info2.hnswInfo.epsilon, HNSW_DEFAULT_EPSILON);

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -534,15 +534,17 @@ TYPED_TEST(HNSWTest, test_hnsw_info) {
     ASSERT_EQ(info.hnswInfo.efRuntime, 500);
     ASSERT_EQ(info.hnswInfo.epsilon, 0.005);
     ASSERT_EQ(info.commonInfo.basicInfo.type, params.type);
+    ASSERT_FALSE(info.commonInfo.basicInfo.isTiered);
 
     // Validate that Static info returns the right restricted info as well.
-    VecSimIndexStaticInfo s_info = VecSimIndex_StaticInfo(index);
+    VecSimIndexBasicInfo s_info = VecSimIndex_BasicInfo(index);
     ASSERT_EQ(info.commonInfo.basicInfo.algo, s_info.algo);
     ASSERT_EQ(info.commonInfo.basicInfo.dim, s_info.dim);
     ASSERT_EQ(info.commonInfo.basicInfo.blockSize, s_info.blockSize);
     ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
     ASSERT_EQ(info.commonInfo.basicInfo.isMulti, s_info.isMulti);
     ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    ASSERT_EQ(info.commonInfo.basicInfo.isTiered, s_info.isTiered);
 
     VecSimIndex_Free(index);
 }

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -355,11 +355,11 @@ TYPED_TEST(HNSWMultiTest, test_hnsw_info) {
     VecSimIndex *index = this->CreateNewIndex(params);
 
     VecSimIndexInfo info = VecSimIndex_Info(index);
-    ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
-    ASSERT_EQ(info.commonInfo.dim, d);
-    ASSERT_TRUE(info.commonInfo.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, d);
+    ASSERT_TRUE(info.commonInfo.basicInfo.isMulti);
     // Default args.
-    ASSERT_EQ(info.commonInfo.blockSize, DEFAULT_BLOCK_SIZE);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(info.hnswInfo.M, HNSW_DEFAULT_M);
     ASSERT_EQ(info.hnswInfo.efConstruction, HNSW_DEFAULT_EF_C);
     ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
@@ -381,11 +381,11 @@ TYPED_TEST(HNSWMultiTest, test_hnsw_info) {
 
     index = this->CreateNewIndex(params);
     info = VecSimIndex_Info(index);
-    ASSERT_EQ(info.algo, VecSimAlgo_HNSWLIB);
-    ASSERT_EQ(info.commonInfo.dim, d);
-    ASSERT_TRUE(info.commonInfo.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, d);
+    ASSERT_TRUE(info.commonInfo.basicInfo.isMulti);
     // User args.
-    ASSERT_EQ(info.commonInfo.blockSize, bs);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, bs);
     ASSERT_EQ(info.hnswInfo.M, M);
     ASSERT_EQ(info.hnswInfo.efConstruction, ef_C);
     ASSERT_EQ(info.hnswInfo.efRuntime, ef_RT);

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -2885,8 +2885,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
         if (!strcmp(infoField->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
             // Algorithm type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
-            ASSERT_STREQ(infoField->fieldValue.stringValue,
-                         VecSimCommonStrings::TIERED_STRING);
+            ASSERT_STREQ(infoField->fieldValue.stringValue, VecSimCommonStrings::TIERED_STRING);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TYPE_STRING)) {
             // Vector type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -2936,7 +2936,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::BACKEND_INDEX_STRING)) {
             ASSERT_EQ(infoField->fieldType, INFOFIELD_ITERATOR);
             compareHNSWIndexInfoToIterator(backendIndexInfo, infoField->fieldValue.iteratorValue);
-        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TIERED_BUFFER_LIMIT)) {
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TIERED_BUFFER_LIMIT_STRING)) {
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
             ASSERT_EQ(infoField->fieldValue.uintegerValue, info.tieredInfo.bufferLimit);
         } else if (!strcmp(infoField->fieldName,

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -2756,19 +2756,19 @@ TYPED_TEST(HNSWTieredIndexTest, testInfo) {
     VecSimParams hnsw_params = CreateParams(params);
     auto jobQ = JobQueue();
     auto index_ctx = new IndexExtCtx();
-    auto *tiered_index = this->CreateTieredHNSWIndex(hnsw_params, &jobQ, index_ctx, 1);
+    auto *tiered_index = this->CreateTieredHNSWIndex(hnsw_params, &jobQ, index_ctx, 1, 1000);
     auto allocator = tiered_index->getAllocator();
 
     VecSimIndexInfo info = tiered_index->info();
-    EXPECT_EQ(info.algo, VecSimAlgo_TIERED);
+    EXPECT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_TIERED);
     EXPECT_EQ(info.commonInfo.indexSize, 0);
     EXPECT_EQ(info.commonInfo.indexLabelCount, 0);
     EXPECT_EQ(info.commonInfo.memory, tiered_index->getAllocationSize());
-    EXPECT_EQ(info.commonInfo.isMulti, TypeParam::isMulti());
-    EXPECT_EQ(info.commonInfo.dim, dim);
-    EXPECT_EQ(info.commonInfo.metric, VecSimMetric_L2);
-    EXPECT_EQ(info.commonInfo.type, TypeParam::get_index_type());
-    EXPECT_EQ(info.commonInfo.blockSize, INVALID_INFO);
+    EXPECT_EQ(info.commonInfo.basicInfo.isMulti, TypeParam::isMulti());
+    EXPECT_EQ(info.commonInfo.basicInfo.dim, dim);
+    EXPECT_EQ(info.commonInfo.basicInfo.metric, VecSimMetric_L2);
+    EXPECT_EQ(info.commonInfo.basicInfo.type, TypeParam::get_index_type());
+    EXPECT_EQ(info.commonInfo.basicInfo.blockSize, INVALID_INFO);
     VecSimIndexInfo frontendIndexInfo = tiered_index->frontendIndex->info();
     VecSimIndexInfo backendIndexInfo = tiered_index->backendIndex->info();
 
@@ -2781,6 +2781,18 @@ TYPED_TEST(HNSWTieredIndexTest, testInfo) {
                                           backendIndexInfo.commonInfo.memory +
                                           frontendIndexInfo.commonInfo.memory);
     EXPECT_EQ(info.tieredInfo.backgroundIndexing, false);
+    EXPECT_EQ(info.tieredInfo.bufferLimit, 1000);
+    EXPECT_EQ(info.tieredInfo.specificTieredBackendInfo.hnswTieredInfo.pendingSwapJobsThreshold, 1);
+
+    // Validate that Static info returns the right restricted info as well.
+    VecSimIndexStaticInfo s_info = VecSimIndex_StaticInfo(tiered_index);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, s_info.algo);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, s_info.dim);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, s_info.blockSize);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    ASSERT_EQ(info.commonInfo.basicInfo.isMulti, s_info.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    ASSERT_EQ(VecSimAlgo_HNSWLIB, s_info.tieredBackendAlgo);
 
     GenerateAndAddVector(tiered_index, dim, 1, 1);
     info = tiered_index->info();
@@ -2865,7 +2877,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
     VecSimIndexInfo backendIndexInfo = tiered_index->backendIndex->info();
 
     VecSimInfoIterator *infoIterator = tiered_index->infoIterator();
-    EXPECT_EQ(infoIterator->numberOfFields(), 13);
+    EXPECT_EQ(infoIterator->numberOfFields(), 15);
 
     while (infoIterator->hasNext()) {
         VecSim_InfoField *infoField = VecSimInfoIterator_NextField(infoIterator);
@@ -2873,21 +2885,22 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
         if (!strcmp(infoField->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
             // Algorithm type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
-            ASSERT_STREQ(infoField->fieldValue.stringValue, VecSimAlgo_ToString(info.algo));
+            ASSERT_STREQ(infoField->fieldValue.stringValue,
+                         VecSimAlgo_ToString(info.commonInfo.basicInfo.algo));
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TYPE_STRING)) {
             // Vector type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
             ASSERT_STREQ(infoField->fieldValue.stringValue,
-                         VecSimType_ToString(info.commonInfo.type));
+                         VecSimType_ToString(info.commonInfo.basicInfo.type));
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::DIMENSION_STRING)) {
             // Vector dimension.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
-            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.dim);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.dim);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::METRIC_STRING)) {
             // Metric.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
             ASSERT_STREQ(infoField->fieldValue.stringValue,
-                         VecSimMetric_ToString(info.commonInfo.metric));
+                         VecSimMetric_ToString(info.commonInfo.basicInfo.metric));
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::SEARCH_MODE_STRING)) {
             // Search mode.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
@@ -2904,7 +2917,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::IS_MULTI_STRING)) {
             // Is the index multi value.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
-            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.isMulti);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.isMulti);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::MEMORY_STRING)) {
             // Memory.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
@@ -2923,6 +2936,15 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::BACKEND_INDEX_STRING)) {
             ASSERT_EQ(infoField->fieldType, INFOFIELD_ITERATOR);
             compareHNSWIndexInfoToIterator(backendIndexInfo, infoField->fieldValue.iteratorValue);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TIERED_BUFFER_LIMIT)) {
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.tieredInfo.bufferLimit);
+        } else if (!strcmp(infoField->fieldName,
+                           VecSimCommonStrings::TIERED_HNSW_SWAP_JOBS_THRESHOLD_STRING)) {
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(
+                infoField->fieldValue.uintegerValue,
+                info.tieredInfo.specificTieredBackendInfo.hnswTieredInfo.pendingSwapJobsThreshold);
         } else {
             FAIL();
         }

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -2760,7 +2760,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfo) {
     auto allocator = tiered_index->getAllocator();
 
     VecSimIndexInfo info = tiered_index->info();
-    EXPECT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_TIERED);
+    EXPECT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
     EXPECT_EQ(info.commonInfo.indexSize, 0);
     EXPECT_EQ(info.commonInfo.indexLabelCount, 0);
     EXPECT_EQ(info.commonInfo.memory, tiered_index->getAllocationSize());
@@ -2768,7 +2768,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfo) {
     EXPECT_EQ(info.commonInfo.basicInfo.dim, dim);
     EXPECT_EQ(info.commonInfo.basicInfo.metric, VecSimMetric_L2);
     EXPECT_EQ(info.commonInfo.basicInfo.type, TypeParam::get_index_type());
-    EXPECT_EQ(info.commonInfo.basicInfo.blockSize, INVALID_INFO);
+    EXPECT_EQ(info.commonInfo.basicInfo.blockSize, DEFAULT_BLOCK_SIZE);
     VecSimIndexInfo frontendIndexInfo = tiered_index->frontendIndex->info();
     VecSimIndexInfo backendIndexInfo = tiered_index->backendIndex->info();
 
@@ -2785,14 +2785,14 @@ TYPED_TEST(HNSWTieredIndexTest, testInfo) {
     EXPECT_EQ(info.tieredInfo.specificTieredBackendInfo.hnswTieredInfo.pendingSwapJobsThreshold, 1);
 
     // Validate that Static info returns the right restricted info as well.
-    VecSimIndexStaticInfo s_info = VecSimIndex_StaticInfo(tiered_index);
+    VecSimIndexBasicInfo s_info = VecSimIndex_BasicInfo(tiered_index);
     ASSERT_EQ(info.commonInfo.basicInfo.algo, s_info.algo);
     ASSERT_EQ(info.commonInfo.basicInfo.dim, s_info.dim);
     ASSERT_EQ(info.commonInfo.basicInfo.blockSize, s_info.blockSize);
     ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
     ASSERT_EQ(info.commonInfo.basicInfo.isMulti, s_info.isMulti);
     ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
-    ASSERT_EQ(VecSimAlgo_HNSWLIB, s_info.tieredBackendAlgo);
+    ASSERT_EQ(info.commonInfo.basicInfo.isTiered, s_info.isTiered);
 
     GenerateAndAddVector(tiered_index, dim, 1, 1);
     info = tiered_index->info();

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -2886,7 +2886,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
             // Algorithm type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
             ASSERT_STREQ(infoField->fieldValue.stringValue,
-                         VecSimAlgo_ToString(info.commonInfo.basicInfo.algo));
+                         VecSimCommonStrings::TIERED_STRING);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TYPE_STRING)) {
             // Vector type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -110,13 +110,13 @@ void runBatchIteratorSearchTest(VecSimBatchIterator *batch_iterator, size_t n_re
 }
 
 void compareCommonInfo(CommonInfo info1, CommonInfo info2) {
-    ASSERT_EQ(info1.dim, info2.dim);
-    ASSERT_EQ(info1.metric, info2.metric);
+    ASSERT_EQ(info1.basicInfo.dim, info2.basicInfo.dim);
+    ASSERT_EQ(info1.basicInfo.metric, info2.basicInfo.metric);
     ASSERT_EQ(info1.indexSize, info2.indexSize);
-    ASSERT_EQ(info1.type, info2.type);
+    ASSERT_EQ(info1.basicInfo.type, info2.basicInfo.type);
     ASSERT_EQ(info1.memory, info2.memory);
-    ASSERT_EQ(info1.blockSize, info2.blockSize);
-    ASSERT_EQ(info1.isMulti, info2.isMulti);
+    ASSERT_EQ(info1.basicInfo.blockSize, info2.basicInfo.blockSize);
+    ASSERT_EQ(info1.basicInfo.isMulti, info2.basicInfo.isMulti);
     ASSERT_EQ(info1.last_mode, info2.last_mode);
     ASSERT_EQ(info1.indexLabelCount, info2.indexLabelCount);
 }
@@ -164,21 +164,22 @@ void compareFlatIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
         if (!strcmp(infoField->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
             // Algorithm type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
-            ASSERT_STREQ(infoField->fieldValue.stringValue, VecSimAlgo_ToString(info.algo));
+            ASSERT_STREQ(infoField->fieldValue.stringValue,
+                         VecSimAlgo_ToString(info.commonInfo.basicInfo.algo));
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TYPE_STRING)) {
             // Vector type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
             ASSERT_STREQ(infoField->fieldValue.stringValue,
-                         VecSimType_ToString(info.commonInfo.type));
+                         VecSimType_ToString(info.commonInfo.basicInfo.type));
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::DIMENSION_STRING)) {
             // Vector dimension.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
-            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.dim);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.dim);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::METRIC_STRING)) {
             // Metric.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
             ASSERT_STREQ(infoField->fieldValue.stringValue,
-                         VecSimMetric_ToString(info.commonInfo.metric));
+                         VecSimMetric_ToString(info.commonInfo.basicInfo.metric));
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::SEARCH_MODE_STRING)) {
             // Search mode.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
@@ -195,11 +196,11 @@ void compareFlatIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::IS_MULTI_STRING)) {
             // Is the index multi value.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
-            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.isMulti);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.isMulti);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::BLOCK_SIZE_STRING)) {
             // Block size.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
-            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.blockSize);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.blockSize);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::MEMORY_STRING)) {
             // Memory.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
@@ -217,21 +218,22 @@ void compareHNSWIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
         if (!strcmp(infoField->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
             // Algorithm type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
-            ASSERT_STREQ(infoField->fieldValue.stringValue, VecSimAlgo_ToString(info.algo));
+            ASSERT_STREQ(infoField->fieldValue.stringValue,
+                         VecSimAlgo_ToString(info.commonInfo.basicInfo.algo));
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TYPE_STRING)) {
             // Vector type.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
             ASSERT_STREQ(infoField->fieldValue.stringValue,
-                         VecSimType_ToString(info.commonInfo.type));
+                         VecSimType_ToString(info.commonInfo.basicInfo.type));
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::DIMENSION_STRING)) {
             // Vector dimension.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
-            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.dim);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.dim);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::METRIC_STRING)) {
             // Metric.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
             ASSERT_STREQ(infoField->fieldValue.stringValue,
-                         VecSimMetric_ToString(info.commonInfo.metric));
+                         VecSimMetric_ToString(info.commonInfo.basicInfo.metric));
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::SEARCH_MODE_STRING)) {
             // Search mode.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
@@ -248,7 +250,7 @@ void compareHNSWIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::IS_MULTI_STRING)) {
             // Is the index multi value.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
-            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.isMulti);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.isMulti);
         } else if (!strcmp(infoField->fieldName,
                            VecSimCommonStrings::HNSW_EF_CONSTRUCTION_STRING)) {
             // EF construction.
@@ -281,7 +283,7 @@ void compareHNSWIndexInfoToIterator(VecSimIndexInfo info, VecSimInfoIterator *in
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::BLOCK_SIZE_STRING)) {
             // Block size.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
-            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.blockSize);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.blockSize);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::HNSW_NUM_MARKED_DELETED)) {
             // Number of marked deleted.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);


### PR DESCRIPTION
**Describe the changes in the pull request**

Split some index meta-data from the unified info struct, and add `VecSimIndex_StaticInfo` API to retrieve these fields alone. The motivation for that is to avoid heavy computation and locking that may occur when calling `VecSimIndex_Info`, since today, in the tiered index, this includes computing the number of labels in the tiered index that includes going over both sub-indices labels-set while holding a lock. So now we can replace the call for `VecSimIndex_Info` upon resolving query params and creating a vector iterator in RediSearch, and remove this bottleneck.

Also,  add additional 2 fields for tiered index - buffer limit and swap jobs threshold.

**Mark if applicable**

- [ X ] This PR introduces API changes
- [ ] This PR introduces serialization changes
