### PR TITLE
Provide GPU-accelerated vector indexes with RAFT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 3.10)
+option(USE_CUDA "Build Cuda code" On)
+if(USE_CUDA)
+  cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
+else()
+  cmake_minimum_required(VERSION 3.10)
+endif()
 cmake_policy(SET CMP0077 NEW)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -23,6 +28,18 @@ include(cmake/san.cmake)
 
 # ----------------------------------------------------------------------------------------------
 project(VectorSimilarity)
+
+if (USE_CUDA)
+    # Enable CUDA compilation for this project
+    enable_language(CUDA)
+ 	# Add definition for conditional compilation of CUDA components
+	add_definitions(-DUSE_CUDA)
+    # Perform all RAFT-specific CMake setup
+	include(cmake/raft.cmake)
+    # Required flags for compiling RAFT
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3 -std=c++17")
+endif()
 
 # Only do these if this is the main project, and not if it is included through add_subdirectory
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 option(USE_CUDA "Build Cuda code" On)
 if(USE_CUDA)
-  cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
+  cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 else()
   cmake_minimum_required(VERSION 3.10)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 # Only do these if this is the main project, and not if it is included through add_subdirectory
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions -fPIC ${CLANG_SAN_FLAGS} ${LLVM_CXX_FLAGS} ${COV_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions -fPIC -pthread ${CLANG_SAN_FLAGS} ${LLVM_CXX_FLAGS} ${COV_CXX_FLAGS}")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${LLVM_LD_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${LLVM_LD_FLAGS}")
 

--- a/check-format.sh
+++ b/check-format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-CLANG_FMT_SRCS=$(find ./src/ \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))
-CLANG_FMT_TESTS="$(find ./tests/ -type d \( -path ./tests/unit/build \) -prune -false -o  \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))"
+CLANG_FMT_SRCS=$(find ./src/ \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.cuh' -o -name '*.cu' \))
+CLANG_FMT_TESTS="$(find ./tests/ -type d \( -path ./tests/unit/build \) -prune -false -o  \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.cuh' -o -name '*.cu' \))"
 
 E=0
 for filename in $CLANG_FMT_SRCS $CLANG_FMT_TESTS; do

--- a/cmake/raft.cmake
+++ b/cmake/raft.cmake
@@ -1,0 +1,81 @@
+if(USE_CUDA)
+	# Set which version of RAPIDS to use
+	set(RAPIDS_VERSION 23.08)
+	# Set which version of RAFT to use (defined separately for testing
+	# minimal dependency changes if necessary)
+	set(RAFT_VERSION "${RAPIDS_VERSION}")
+	set(RAFT_FORK "rapidsai")
+	set(RAFT_PINNED_TAG "branch-${RAPIDS_VERSION}")
+
+	# Download CMake file for bootstrapping RAPIDS-CMake, a utility that
+	# simplifies handling of complex RAPIDS dependencies
+	if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/<PROJ>_RAPIDS.cmake)
+		file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION}/<PROJ>_RAPIDS.cmake
+			${CMAKE_CURRENT_BINARY_DIR}/<PROJ>_RAPIDS.cmake)
+	endif()
+	include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+
+	# General tool for orchestrating RAPIDS dependencies
+	include(rapids-cmake)
+	# CPM helper functions with dependency tracking
+	include(rapids-cpm)
+	rapids_cpm_init()
+	# Common CMake CUDA logic
+	include(rapids-cuda)
+	# Include required dependencies in Project-Config.cmake modules
+	# include(rapids-export)  TODO(wphicks)
+	# Functions to find system dependencies with dependency tracking
+	include(rapids-find)
+
+	# Correctly handle supported CUDA architectures
+	#    (From rapids-cuda)
+	rapids_cuda_init_architectures(VectorSimilarity)
+
+	# Find system CUDA toolkit
+	rapids_find_package(CUDAToolkit REQUIRED)
+
+	set(RAFT_VERSION "${RAPIDS_VERSION}")
+	set(RAFT_FORK "rapidsai")
+	set(RAFT_PINNED_TAG "branch-${RAPIDS_VERSION}")
+	
+	function(find_and_configure_raft)
+		set(oneValueArgs VERSION FORK PINNED_TAG COMPILE_LIBRARY)
+		cmake_parse_arguments(PKG "${options}" "${oneValueArgs}"
+			"${multiValueArgs}" ${ARGN} )
+	
+	    set(RAFT_COMPONENTS "")
+	    if(PKG_COMPILE_LIBRARY)
+			string(APPEND RAFT_COMPONENTS " compiled")
+	    endif()
+	    # Invoke CPM find_package()
+		#     (From rapids-cpm)
+	    rapids_cpm_find(raft ${PKG_VERSION}
+			GLOBAL_TARGETS      raft::raft
+			BUILD_EXPORT_SET    VectorSimilarity-exports
+			INSTALL_EXPORT_SET  VectorSimilarity-exports
+			COMPONENTS          ${RAFT_COMPONENTS}
+			CPM_ARGS
+			GIT_REPOSITORY https://github.com/${PKG_FORK}/raft.git
+			GIT_TAG        ${PKG_PINNED_TAG}
+			SOURCE_SUBDIR  cpp
+			OPTIONS
+			"BUILD_TESTS OFF"
+			"BUILD_BENCH OFF"
+			"RAFT_COMPILE_LIBRARY ${PKG_COMPILE_LIBRARY}"
+		)
+		if(raft_ADDED)
+			message(VERBOSE "VectorSimilarity: Using RAFT located in ${raft_SOURCE_DIR}")
+		else()
+			message(VERBOSE "VectorSimilarity: Using RAFT located in ${raft_DIR}")
+		endif()
+	endfunction()
+	
+	# Change pinned tag here to test a commit in CI
+	# To use a different RAFT locally, set the CMake variable
+	# CPM_raft_SOURCE=/path/to/local/raft
+	find_and_configure_raft(VERSION    ${RAFT_VERSION}.00
+		FORK             ${RAFT_FORK}
+		PINNED_TAG       ${RAFT_PINNED_TAG}
+		COMPILE_LIBRARY  OFF
+	)
+endif()

--- a/cmake/raft.cmake
+++ b/cmake/raft.cmake
@@ -1,11 +1,15 @@
 if(USE_CUDA)
 	# Set which version of RAPIDS to use
-	set(RAPIDS_VERSION 23.06)
+	set(RAPIDS_VERSION 23.10)
 	# Set which version of RAFT to use (defined separately for testing
 	# minimal dependency changes if necessary)
 	set(RAFT_VERSION "${RAPIDS_VERSION}")
-	set(RAFT_FORK "rapidsai")
-	set(RAFT_PINNED_TAG "branch-${RAPIDS_VERSION}")
+    # TODO(wphicks): Reset to main fork and branch after
+    # https://github.com/rapidsai/raft/pull/1716 has been merged
+    # set(RAFT_FORK "rapidsai")
+    set(RAFT_FORK "wphicks")
+    # set(RAFT_PINNED_TAG "branch-${RAPIDS_VERSION}")
+    set(RAFT_PINNED_TAG "fea-resource_manager")
 
 	# Download CMake file for bootstrapping RAPIDS-CMake, a utility that
 	# simplifies handling of complex RAPIDS dependencies

--- a/cmake/raft.cmake
+++ b/cmake/raft.cmake
@@ -1,6 +1,6 @@
 if(USE_CUDA)
 	# Set which version of RAPIDS to use
-	set(RAPIDS_VERSION 23.08)
+	set(RAPIDS_VERSION 23.06)
 	# Set which version of RAFT to use (defined separately for testing
 	# minimal dependency changes if necessary)
 	set(RAFT_VERSION "${RAPIDS_VERSION}")
@@ -9,11 +9,11 @@ if(USE_CUDA)
 
 	# Download CMake file for bootstrapping RAPIDS-CMake, a utility that
 	# simplifies handling of complex RAPIDS dependencies
-	if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/<PROJ>_RAPIDS.cmake)
-		file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION}/<PROJ>_RAPIDS.cmake
-			${CMAKE_CURRENT_BINARY_DIR}/<PROJ>_RAPIDS.cmake)
+	if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+		file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION}/RAPIDS.cmake
+			${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
 	endif()
-	include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+    include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
 
 	# General tool for orchestrating RAPIDS dependencies
 	include(rapids-cmake)

--- a/src/VecSim/CMakeLists.txt
+++ b/src/VecSim/CMakeLists.txt
@@ -32,9 +32,15 @@ add_library(VectorSimilarity ${VECSIM_LIBTYPE}
     ${HEADER_LIST}
 )
 
-target_link_libraries(VectorSimilarity VectorSimilaritySpaces)
 
 if(VECSIM_BUILD_TESTS)
     add_library(VectorSimilaritySerializer utils/serializer.cpp)
-    target_link_libraries(VectorSimilarity VectorSimilaritySerializer)
 endif()
+
+target_link_libraries(VectorSimilarity
+PUBLIC
+	VectorSimilaritySpaces
+	$<$<BOOL:${VECSIM_BUILD_TESTS}>:VectorSimilaritySerializer>
+PRIVATE
+	$<$<BOOL:${USE_CUDA}>:raft::raft>
+)

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -35,6 +35,11 @@ protected:
 public:
     BruteForceIndex(const BFParams *params, const AbstractIndexInitParams &abstractInitParams);
 
+    void clear() {
+      idToLabelMapping.clear();
+      vectorBlocks.clear();
+      count = idType{};
+    }
     size_t indexSize() const override;
     size_t indexCapacity() const override;
     vecsim_stl::vector<DistType> computeBlockScores(const DataBlock &block, const void *queryBlob,

--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -36,9 +36,9 @@ public:
     BruteForceIndex(const BFParams *params, const AbstractIndexInitParams &abstractInitParams);
 
     void clear() {
-      idToLabelMapping.clear();
-      vectorBlocks.clear();
-      count = idType{};
+        idToLabelMapping.clear();
+        vectorBlocks.clear();
+        count = idType{};
     }
     size_t indexSize() const override;
     size_t indexCapacity() const override;

--- a/src/VecSim/algorithms/ivf/ivf.cuh
+++ b/src/VecSim/algorithms/ivf/ivf.cuh
@@ -1,0 +1,342 @@
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <cuda_runtime.h>
+#include <library_types.h>
+#include "VecSim/vec_sim.h"
+// For VecSimMetric, IVFParams, labelType
+#include "VecSim/vec_sim_common.h"
+// For VecSimIndexAbstract
+#include "VecSim/vec_sim_index.h"
+#include "VecSim/query_result_struct.h"
+#include "VecSim/memory/vecsim_malloc.h"
+
+#include <raft/core/device_resources.hpp>
+#include <raft/core/error.hpp>
+#include <raft/distance/distance_types.hpp>
+#include <raft/neighbors/ivf_flat.cuh>
+#include <raft/neighbors/ivf_flat_types.hpp>
+#include <raft/neighbors/ivf_pq.cuh>
+#include <raft/neighbors/ivf_pq_types.hpp>
+
+#pragma once
+
+inline auto constexpr GetRaftDistanceType(VecSimMetric vsm) {
+    auto result = raft::distance::DistanceType{};
+    switch (vsm) {
+      case VecSimMetric_L2:
+        result = raft::distance::DistanceType::L2Expanded;
+        break;
+      case VecSimMetric_IP:
+        result = raft::distance::DistanceType::InnerProduct;
+        break;
+      default:
+        throw raft::exception("Metric not supported");
+    }
+    return result;
+}
+
+inline auto constexpr GetRaftCodebookKind(IVFPQCodebookKind vss_codebook) {
+  auto result = raft::neighbors::ivf_pq::codebook_gen{};
+  switch(vss_codebook) {
+    case  IVFPQCodebookKind_PerCluster:
+      result = raft::neighbors::ivf_pq::codebook_gen::PER_CLUSTER;
+      break;
+    case IVFPQCodebookKind_PerSubspace:
+      result = raft::neighbors::ivf_pq::codebook_gen::PER_SUBSPACE;
+      break;
+    default:
+      throw raft::exception("Unexpected IVFPQ codebook kind");
+  }
+  return result;
+}
+
+inline auto constexpr GetCudaType(CudaType vss_type) {
+  auto result = cudaDataType_t{};
+  switch(vss_type) {
+    case  CUDAType_R_32F:
+      result = CUDA_R_32F;
+      break;
+    case CUDAType_R_16F:
+      result = CUDA_R_16F;
+      break;
+    case CUDAType_R_8U:
+      result = CUDA_R_8U;
+      break;
+    default:
+      throw raft::exception("Unexpected CUDA type");
+  }
+  return result;
+}
+
+template <typename DataType, typename DistType=DataType>
+struct IVFIndex : public VecSimIndexAbstract<DistType> {
+    using data_type = DataType;
+    using dist_type = DistType;
+
+private:
+    // Allow either IVF-flat or IVFPQ parameters
+    using build_params_t = std::variant<raft::neighbors::ivf_flat::index_params, raft::neighbors::ivf_pq::index_params>;
+    using search_params_t = std::variant<raft::neighbors::ivf_flat::search_params, raft::neighbors::ivf_pq::search_params>;
+    using internal_idx_t = std::uint32_t;
+    using ann_index_t = std::variant<raft::neighbors::ivf_flat::index<data_type, internal_idx_t>, raft::neighbors::ivf_pq::index<internal_idx_t>>;
+
+public:
+    IVFIndex(const IVFParams *ivfParams, const AbstractIndexInitParams & commonParams)
+        : VecSimIndexAbstract<dist_type>{commonParams},
+          res_{}, //TODO(wphicks): Construct smartly
+          build_params_{[ivfParams](){
+            auto result = ivfParams->pqBits > 0 ?
+              build_params_t{std::in_place_index<1>} : 
+              build_params_t{std::in_place_index<0>};
+            std::visit(
+              [ivfParams](auto&& inner) {
+                inner.metric = GetRaftDistanceType(ivfParams->metric);
+                inner.n_lists = ivfParams->nLists;
+                inner.kmeans_n_iters = ivfParams->kmeans_nIters;
+                inner.kmeans_trainset_fraction = ivfParams->kmeans_trainsetFraction;
+                inner.conservative_memory_allocation = ivfParams->conservativeMemoryAllocation;
+                if constexpr (std::is_same_v<decltype(inner), raft::neighbors::ivf_pq::index_params>) {
+                  inner.pq_bits = ivfParams->pqBits;
+                  inner.pq_dim = ivfParams->pqDim;
+                  inner.codebook_kind = GetRaftCodebookKind(ivfParams->codebookKind);
+                } else {
+                  inner.adaptive_centers = ivfParams->adaptiveCenters;
+                }
+              }, result
+            );
+            return result;
+          }()},
+          search_params_{[ivfParams](){
+            auto result = ivfParams->pqBits > 0 ?
+              search_params_t{std::in_place_index<1>} : 
+              search_params_t{std::in_place_index<0>};
+            std::visit(
+              [ivfParams](auto&& inner) {
+                inner.n_probes = ivfParams->nProbes;
+                if constexpr (std::is_same_v<decltype(inner), raft::neighbors::ivf_pq::search_params>) {
+                  inner.lut_dtype = GetCudaType(ivfParams->lutType);
+                  inner.internal_distance_dtype = GetCudaType(ivfParams->internalDistanceType);
+                  inner.preferred_shmem_carvout = ivfParams->preferredShmemCarveout;
+                }
+              }, result
+            );
+            return result;
+          }()},
+          index_{std::nullopt}
+          {}
+    auto addVector(const void *vector_data, labelType label,
+                  bool overwrite_allowed = true) override {
+        return addVectorBatch(vector_data, &label, 1, overwrite_allowed);
+    }
+    auto addVectorBatch(const void *vector_data, labelType *label, size_t batch_size,
+                       bool overwrite_allowed = true) {
+      // Allocate memory on device to hold vectors to be added
+      auto vector_data_gpu =
+          raft::make_device_matrix<data_type, internal_idx_t>(res_, batch_size,
+              this->dim);
+      // Allocate memory on device to hold vector labels
+      auto label_gpu = raft::make_device_vector<labelType>(
+        res_,
+        batch_size
+      );
+
+      // Copy vector data to previously allocated device buffer
+      raft::copy(
+        vector_data_gpu.data_handle(),
+        static_cast<DataType const*>(vector_data),
+        this->dim * batch_size,
+        res_.get_stream()
+      );
+      // Copy label data to previously allocated device buffer
+      raft::copy(
+        label_gpu.data_handle(),
+        label,
+        batch_size,
+        res_.get_stream()
+      );
+
+      if (std::holds_alternative<raft::neighbors::ivf_flat::index_params>(build_params_)) {
+        if (!index_) {
+          index_ = raft::neighbors::ivf_flat::build(
+            res_,
+            std::get<raft::neighbors::ivf_flat::index_params>(build_params_),
+            vector_data_gpu.view()
+          );
+        }
+        raft::neighbors::ivf_flat::extend(
+          res_,
+          vector_data_gpu.view(),
+          label_gpu,
+          *index_
+        );
+      } else {
+        if (!index_) {
+          index_ = raft::neighbors::ivf_pq::build(
+            res_,
+            std::get<raft::neighbors::ivf_pq::index_params>(build_params_),
+            vector_data_gpu.view()
+          );
+        }
+        raft::neighbors::ivf_pq::extend(
+          res_,
+          vector_data_gpu.view(),
+          label_gpu,
+          *index_
+        );
+      }
+
+      // Ensure that above operations have executed on device before
+      // returning from this function on host
+      res_.sync_stream();
+      return batch_size;
+    }
+    auto deleteVector(labelType label) override {
+        assert(!"deleteVector not implemented");
+        return 0;
+    }
+    double getDistanceFrom(labelType label, const void *vector_data) const override {
+        assert(!"getDistanceFrom not implemented");
+        return INVALID_SCORE;
+    }
+    size_t indexCapacity() const override {
+        assert(!"indexCapacity not implemented");
+        return 0;
+    }
+    void increaseCapacity() override {
+        assert(!"increaseCapacity not implemented");
+    }
+    inline auto indexLabelCount() const override {
+        return this->indexSize(); // TODO: Return unique counts
+    }
+    auto topKQuery(const void *queryBlob, size_t k,
+                                     VecSimQueryParams *queryParams) override {
+      auto result_list = VecSimQueryResult_List{0};
+      auto nVectors = this->indexSize();
+      if (nVectors == 0) {
+          result_list.results = array_new<VecSimQueryResult>(0);
+      } else {
+        // Ensure we are not trying to retrieve more vectors than exist in the
+        // index
+        k = std::min(k, nVectors);
+        // Allocate memory on device for search vector
+        auto vector_data_gpu = raft::make_device_matrix<data_type>(res_,1, this->dim);
+        // Allocate memory on device for neighbor results
+        auto neighbors_gpu = raft::make_device_vector<labelType>(res_, k);
+        // Allocate memory on device for distance results
+        auto distances_gpu = raft::make_device_vector<dist_type>(res_, k);
+        // Copy query vector to device
+        raft::copy(
+          vector_data_gpu.data_handle(),
+          static_cast<data_type>(queryBlob),
+          this->dim,
+          res_.get_stream()
+        );
+
+        // Perform correct search based on index type
+        if (
+          std::holds_alternative<raft::neighbors::ivf_flat::index>(index_)
+        ) {
+          raft::neighbors::ivf_flat::search<data_type, internal_idx_t>(
+            res_,
+            std::get<raft::neighbors::ivf_flat::search_params>(search_params_),
+            std::get<raft::neighbors::ivf_flat::index>(*index_),
+            vector_data_gpu.view(),
+            neighbors_gpu.view(),
+            distances_gpu.view()
+          )
+        } else {
+          raft::neighbors::ivf_pq::search<data_type, internal_idx_t>(
+            res_,
+            std::get<raft::neighbors::ivf_flat::search_params>(search_params_),
+            std::get<raft::neighbors::ivf_flat::index>(*index_),
+            vector_data_gpu.view(),
+            neighbors_gpu.view(),
+            distances_gpu.view()
+          )
+        }
+
+        // Allocate host buffers to hold returned results
+        auto neighbors = std::unique_ptr(
+            array_new_len<labelType>(k, k),
+            &array_free<labelType>
+        );
+        auto distances = std::unique_ptr(
+            array_new_len<dist_type>(k, k),
+            &array_free<dist_type>
+        );
+        // Copy data back from device to host
+        raft::copy(
+          neighbors.get(),
+          neighbors_gpu.data_handle(),
+          this->dim,
+          res_.get_stream()
+        );
+        raft::copy(
+          distances.get(),
+          distances_gpu.data_handle(),
+          this->dim,
+          res_.get_stream()
+        );
+
+        result_list.results = array_new_len<VecSimQueryResult>(k, k);
+
+        // Ensure search is complete and data have been copied back before
+        // building query result objects on host
+        res_.sync_stream();
+        for (size_t i = 0; i < k; ++i) {
+            VecSimQueryResult_SetId(result_list.results[i], neighbors[i]);
+            VecSimQueryResult_SetScore(result_list.results[i], distances[i]);
+        }
+      }
+      return result_list;
+    }
+
+    VecSimQueryResult_List rangeQuery(const void *queryBlob, double radius,
+                                      VecSimQueryParams *queryParams) override {
+        assert(!"RangeQuery not implemented");
+    }
+    VecSimInfoIterator *infoIterator() const override { assert(!"infoIterator not implemented"); }
+    virtual VecSimBatchIterator *newBatchIterator(const void *queryBlob,
+                                                  VecSimQueryParams *queryParams) const override {
+        assert(!"newBatchIterator not implemented");
+    }
+    bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) override {
+        assert(!"preferAdHocSearch not implemented");
+    }
+
+    auto& get_resources() const { return res_; }
+
+    auto nLists() {
+      return std::visit([](auto&& params) {
+        return params.n_list;
+      }, build_params_);
+    }
+
+    auto indexSize() {
+      auto result = size_t{};
+      if (index_) {
+        result = std::visit([](auto&& index) {
+          return index.size();
+        }, *index_);
+      }
+      return result;
+    }
+
+  private:
+    // An object used to manage common device resources that may be
+    // expensive to build but frequently accessed
+    raft::device_resources res_;
+    // Store build params to allow for index build on first batch
+    // insertion
+    build_params_t build_params_;
+    // Store search params to use with each search after initializing in
+    // constructor
+    search_params_t search_params_;
+    // Use a std::optional to allow building of the index on first batch
+    // insertion
+    std::optional<ann_index_t> index_;
+};

--- a/src/VecSim/algorithms/ivf/ivf_tiered.cuh
+++ b/src/VecSim/algorithms/ivf/ivf_tiered.cuh
@@ -3,114 +3,83 @@
 #include "VecSim/vec_sim_tiered_index.h"
 
 struct RAFTTransferJob : public AsyncJob {
-  bool overwrite_allowed{true};
-  RAFTTransferJob(
-    std::shared_ptr<VecSimAllocator> allocator, bool overwrite_allowed_,
-    JobCallback insertCb,
-    VecSimIndex *index_
-  ) : AsyncJob{allocator, RAFT_TRANSFER_JOB, insertCb, index_},
-    overwrite_allowed{overwrite_allowed_} {}
+    bool overwrite_allowed{true};
+    RAFTTransferJob(std::shared_ptr<VecSimAllocator> allocator, bool overwrite_allowed_,
+                    JobCallback insertCb, VecSimIndex *index_)
+        : AsyncJob{allocator, RAFT_TRANSFER_JOB, insertCb, index_},
+          overwrite_allowed{overwrite_allowed_} {}
 };
 
 template <typename DataType, typename DistType>
 struct TieredIVFIndex : public VecSimTieredIndex<DataType, DistType> {
-  auto addVector(
-    const void* blob, labelType label, bool overwrite_allowed
-  ) {
-    auto frontend_lock = std::scoped_lock(this->flatIndexGuard);
-    auto result = this->frontendIndex->addVector(
-      blob, label, overwrite_allowed
-    );
-    if (this->frontendIndex->indexSize() >= this->flatBufferLimit) {
-      transferToBackend(overwrite_allowed);
-    }
-    return result;
-  }
-
-  auto deleteVector(labelType label) {
-    // TODO(wphicks)
-    // If in flatIndex, delete
-    // If being transferred to backend, wait for transfer
-    // If in backendIndex, delete
-  }
-
-  auto indexSize() {
-    auto frontend_lock = std::scoped_lock(this->flatIndexGuard);
-    auto backend_lock = std::scoped_lock(this->mainIndexGuard);
-    return (
-      getBackendIndex().indexSize() + this->frontendIndex.indexSize()
-    );
-  }
-
-  auto indexLabelCount() const override {
-    // TODO(wphicks) Count unique labels between both indexes
-  }
-
-  auto indexCapacity() const override {
-    return (
-      getBackendIndex().indexCapacity() +
-      this->flatBufferLimit
-    );
-  }
-
-  void increaseCapacity() override {
-    getBackendIndex().increaseCapacity();
-  }
-
-  auto getDistanceFrom(labelType label, const void* blob) {
-    auto frontend_lock = std::unique_lock(this->flatIndexGuard);
-    auto flat_dist = this->frontendIndex->getDistanceFrom(label, blob);
-    frontend_lock.unlock();
-    auto backend_lock = std::scoped_lock(this->mainIndexGuard);
-    auto raft_dist = getBackendIndex().getDistanceFrom(label, blob);
-    return std::fmin(flat_dist, raft_dist);
-  }
-
-  void executeTransferJob(RAFTTransferJob* job) {
-    transferToBackend(job->overwrite_allowed);
-  }
-
- private:
-  vecsim_stl::unordered_map<labelType, vecsim_stl::vector<RAFTTransferJob *>> labelToTransferJobs;
-  auto& getBackendIndex() {
-    return *dynamic_cast<IVFIndex<DataType, DistType>*>(
-      this->backendIndex
-    );
-  }
-
-  void transferToBackend(overwrite_allowed=true) {
-	auto dim = this->index->getDim();
-    auto frontend_lock = std::unique_lock(this->flatIndexGuard);
-	auto nVectors = this->flatBuffer->indexSize();
-	const auto &vectorBlocks = this->flatBuffer->getVectorBlocks();
-    auto vectorData = raft::make_host_matrix(
-      getBackendIndex().get_resources(),
-      nVectors,
-      dim
-    );
-
-    auto* out = vectorData.data_handle();
-    for (auto block_id = 0; block_id < vectorBlocks.size(); ++block_id) {
-      auto* in_begin = reinterpret_cast<DataType*>(
-        vectorBlocks[block_id].getElement(0)
-      );
-      auto length = vectorBlocks[block_id].getLength();
-      std::copy(
-        in_begin,
-        in_begin + length,
-        out
-      );
-      out += length;
+    auto addVector(const void *blob, labelType label, bool overwrite_allowed) {
+        auto frontend_lock = std::scoped_lock(this->flatIndexGuard);
+        auto result = this->frontendIndex->addVector(blob, label, overwrite_allowed);
+        if (this->frontendIndex->indexSize() >= this->flatBufferLimit) {
+            transferToBackend(overwrite_allowed);
+        }
+        return result;
     }
 
-    auto backend_lock = std::scoped_lock(this->mainIndexGuard);
-    this->flatBuffer->clear();
-    frontend_lock.unlock();
-    getBackendIndex().addVectorBatch(
-      vectorData.data_handle(),
-      this->flatBuffer->getLabels(),
-      nVectors,
-      overwrite_allowed
-    );
-  }
+    auto deleteVector(labelType label) {
+        // TODO(wphicks)
+        // If in flatIndex, delete
+        // If being transferred to backend, wait for transfer
+        // If in backendIndex, delete
+    }
+
+    auto indexSize() {
+        auto frontend_lock = std::scoped_lock(this->flatIndexGuard);
+        auto backend_lock = std::scoped_lock(this->mainIndexGuard);
+        return (getBackendIndex().indexSize() + this->frontendIndex.indexSize());
+    }
+
+    auto indexLabelCount() const override {
+        // TODO(wphicks) Count unique labels between both indexes
+    }
+
+    auto indexCapacity() const override {
+        return (getBackendIndex().indexCapacity() + this->flatBufferLimit);
+    }
+
+    void increaseCapacity() override { getBackendIndex().increaseCapacity(); }
+
+    auto getDistanceFrom(labelType label, const void *blob) {
+        auto frontend_lock = std::unique_lock(this->flatIndexGuard);
+        auto flat_dist = this->frontendIndex->getDistanceFrom(label, blob);
+        frontend_lock.unlock();
+        auto backend_lock = std::scoped_lock(this->mainIndexGuard);
+        auto raft_dist = getBackendIndex().getDistanceFrom(label, blob);
+        return std::fmin(flat_dist, raft_dist);
+    }
+
+    void executeTransferJob(RAFTTransferJob *job) { transferToBackend(job->overwrite_allowed); }
+
+private:
+    vecsim_stl::unordered_map<labelType, vecsim_stl::vector<RAFTTransferJob *>> labelToTransferJobs;
+    auto &getBackendIndex() {
+        return *dynamic_cast<IVFIndex<DataType, DistType> *>(this->backendIndex);
+    }
+
+    void transferToBackend(overwrite_allowed = true) {
+        auto dim = this->index->getDim();
+        auto frontend_lock = std::unique_lock(this->flatIndexGuard);
+        auto nVectors = this->flatBuffer->indexSize();
+        const auto &vectorBlocks = this->flatBuffer->getVectorBlocks();
+        auto vectorData = raft::make_host_matrix(getBackendIndex().get_resources(), nVectors, dim);
+
+        auto *out = vectorData.data_handle();
+        for (auto block_id = 0; block_id < vectorBlocks.size(); ++block_id) {
+            auto *in_begin = reinterpret_cast<DataType *>(vectorBlocks[block_id].getElement(0));
+            auto length = vectorBlocks[block_id].getLength();
+            std::copy(in_begin, in_begin + length, out);
+            out += length;
+        }
+
+        auto backend_lock = std::scoped_lock(this->mainIndexGuard);
+        this->flatBuffer->clear();
+        frontend_lock.unlock();
+        getBackendIndex().addVectorBatch(vectorData.data_handle(), this->flatBuffer->getLabels(),
+                                         nVectors, overwrite_allowed);
+    }
 };

--- a/src/VecSim/algorithms/ivf/ivf_tiered.cuh
+++ b/src/VecSim/algorithms/ivf/ivf_tiered.cuh
@@ -1,4 +1,116 @@
+#include <mutex>
+#include "VecSim/algorithms/ivf/ivf.cuh"
 #include "VecSim/vec_sim_tiered_index.h"
+
+struct RAFTTransferJob : public AsyncJob {
+  bool overwrite_allowed{true};
+  RAFTTransferJob(
+    std::shared_ptr<VecSimAllocator> allocator, bool overwrite_allowed_,
+    JobCallback insertCb,
+    VecSimIndex *index_
+  ) : AsyncJob{allocator, RAFT_TRANSFER_JOB, insertCb, index_},
+    overwrite_allowed{overwrite_allowed_} {}
+};
+
 template <typename DataType, typename DistType>
 struct TieredIVFIndex : public VecSimTieredIndex<DataType, DistType> {
+  auto addVector(
+    const void* blob, labelType label, bool overwrite_allowed
+  ) {
+    auto frontend_lock = std::scoped_lock(this->flatIndexGuard);
+    auto result = this->frontendIndex->addVector(
+      blob, label, overwrite_allowed
+    );
+    if (this->frontendIndex->indexSize() >= this->flatBufferLimit) {
+      transferToBackend(overwrite_allowed);
+    }
+    return result;
+  }
+
+  auto deleteVector(labelType label) {
+    // TODO(wphicks)
+    // If in flatIndex, delete
+    // If being transferred to backend, wait for transfer
+    // If in backendIndex, delete
+  }
+
+  auto indexSize() {
+    auto frontend_lock = std::scoped_lock(this->flatIndexGuard);
+    auto backend_lock = std::scoped_lock(this->mainIndexGuard);
+    return (
+      getBackendIndex().indexSize() + this->frontendIndex.indexSize()
+    );
+  }
+
+  auto indexLabelCount() const override {
+    // TODO(wphicks) Count unique labels between both indexes
+  }
+
+  auto indexCapacity() const override {
+    return (
+      getBackendIndex().indexCapacity() +
+      this->flatBufferLimit
+    );
+  }
+
+  void increaseCapacity() override {
+    getBackendIndex().increaseCapacity();
+  }
+
+  auto getDistanceFrom(labelType label, const void* blob) {
+    auto frontend_lock = std::unique_lock(this->flatIndexGuard);
+    auto flat_dist = this->frontendIndex->getDistanceFrom(label, blob);
+    frontend_lock.unlock();
+    auto backend_lock = std::scoped_lock(this->mainIndexGuard);
+    auto raft_dist = getBackendIndex().getDistanceFrom(label, blob);
+    return std::fmin(flat_dist, raft_dist);
+  }
+
+  void executeTransferJob(RAFTTransferJob* job) {
+    transferToBackend(job->overwrite_allowed);
+  }
+
+ private:
+  vecsim_stl::unordered_map<labelType, vecsim_stl::vector<RAFTTransferJob *>> labelToTransferJobs;
+  auto& getBackendIndex() {
+    return *dynamic_cast<IVFIndex<DataType, DistType>*>(
+      this->backendIndex
+    );
+  }
+
+  void transferToBackend(overwrite_allowed=true) {
+	auto dim = this->index->getDim();
+    auto frontend_lock = std::unique_lock(this->flatIndexGuard);
+	auto nVectors = this->flatBuffer->indexSize();
+	const auto &vectorBlocks = this->flatBuffer->getVectorBlocks();
+    auto vectorData = raft::make_host_matrix(
+      getBackendIndex().get_resources(),
+      nVectors,
+      dim
+    );
+
+    auto* out = vectorData.data_handle();
+    for (auto block_id = 0; block_id < vectorBlocks.size(); ++block_id) {
+      auto* in_begin = reinterpret_cast<DataType*>(
+        vectorBlocks[block_id].getElement(0)
+      );
+      auto length = vectorBlocks[block_id].getLength();
+      std::copy(
+        in_begin,
+        in_begin + length,
+        out
+      );
+      out += length;
+    }
+
+    auto backend_lock = std::scoped_lock(this->mainIndexGuard);
+    this->flatBuffer->clear();
+    frontend_lock.unlock();
+    getBackendIndex().addVectorBatch(
+      vectorData.data_handle(),
+      this->flatBuffer->getLabels(),
+      nVectors,
+      overwrite_allowed
+    );
+  }
 };

--- a/src/VecSim/algorithms/ivf/ivf_tiered.cuh
+++ b/src/VecSim/algorithms/ivf/ivf_tiered.cuh
@@ -1,0 +1,4 @@
+#include "VecSim/vec_sim_tiered_index.h"
+template <typename DataType, typename DistType>
+struct TieredIVFIndex : public VecSimTieredIndex<DataType, DistType> {
+};

--- a/src/VecSim/tombstone_interface.h
+++ b/src/VecSim/tombstone_interface.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stddef.h>
+#include <vector>
 #include "vec_sim_common.h"
 
 /*

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -194,6 +194,7 @@ typedef enum {
     HNSW_REPAIR_NODE_CONNECTIONS_JOB,
     HNSW_SEARCH_JOB,
     HNSW_SWAP_JOB,
+    RAFT_TRANSFER_JOB,
     INVALID_JOB // to indicate that finding a JobType >= INVALID_JOB is an error
 } JobType;
 

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -48,7 +48,6 @@ typedef enum { IVFPQCodebookKind_PerCluster, IVFPQCodebookKind_PerSubspace } IVF
 // CUDA types supported by GPU-accelerated indexes
 typedef enum { CUDAType_R_32F, CUDAType_R_16F, CUDAType_R_8U } CudaType;
 
-
 typedef size_t labelType;
 typedef unsigned int idType;
 
@@ -138,17 +137,17 @@ typedef struct {
 } TieredIndexParams;
 
 typedef struct {
-    VecSimType type;     // Datatype to index.
-    size_t dim;          // Vector's dimension.
-    VecSimMetric metric; // Distance metric to use in the index.
-    bool multi;          // Determines if the index should multi-index or not.
-    size_t nLists;       // Number of inverted lists
-    bool conservativeMemoryAllocation;  // Use as little GPU memory as possible
-    size_t kmeans_nIters; // Iterations for kmeans calculation
-    double kmeans_trainsetFraction; // Fraction of dataset used for kmeans training
-    unsigned nProbes; // The number of clusters to search
-    size_t pqBits; // Bit length of vector element after PQ compression. If set
-                   // to 0, IVF flat will be used instead of IVFPQ.
+    VecSimType type;                   // Datatype to index.
+    size_t dim;                        // Vector's dimension.
+    VecSimMetric metric;               // Distance metric to use in the index.
+    bool multi;                        // Determines if the index should multi-index or not.
+    size_t nLists;                     // Number of inverted lists
+    bool conservativeMemoryAllocation; // Use as little GPU memory as possible
+    size_t kmeans_nIters;              // Iterations for kmeans calculation
+    double kmeans_trainsetFraction;    // Fraction of dataset used for kmeans training
+    unsigned nProbes;                  // The number of clusters to search
+    size_t pqBits;                     // Bit length of vector element after PQ compression. If set
+                                       // to 0, IVF flat will be used instead of IVFPQ.
     // ***************** IVF-Flat-only parameters ******************
     // The following parameters will be ignored if pqBits is set to a
     // non-zero value.
@@ -164,13 +163,13 @@ typedef struct {
     CudaType lutType;
     CudaType internalDistanceType;
     double preferredShmemCarveout; // Fraction of GPU's unified memory / L1
-                                  // cache to be used as shared memory
+                                   // cache to be used as shared memory
 
 } IVFParams;
 
 typedef struct {
-  IVFParams ivfParams;
-  TieredIndexParams tieredParams;
+    IVFParams ivfParams;
+    TieredIndexParams tieredParams;
 } TieredIVFParams;
 
 typedef union {
@@ -279,7 +278,7 @@ typedef struct {
 
 typedef struct {
     size_t nLists; // Number of inverted lists.
-    size_t pqDim; // Dimensionality of encoded vector after PQ
+    size_t pqDim;  // Dimensionality of encoded vector after PQ
     size_t pqBits; // Bits per encoded vector element after PQ
 } ivfInfoStruct;
 

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -143,23 +143,27 @@ typedef struct {
     VecSimMetric metric; // Distance metric to use in the index.
     bool multi;          // Determines if the index should multi-index or not.
     size_t nLists;       // Number of inverted lists
-    bool adaptiveCenters; // If index should be updated for new vectors
     bool conservativeMemoryAllocation;  // Use as little GPU memory as possible
     size_t kmeans_nIters; // Iterations for kmeans calculation
-    float kmeans_trainsetFraction; // Fraction of dataset used for kmeans training
+    double kmeans_trainsetFraction; // Fraction of dataset used for kmeans training
     unsigned nProbes; // The number of clusters to search
-    size_t pqDim; // The dimensionality of an encoded vector after PQ
-                  // compression. If set to 0, IVF flat will be used
-                  // instead of IVFPQ.
-                  //
-    // ******************* IVFPQ-only parameters *******************
-    // The following parameters will be ignored if pqDim is set to 0
+    size_t pqBits; // Bit length of vector element after PQ compression. If set
+                   // to 0, IVF flat will be used instead of IVFPQ.
+    // ***************** IVF-Flat-only parameters ******************
+    // The following parameters will be ignored if pqBits is set to a
+    // non-zero value.
+    bool adaptiveCenters; // If index should be updated for new vectors
 
-    size_t pqBits; // Bit length of vector element after PQ compression
+    // ******************* IVFPQ-only parameters *******************
+    // The following parameters will be ignored if pqBits is set to 0
+    size_t pqDim; // The dimensionality of an encoded vector after PQ
+                  // compression. If set to 0, a heuristic will be used to
+                  // select the dimensionality.
+
     IVFPQCodebookKind codebookKind;
     CudaType lutType;
     CudaType internalDistanceType;
-    double preferredShmemCarvout; // Fraction of GPU's unified memory / L1
+    double preferredShmemCarveout; // Fraction of GPU's unified memory / L1
                                   // cache to be used as shared memory
 
 } IVFParams;


### PR DESCRIPTION
This PR is a replacement for #377, which fell out of date with changes on main. This PR provides access to GPU-accelerated index types provided by the RAPIDS RAFT library. It introduces two new index types: IVF and Tiered IVF, which provide access to both IVF Flat and IVFPQ indexes depending on how they are configured.

The intention of this initial integration is to provide GPU-based performance improvements for building indexes and batched searches. A later PR will introduce another index type which will offer perf improvement (relative to CPU HNSW) for single-query searches as well.

**Main objects this PR modified**
This PR does not substantively modify existing objects. A `clear` method is added to the brute force index to allow it to be reset with a single call.

**This PR is still a work in progress.** Remaining tasks:

- [ ] Update index-to-index transfer in tiered index to make use of asynchronous job infrastructure (Work on this was started but not completed)
- [ ] Add vector deletion once enabled by RAFT (https://github.com/rapidsai/raft/issues/1565)
- [ ] Add tests
- [ ] Add source files instantiating the index types provided by the current headers
- [ ] Switch back to mainline RAFT after merge of https://github.com/rapidsai/raft/pull/1716

Tasks to be tackled in later PRs:

- Integrating CAGRA indexes
- Multivalue support
- Vector update support

Questions for this PR:

- Should the IVF indexes be named in such a way as to indicate that they are GPU indexes in order to allow for possible CPU IVF support in the future?
- Based on initial feedback for 377, I have merged IVF Flat and IVF PQ into a single index type, with the choice of algorithm determined by the configuration parameters. Does this design meet the needs mentioned, or do we prefer the earlier separation?

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes