### PR TITLE
Reduce locks for adhoc BF 

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force_multi.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_multi.h
@@ -26,7 +26,7 @@ public:
     int addVector(const void *vector_data, labelType label, void *auxiliaryCtx = nullptr) override;
     int deleteVector(labelType labelType) override;
     int deleteVectorById(labelType label, idType id) override;
-    double getDistanceFrom(labelType label, const void *vector_data) const override;
+    double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override;
     inline size_t indexLabelCount() const override { return this->labelToIdsLookup.size(); }
 
     inline std::unique_ptr<vecsim_stl::abstract_results_container>
@@ -192,7 +192,8 @@ int BruteForceIndex_Multi<DataType, DistType>::deleteVectorById(labelType label,
 }
 
 template <typename DataType, typename DistType>
-double BruteForceIndex_Multi<DataType, DistType>::getDistanceFrom(labelType label,
+double
+BruteForceIndex_Multi<DataType, DistType>::getDistanceFrom_Unsafe(labelType label,
                                                                   const void *vector_data) const {
 
     auto IDs = this->labelToIdsLookup.find(label);

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -24,7 +24,7 @@ public:
     int addVector(const void *vector_data, labelType label, void *auxiliaryCtx = nullptr) override;
     int deleteVector(labelType label) override;
     int deleteVectorById(labelType label, idType id) override;
-    double getDistanceFrom(labelType label, const void *vector_data) const override;
+    double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override;
 
     inline std::unique_ptr<vecsim_stl::abstract_results_container>
     getNewResultsContainer(size_t cap) const override {
@@ -184,7 +184,8 @@ int BruteForceIndex_Single<DataType, DistType>::deleteVectorById(labelType label
 }
 
 template <typename DataType, typename DistType>
-double BruteForceIndex_Single<DataType, DistType>::getDistanceFrom(labelType label,
+double
+BruteForceIndex_Single<DataType, DistType>::getDistanceFrom_Unsafe(labelType label,
                                                                    const void *vector_data) const {
 
     auto optionalId = this->labelToIdLookup.find(label);

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -300,6 +300,8 @@ public:
     inline auto safeGetEntryPointState() const;
     inline void lockIndexDataGuard() const;
     inline void unlockIndexDataGuard() const;
+    inline void lockSharedIndexDataGuard() const;
+    inline void unlockSharedIndexDataGuard() const;
     inline void lockNodeLinks(idType node_id) const;
     inline void unlockNodeLinks(idType node_id) const;
     inline void lockNodeLinks(ElementGraphData *node_data) const;
@@ -507,6 +509,16 @@ void HNSWIndex<DataType, DistType>::lockIndexDataGuard() const {
 template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::unlockIndexDataGuard() const {
     indexDataGuard.unlock();
+}
+
+template <typename DataType, typename DistType>
+void HNSWIndex<DataType, DistType>::lockSharedIndexDataGuard() const {
+    indexDataGuard.lock_shared();
+}
+
+template <typename DataType, typename DistType>
+void HNSWIndex<DataType, DistType>::unlockSharedIndexDataGuard() const {
+    indexDataGuard.unlock_shared();
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -353,7 +353,6 @@ public:
 
     // Inline priority queue getter that need to be implemented by derived class.
     virtual inline candidatesLabelsMaxHeap<DistType> *getNewMaxPriorityQueue() const = 0;
-    virtual double safeGetDistanceFrom(labelType label, const void *vector_data) const = 0;
 
 #ifdef BUILD_TESTS
     /**

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -130,20 +130,20 @@ double HNSWIndex_Multi<DataType, DistType>::getDistanceFromInternal(labelType la
     DistType dist = INVALID_SCORE;
 
     // Check if the label exists in the index, return invalid score if not.
-//    if (Safe)
-//        this->indexDataGuard.lock_shared();
+    //    if (Safe)
+    //        this->indexDataGuard.lock_shared();
     auto it = this->labelLookup.find(label);
     if (it == this->labelLookup.end()) {
-//        if (Safe)
-//            this->indexDataGuard.unlock_shared();
+        //        if (Safe)
+        //            this->indexDataGuard.unlock_shared();
         return dist;
     }
 
     // Get the vector of ids associated with the label.
     // Get a copy if `Safe` is true, otherwise get a reference.
     decltype(auto) IDs = getCopyOrReference<Safe>(it->second);
-//    if (Safe)
-//        this->indexDataGuard.unlock_shared();
+    //    if (Safe)
+    //        this->indexDataGuard.unlock_shared();
 
     // Iterate over the ids and find the minimum distance.
     for (auto id : IDs) {

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -130,20 +130,20 @@ double HNSWIndex_Multi<DataType, DistType>::getDistanceFromInternal(labelType la
     DistType dist = INVALID_SCORE;
 
     // Check if the label exists in the index, return invalid score if not.
-    if (Safe)
-        this->indexDataGuard.lock_shared();
+//    if (Safe)
+//        this->indexDataGuard.lock_shared();
     auto it = this->labelLookup.find(label);
     if (it == this->labelLookup.end()) {
-        if (Safe)
-            this->indexDataGuard.unlock_shared();
+//        if (Safe)
+//            this->indexDataGuard.unlock_shared();
         return dist;
     }
 
     // Get the vector of ids associated with the label.
     // Get a copy if `Safe` is true, otherwise get a reference.
     decltype(auto) IDs = getCopyOrReference<Safe>(it->second);
-    if (Safe)
-        this->indexDataGuard.unlock_shared();
+//    if (Safe)
+//        this->indexDataGuard.unlock_shared();
 
     // Iterate over the ids and find the minimum distance.
     for (auto id : IDs) {

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -42,7 +42,6 @@ private:
         return keys;
     };
 
-    template <bool Safe>
     inline double getDistanceFromInternal(labelType label, const void *vector_data) const;
 
 public:
@@ -92,10 +91,7 @@ public:
     inline bool safeCheckIfLabelExistsInIndex(labelType label,
                                               bool also_done_processing) const override;
     double getDistanceFrom(labelType label, const void *vector_data) const override {
-        return getDistanceFromInternal<false>(label, vector_data);
-    }
-    double safeGetDistanceFrom(labelType label, const void *vector_data) const override {
-        return getDistanceFromInternal<true>(label, vector_data);
+        return getDistanceFromInternal(label, vector_data);
     }
 };
 
@@ -124,26 +120,19 @@ constexpr decltype(auto) getCopyOrReference(Arg &&arg) {
 }
 
 template <typename DataType, typename DistType>
-template <bool Safe>
 double HNSWIndex_Multi<DataType, DistType>::getDistanceFromInternal(labelType label,
                                                                     const void *vector_data) const {
     DistType dist = INVALID_SCORE;
 
     // Check if the label exists in the index, return invalid score if not.
-    //    if (Safe)
-    //        this->indexDataGuard.lock_shared();
     auto it = this->labelLookup.find(label);
     if (it == this->labelLookup.end()) {
-        //        if (Safe)
-        //            this->indexDataGuard.unlock_shared();
         return dist;
     }
 
     // Get the vector of ids associated with the label.
     // Get a copy if `Safe` is true, otherwise get a reference.
-    decltype(auto) IDs = getCopyOrReference<Safe>(it->second);
-    //    if (Safe)
-    //        this->indexDataGuard.unlock_shared();
+    auto &IDs = it->second;
 
     // Iterate over the ids and find the minimum distance.
     for (auto id : IDs) {

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -90,7 +90,7 @@ public:
     inline std::vector<idType> markDelete(labelType label) override;
     inline bool safeCheckIfLabelExistsInIndex(labelType label,
                                               bool also_done_processing) const override;
-    double getDistanceFrom(labelType label, const void *vector_data) const override {
+    double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
         return getDistanceFromInternal(label, vector_data);
     }
 };
@@ -107,17 +107,6 @@ size_t HNSWIndex_Multi<DataType, DistType>::indexLabelCount() const {
 /**
  * helper functions
  */
-
-// Depending on the value of the Safe template parameter, this function will either return a copy
-// of the argument or a reference to it.
-template <bool Safe, typename Arg>
-constexpr decltype(auto) getCopyOrReference(Arg &&arg) {
-    if constexpr (Safe) {
-        return std::decay_t<Arg>(arg);
-    } else {
-        return (arg);
-    }
-}
 
 template <typename DataType, typename DistType>
 double HNSWIndex_Multi<DataType, DistType>::getDistanceFromInternal(labelType label,

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -72,7 +72,7 @@ public:
     inline bool safeCheckIfLabelExistsInIndex(labelType label,
                                               bool also_done_processing = false) const override;
 
-    double getDistanceFrom(labelType label, const void *vector_data) const override {
+    double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
         return getDistanceFromInternal(label, vector_data);
     }
 };

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -110,18 +110,18 @@ template <bool Safe>
 double
 HNSWIndex_Single<DataType, DistType>::getDistanceFromInternal(labelType label,
                                                               const void *vector_data) const {
-//    if (Safe)
-//        this->indexDataGuard.lock_shared();
+    //    if (Safe)
+    //        this->indexDataGuard.lock_shared();
 
     auto it = labelLookup.find(label);
     if (it == labelLookup.end()) {
-//        if (Safe)
-//            this->indexDataGuard.unlock_shared();
+        //        if (Safe)
+        //            this->indexDataGuard.unlock_shared();
         return INVALID_SCORE;
     }
     idType id = it->second;
-//    if (Safe)
-//        this->indexDataGuard.unlock_shared();
+    //    if (Safe)
+    //        this->indexDataGuard.unlock_shared();
 
     return this->distFunc(vector_data, this->getDataByInternalId(id), this->dim);
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -110,18 +110,18 @@ template <bool Safe>
 double
 HNSWIndex_Single<DataType, DistType>::getDistanceFromInternal(labelType label,
                                                               const void *vector_data) const {
-    if (Safe)
-        this->indexDataGuard.lock_shared();
+//    if (Safe)
+//        this->indexDataGuard.lock_shared();
 
     auto it = labelLookup.find(label);
     if (it == labelLookup.end()) {
-        if (Safe)
-            this->indexDataGuard.unlock_shared();
+//        if (Safe)
+//            this->indexDataGuard.unlock_shared();
         return INVALID_SCORE;
     }
     idType id = it->second;
-    if (Safe)
-        this->indexDataGuard.unlock_shared();
+//    if (Safe)
+//        this->indexDataGuard.unlock_shared();
 
     return this->distFunc(vector_data, this->getDataByInternalId(id), this->dim);
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -25,7 +25,6 @@ private:
     inline void resizeLabelLookup(size_t new_max_elements) override;
     inline vecsim_stl::set<labelType> getLabelsSet() const override;
 
-    template <bool Safe>
     inline double getDistanceFromInternal(labelType label, const void *vector_data) const;
 
 public:
@@ -74,10 +73,7 @@ public:
                                               bool also_done_processing = false) const override;
 
     double getDistanceFrom(labelType label, const void *vector_data) const override {
-        return getDistanceFromInternal<false>(label, vector_data);
-    }
-    double safeGetDistanceFrom(labelType label, const void *vector_data) const override {
-        return getDistanceFromInternal<true>(label, vector_data);
+        return getDistanceFromInternal(label, vector_data);
     }
 };
 
@@ -106,22 +102,15 @@ inline vecsim_stl::set<labelType> HNSWIndex_Single<DataType, DistType>::getLabel
 };
 
 template <typename DataType, typename DistType>
-template <bool Safe>
 double
 HNSWIndex_Single<DataType, DistType>::getDistanceFromInternal(labelType label,
                                                               const void *vector_data) const {
-    //    if (Safe)
-    //        this->indexDataGuard.lock_shared();
 
     auto it = labelLookup.find(label);
     if (it == labelLookup.end()) {
-        //        if (Safe)
-        //            this->indexDataGuard.unlock_shared();
         return INVALID_SCORE;
     }
     idType id = it->second;
-    //    if (Safe)
-    //        this->indexDataGuard.unlock_shared();
 
     return this->distFunc(vector_data, this->getDataByInternalId(id), this->dim);
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -210,6 +210,17 @@ public:
                    "running asynchronous GC for tiered HNSW index");
         this->executeReadySwapJobs(this->pendingSwapJobsThreshold);
     }
+    void acquireLocks() override {
+        this->flatIndexGuard.lock_shared();
+        this->mainIndexGuard.lock_shared();
+        this->getHNSWIndex()->lockIndexDataGuard();
+    }
+
+    void releaseLocks() override {
+        this->flatIndexGuard.unlock_shared();
+        this->mainIndexGuard.unlock_shared();
+        this->getHNSWIndex()->unlockIndexDataGuard();
+    }
 #ifdef BUILD_TESTS
     void getDataByLabel(labelType label, std::vector<std::vector<DataType>> &vectors_output) const;
 #endif
@@ -808,9 +819,9 @@ double TieredHNSWIndex<DataType, DistType>::getDistanceFrom(labelType label,
                                                             const void *blob) const {
     // Try to get the distance from the flat buffer.
     // If the label doesn't exist, the distance will be NaN.
-    this->flatIndexGuard.lock_shared();
+//    this->flatIndexGuard.lock_shared();
     auto flat_dist = this->frontendIndex->getDistanceFrom(label, blob);
-    this->flatIndexGuard.unlock_shared();
+//    this->flatIndexGuard.unlock_shared();
 
     // Optimization. TODO: consider having different implementations for single and multi indexes,
     // to avoid checking the index type on every query.
@@ -821,9 +832,9 @@ double TieredHNSWIndex<DataType, DistType>::getDistanceFrom(labelType label,
     }
 
     // Try to get the distance from the Main index.
-    this->mainIndexGuard.lock_shared();
+//    this->mainIndexGuard.lock_shared();
     auto hnsw_dist = getHNSWIndex()->safeGetDistanceFrom(label, blob);
-    this->mainIndexGuard.unlock_shared();
+//    this->mainIndexGuard.unlock_shared();
 
     // Return the minimum distance that is not NaN.
     return std::fmin(flat_dist, hnsw_dist);

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -632,9 +632,9 @@ TieredHNSWIndex<DataType, DistType>::~TieredHNSWIndex() {
 template <typename DataType, typename DistType>
 size_t TieredHNSWIndex<DataType, DistType>::indexSize() const {
     this->flatIndexGuard.lock_shared();
-    this->getHNSWIndex()->lockIndexDataGuard();
+    this->getHNSWIndex()->lockSharedIndexDataGuard();
     size_t res = this->backendIndex->indexSize() + this->frontendIndex->indexSize();
-    this->getHNSWIndex()->unlockIndexDataGuard();
+    this->getHNSWIndex()->unlockSharedIndexDataGuard();
     this->flatIndexGuard.unlock_shared();
     return res;
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -213,13 +213,13 @@ public:
     void acquireLocks() override {
         this->flatIndexGuard.lock_shared();
         this->mainIndexGuard.lock_shared();
-        this->getHNSWIndex()->lockIndexDataGuard();
+        this->getHNSWIndex()->lockSharedIndexDataGuard();
     }
 
     void releaseLocks() override {
         this->flatIndexGuard.unlock_shared();
         this->mainIndexGuard.unlock_shared();
-        this->getHNSWIndex()->unlockIndexDataGuard();
+        this->getHNSWIndex()->unlockSharedIndexDataGuard();
     }
 #ifdef BUILD_TESTS
     void getDataByLabel(labelType label, std::vector<std::vector<DataType>> &vectors_output) const;
@@ -819,9 +819,9 @@ double TieredHNSWIndex<DataType, DistType>::getDistanceFrom(labelType label,
                                                             const void *blob) const {
     // Try to get the distance from the flat buffer.
     // If the label doesn't exist, the distance will be NaN.
-//    this->flatIndexGuard.lock_shared();
+    //    this->flatIndexGuard.lock_shared();
     auto flat_dist = this->frontendIndex->getDistanceFrom(label, blob);
-//    this->flatIndexGuard.unlock_shared();
+    //    this->flatIndexGuard.unlock_shared();
 
     // Optimization. TODO: consider having different implementations for single and multi indexes,
     // to avoid checking the index type on every query.
@@ -832,9 +832,9 @@ double TieredHNSWIndex<DataType, DistType>::getDistanceFrom(labelType label,
     }
 
     // Try to get the distance from the Main index.
-//    this->mainIndexGuard.lock_shared();
+    //    this->mainIndexGuard.lock_shared();
     auto hnsw_dist = getHNSWIndex()->safeGetDistanceFrom(label, blob);
-//    this->mainIndexGuard.unlock_shared();
+    //    this->mainIndexGuard.unlock_shared();
 
     // Return the minimum distance that is not NaN.
     return std::fmin(flat_dist, hnsw_dist);

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -12,7 +12,6 @@
 #include "VecSim/vec_sim_index.h"
 #include <cassert>
 #include "memory.h"
-#include "vec_sim_tiered_index.h"
 
 extern "C" void VecSim_SetTimeoutCallbackFunction(timeoutCallbackFunction callback) {
     VecSimIndex::setTimeoutCallbackFunction(callback);
@@ -119,8 +118,9 @@ extern "C" int VecSimIndex_DeleteVector(VecSimIndex *index, size_t label) {
     return index->deleteVector(label);
 }
 
-extern "C" double VecSimIndex_GetDistanceFrom(VecSimIndex *index, size_t label, const void *blob) {
-    return index->getDistanceFrom(label, blob);
+extern "C" double VecSimIndex_GetDistanceFrom_Unsafe(VecSimIndex *index, size_t label,
+                                                     const void *blob) {
+    return index->getDistanceFrom_Unsafe(label, blob);
 }
 
 extern "C" size_t VecSimIndex_EstimateElementSize(const VecSimParams *params) {
@@ -242,9 +242,13 @@ extern "C" void VecSimTieredIndex_GC(VecSimIndex *index) {
     }
 }
 
-extern "C" void VecSimTieredIndex_AcquireSharedLocks(VecSimIndex *index) { index->acquireLocks(); }
+extern "C" void VecSimTieredIndex_AcquireSharedLocks(VecSimIndex *index) {
+    index->acquireSharedLocks();
+}
 
-extern "C" void VecSimTieredIndex_ReleaseSharedLocks(VecSimIndex *index) { index->releaseLocks(); }
+extern "C" void VecSimTieredIndex_ReleaseSharedLocks(VecSimIndex *index) {
+    index->releaseSharedLocks();
+}
 
 extern "C" void VecSim_SetMemoryFunctions(VecSimMemoryFunctions memoryfunctions) {
     VecSimAllocator::setMemoryFunctions(memoryfunctions);

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -242,13 +242,9 @@ extern "C" void VecSimTieredIndex_GC(VecSimIndex *index) {
     }
 }
 
-extern "C" void VecSimTieredIndex_AcquireSharedLocks(VecSimIndex *index) {
-    index->acquireLocks();
-}
+extern "C" void VecSimTieredIndex_AcquireSharedLocks(VecSimIndex *index) { index->acquireLocks(); }
 
-extern "C" void VecSimTieredIndex_ReleaseSharedLocks(VecSimIndex *index) {
-    index->releaseLocks();
-}
+extern "C" void VecSimTieredIndex_ReleaseSharedLocks(VecSimIndex *index) { index->releaseLocks(); }
 
 extern "C" void VecSim_SetMemoryFunctions(VecSimMemoryFunctions memoryfunctions) {
     VecSimAllocator::setMemoryFunctions(memoryfunctions);

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -12,6 +12,7 @@
 #include "VecSim/vec_sim_index.h"
 #include <cassert>
 #include "memory.h"
+#include "vec_sim_tiered_index.h"
 
 extern "C" void VecSim_SetTimeoutCallbackFunction(timeoutCallbackFunction callback) {
     VecSimIndex::setTimeoutCallbackFunction(callback);
@@ -239,6 +240,14 @@ extern "C" void VecSimTieredIndex_GC(VecSimIndex *index) {
     if (index->basicInfo().isTiered) {
         index->runGC();
     }
+}
+
+extern "C" void VecSimTieredIndex_AcquireSharedLocks(VecSimIndex *index) {
+    index->acquireLocks();
+}
+
+extern "C" void VecSimTieredIndex_ReleaseSharedLocks(VecSimIndex *index) {
+    index->releaseLocks();
 }
 
 extern "C" void VecSim_SetMemoryFunctions(VecSimMemoryFunctions memoryfunctions) {

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -199,6 +199,10 @@ void VecSimTieredIndex_GC(VecSimIndex *index);
 bool VecSimIndex_PreferAdHocSearch(VecSimIndex *index, size_t subsetSize, size_t k,
                                    bool initial_check);
 
+void VecSimTieredIndex_AcquireSharedLocks(VecSimIndex *index);
+
+void VecSimTieredIndex_ReleaseSharedLocks(VecSimIndex *index);
+
 /**
  * @brief Allow 3rd party memory functions to be used for memory management.
  *
@@ -227,6 +231,7 @@ void VecSim_SetLogCallbackFunction(logCallbackFunction callback);
  * @param mode VecSimWriteMode the mode in which we add/remove vectors (async or in-place).
  */
 void VecSim_SetWriteMode(VecSimWriteMode mode);
+
 
 #ifdef __cplusplus
 }

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -232,7 +232,6 @@ void VecSim_SetLogCallbackFunction(logCallbackFunction callback);
  */
 void VecSim_SetWriteMode(VecSimWriteMode mode);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -74,6 +74,9 @@ int VecSimIndex_DeleteVector(VecSimIndex *index, size_t label);
  * @brief Calculate the distance of a vector from an index to a vector. This function assumes that
  * the vector fits the index - its type and dimension are the same as the index's, and if the
  * index's distance metric is cosine, the vector is already normalized.
+ * IMPORTANT: for tiered index, this should be called while *locks are locked for shared ownership*,
+ * as we avoid acquiring the locks internally. That is since this is usually called for every vector
+ * individually, and the overhead of acquiring and releasing the locks is significant in that case.
  * @param index the index from which the first vector is located, and that defines the distance
  * metric.
  * @param label the label of the vector in the index.
@@ -82,7 +85,7 @@ int VecSimIndex_DeleteVector(VecSimIndex *index, size_t label);
  * @return The distance (according to the index's distance metric) between `blob` and the vector
  * with label  label`.
  */
-double VecSimIndex_GetDistanceFrom(VecSimIndex *index, size_t label, const void *blob);
+double VecSimIndex_GetDistanceFrom_Unsafe(VecSimIndex *index, size_t label, const void *blob);
 
 /**
  * @brief normalize the vector blob in place.
@@ -199,6 +202,11 @@ void VecSimTieredIndex_GC(VecSimIndex *index);
 bool VecSimIndex_PreferAdHocSearch(VecSimIndex *index, size_t subsetSize, size_t k,
                                    bool initial_check);
 
+/**
+ * @brief Acquire/Release the required locks of the tiered index externally before executing an
+ * an unsafe *READ* operation (as the locks are acquired for shared ownership).
+ * @param index the tiered index to protect (no nothing for non-tiered indexes).
+ */
 void VecSimTieredIndex_AcquireSharedLocks(VecSimIndex *index);
 
 void VecSimTieredIndex_ReleaseSharedLocks(VecSimIndex *index);

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -236,7 +236,7 @@ protected:
         return this->newBatchIterator(processed_blob, queryParams);
     }
 
-    void runGC() override {}        // Do nothing, relevant for tiered index only.
-    void acquireLocks() override {} // Do nothing, relevant for tiered index only.
-    void releaseLocks() override {} // Do nothing, relevant for tiered index only.
+    void runGC() override {}              // Do nothing, relevant for tiered index only.
+    void acquireSharedLocks() override {} // Do nothing, relevant for tiered index only.
+    void releaseSharedLocks() override {} // Do nothing, relevant for tiered index only.
 };

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -236,7 +236,7 @@ protected:
         return this->newBatchIterator(processed_blob, queryParams);
     }
 
-    void runGC() override {} // Do nothing, relevant for tiered index only.
+    void runGC() override {}        // Do nothing, relevant for tiered index only.
     void acquireLocks() override {} // Do nothing, relevant for tiered index only.
     void releaseLocks() override {} // Do nothing, relevant for tiered index only.
 };

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -237,4 +237,6 @@ protected:
     }
 
     void runGC() override {} // Do nothing, relevant for tiered index only.
+    void acquireLocks() override {} // Do nothing, relevant for tiered index only.
+    void releaseLocks() override {} // Do nothing, relevant for tiered index only.
 };

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -221,6 +221,16 @@ public:
     virtual void runGC() = 0;
 
     /**
+     * @brief Acquire the locks for shared ownership in tiered async index.
+     */
+    virtual void acquireLocks() = 0;
+
+    /**
+     * @brief Release the locks for shared ownership in tiered async index.
+     */
+    virtual void releaseLocks() = 0;
+
+    /**
      * @brief Allow 3rd party timeout callback to be used for limiting runtime of a query.
      *
      * @param callback timeoutCallbackFunction function. should get void* and return int.

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -78,7 +78,7 @@ public:
      * @return The distance (according to the index's distance metric) between `blob` and the vector
      * with id `id`.
      */
-    virtual double getDistanceFrom(labelType id, const void *blob) const = 0;
+    virtual double getDistanceFrom_Unsafe(labelType id, const void *blob) const = 0;
 
     /**
      * @brief Return the number of vectors in the index (including ones that are marked as deleted).
@@ -223,12 +223,12 @@ public:
     /**
      * @brief Acquire the locks for shared ownership in tiered async index.
      */
-    virtual void acquireLocks() = 0;
+    virtual void acquireSharedLocks() = 0;
 
     /**
      * @brief Release the locks for shared ownership in tiered async index.
      */
-    virtual void releaseLocks() = 0;
+    virtual void releaseSharedLocks() = 0;
 
     /**
      * @brief Allow 3rd party timeout callback to be used for limiting runtime of a query.

--- a/tests/benchmark/bm_batch_iterator.h
+++ b/tests/benchmark/bm_batch_iterator.h
@@ -142,8 +142,8 @@ void BM_BatchIterator<index_type_t>::BF_BatchesToAdhocBF(benchmark::State &st) {
         VecSimBatchIterator_Free(batchIterator);
         // Switch to ad-hoc BF
         for (size_t i = 0; i < N_VECTORS; i += step) {
-            VecSimIndex_GetDistanceFrom(INDICES[VecSimAlgo_BF], i,
-                                        QUERIES[iter % N_QUERIES].data());
+            VecSimIndex_GetDistanceFrom_Unsafe(INDICES[VecSimAlgo_BF], i,
+                                               QUERIES[iter % N_QUERIES].data());
         }
         iter++;
     }
@@ -203,8 +203,8 @@ void BM_BatchIterator<index_type_t>::HNSW_BatchesToAdhocBF(benchmark::State &st)
                               memory_delta);
         // Switch to ad-hoc BF
         for (size_t i = 0; i < N_VECTORS; i += step) {
-            VecSimIndex_GetDistanceFrom(INDICES[VecSimAlgo_HNSWLIB], i,
-                                        QUERIES[iter % N_QUERIES].data());
+            VecSimIndex_GetDistanceFrom_Unsafe(INDICES[VecSimAlgo_HNSWLIB], i,
+                                               QUERIES[iter % N_QUERIES].data());
         }
         iter++;
     }

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -1178,28 +1178,28 @@ TYPED_TEST(BruteForceTest, brute_get_distance) {
     // VecSimMetric_L2
     distances = {0, 0.3583844006061554, 0.1791922003030777, 23.739208221435547};
     for (size_t i = 0; i < n; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], i + 1, query);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_L2], i + 1, query);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
     // VecSimMetric_IP
     distances = {-18.73921012878418, -16.0794677734375, -17.409339904785156, 1};
     for (size_t i = 0; i < n; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_IP], i + 1, query);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_IP], i + 1, query);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
     // VecSimMetric_Cosine
     distances = {5.9604644775390625e-08, 5.9604644775390625e-08, 0.0025991201400756836, 1};
     for (size_t i = 0; i < n; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], i + 1, norm);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_Cosine], i + 1, norm);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
     // Bad values
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], 0, norm);
+    dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_Cosine], 0, norm);
     ASSERT_TRUE(std::isnan(dist));
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], 46, query);
+    dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_L2], 46, query);
     ASSERT_TRUE(std::isnan(dist));
 
     // Clean-up.
@@ -1346,7 +1346,7 @@ TYPED_TEST(BruteForceTest, testCosine) {
 
     auto verify_res = [&](size_t id, double score, size_t result_rank) {
         ASSERT_EQ(id, (n - result_rank));
-        TEST_DATA_T expected_score = index->getDistanceFrom(id, normalized_query);
+        TEST_DATA_T expected_score = index->getDistanceFrom_Unsafe(id, normalized_query);
         ASSERT_TYPE_EQ(TEST_DATA_T(score), expected_score);
     };
     runTopKSearchTest(index, query, 10, verify_res);
@@ -1362,7 +1362,7 @@ TYPED_TEST(BruteForceTest, testCosine) {
         std::vector<size_t> expected_ids(n_res);
         auto verify_res_batch = [&](size_t id, double score, size_t result_rank) {
             ASSERT_EQ(id, (n - n_res * iteration_num - result_rank));
-            TEST_DATA_T expected_score = index->getDistanceFrom(id, normalized_query);
+            TEST_DATA_T expected_score = index->getDistanceFrom_Unsafe(id, normalized_query);
             ASSERT_TYPE_EQ(TEST_DATA_T(score), expected_score);
         };
         runBatchIteratorSearchTest(batchIterator, n_res, verify_res_batch);
@@ -1571,7 +1571,7 @@ TYPED_TEST(BruteForceTest, rangeQueryCosine) {
     }
     auto verify_res = [&](size_t id, double score, size_t result_rank) {
         ASSERT_EQ(id, result_rank + 1);
-        double expected_score = index->getDistanceFrom(id, query);
+        double expected_score = index->getDistanceFrom_Unsafe(id, query);
         // Verify that abs difference between the actual and expected score is at most 1/10^5.
         ASSERT_EQ(score, expected_score);
     };
@@ -1580,7 +1580,7 @@ TYPED_TEST(BruteForceTest, rangeQueryCosine) {
     // Calculate the score of the 31st distant vector from the query vector (whose id should be 30)
     // to get the radius.
     VecSim_Normalize(query, dim, params.type);
-    double radius = index->getDistanceFrom(31, query);
+    double radius = index->getDistanceFrom_Unsafe(31, query);
     runRangeQueryTest(index, query, radius, verify_res, expected_num_results, BY_SCORE);
     // Return results BY_ID should give the same results.
     runRangeQueryTest(index, query, radius, verify_res, expected_num_results, BY_ID);

--- a/tests/unit/test_bruteforce_multi.cpp
+++ b/tests/unit/test_bruteforce_multi.cpp
@@ -1003,7 +1003,7 @@ TYPED_TEST(BruteForceMultiTest, brute_get_distance) {
     // minimum of each label are:
     distances = {0, 0.1791922003030777};
     for (size_t i = 0; i < n_labels; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], i, query);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_L2], i, query);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
@@ -1012,7 +1012,7 @@ TYPED_TEST(BruteForceMultiTest, brute_get_distance) {
     // minimum of each label are:
     distances = {-18.73921012878418, -17.409339904785156};
     for (size_t i = 0; i < n_labels; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_IP], i, query);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_IP], i, query);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
@@ -1021,14 +1021,14 @@ TYPED_TEST(BruteForceMultiTest, brute_get_distance) {
     // minimum of each label are:
     distances = {5.9604644775390625e-08, 0.0025991201400756836};
     for (size_t i = 0; i < n_labels; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], i, norm);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_Cosine], i, norm);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
     // Bad values
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], -1, norm);
+    dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_Cosine], -1, norm);
     ASSERT_TRUE(std::isnan(dist));
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], 46, query);
+    dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_L2], 46, query);
     ASSERT_TRUE(std::isnan(dist));
 
     // Clean-up.
@@ -1075,7 +1075,7 @@ TYPED_TEST(BruteForceMultiTest, testCosine) {
     auto verify_res = [&](size_t id, double score, size_t result_rank) {
         ASSERT_EQ(id, (n - result_rank));
 
-        TEST_DATA_T expected_score = index->getDistanceFrom(id, normalized_query);
+        TEST_DATA_T expected_score = index->getDistanceFrom_Unsafe(id, normalized_query);
 
         ASSERT_TYPE_EQ(TEST_DATA_T(score), expected_score);
     };
@@ -1092,7 +1092,7 @@ TYPED_TEST(BruteForceMultiTest, testCosine) {
         std::vector<size_t> expected_ids(n_res);
         auto verify_res_batch = [&](size_t id, double score, size_t result_rank) {
             ASSERT_EQ(id, (n - n_res * iteration_num - result_rank));
-            TEST_DATA_T expected_score = index->getDistanceFrom(id, normalized_query);
+            TEST_DATA_T expected_score = index->getDistanceFrom_Unsafe(id, normalized_query);
 
             ASSERT_TYPE_EQ(TEST_DATA_T(score), expected_score);
         };

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -1428,28 +1428,28 @@ TYPED_TEST(HNSWTest, hnsw_get_distance) {
     // VecSimMetric_L2
     distances = {0, 0.3583844006061554, 0.1791922003030777, 23.739208221435547};
     for (size_t i = 0; i < n; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], i + 1, query);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_L2], i + 1, query);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
     // VecSimMetric_IP
     distances = {-18.73921012878418, -16.0794677734375, -17.409339904785156, 1};
     for (size_t i = 0; i < n; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_IP], i + 1, query);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_IP], i + 1, query);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
     // VecSimMetric_Cosine
     distances = {5.9604644775390625e-08, 5.9604644775390625e-08, 0.0025991201400756836, 1};
     for (size_t i = 0; i < n; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], i + 1, norm);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_Cosine], i + 1, norm);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
     // Bad values
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], 0, norm);
+    dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_Cosine], 0, norm);
     ASSERT_TRUE(std::isnan(dist));
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], 46, query);
+    dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_L2], 46, query);
     ASSERT_TRUE(std::isnan(dist));
 
     // Clean-up.
@@ -1552,7 +1552,7 @@ TYPED_TEST(HNSWTest, testCosine) {
 
     auto verify_res = [&](size_t id, double score, size_t result_rank) {
         ASSERT_EQ(id, (n - result_rank));
-        TEST_DATA_T expected_score = index->getDistanceFrom(id, query);
+        TEST_DATA_T expected_score = index->getDistanceFrom_Unsafe(id, query);
         ASSERT_DOUBLE_EQ(score, expected_score);
     };
 
@@ -1569,7 +1569,7 @@ TYPED_TEST(HNSWTest, testCosine) {
         std::vector<size_t> expected_ids(n_res);
         auto verify_res_batch = [&](size_t id, double score, size_t result_rank) {
             ASSERT_EQ(id, (n - n_res * iteration_num - result_rank));
-            double expected_score = index->getDistanceFrom(id, query);
+            double expected_score = index->getDistanceFrom_Unsafe(id, query);
             ASSERT_DOUBLE_EQ(score, expected_score);
         };
         runBatchIteratorSearchTest(batchIterator, n_res, verify_res_batch);
@@ -1855,13 +1855,13 @@ TYPED_TEST(HNSWTest, rangeQueryCosine) {
     VecSim_Normalize(query, dim, params.type);
     auto verify_res = [&](size_t id, double score, size_t result_rank) {
         ASSERT_EQ(id, result_rank + 1);
-        double expected_score = index->getDistanceFrom(id, query);
+        double expected_score = index->getDistanceFrom_Unsafe(id, query);
         ASSERT_EQ(score, expected_score);
     };
     uint expected_num_results = 31;
     // Calculate the score of the 31st distant vector from the query vector (whose id should be 30)
     // to get the radius.
-    double radius = index->getDistanceFrom(31, query);
+    double radius = index->getDistanceFrom_Unsafe(31, query);
     runRangeQueryTest(index, query, radius, verify_res, expected_num_results, BY_SCORE);
 
     // Return results BY_ID should give the same results.

--- a/tests/unit/test_hnsw_multi.cpp
+++ b/tests/unit/test_hnsw_multi.cpp
@@ -819,7 +819,7 @@ TYPED_TEST(HNSWMultiTest, hnsw_get_distance) {
     // minimum of each label are:
     distances = {0, 0.1791922003030777};
     for (size_t i = 0; i < n_labels; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], i, query);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_L2], i, query);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
@@ -828,7 +828,7 @@ TYPED_TEST(HNSWMultiTest, hnsw_get_distance) {
     // minimum of each label are:
     distances = {-18.73921012878418, -17.409339904785156};
     for (size_t i = 0; i < n_labels; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_IP], i, query);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_IP], i, query);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
@@ -837,14 +837,14 @@ TYPED_TEST(HNSWMultiTest, hnsw_get_distance) {
     // minimum of each label are:
     distances = {5.9604644775390625e-08, 0.0025991201400756836};
     for (size_t i = 0; i < n_labels; i++) {
-        dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], i, norm);
+        dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_Cosine], i, norm);
         ASSERT_NEAR(dist, distances[i], 1e-5);
     }
 
     // Bad values
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_Cosine], -1, norm);
+    dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_Cosine], -1, norm);
     ASSERT_TRUE(std::isnan(dist));
-    dist = VecSimIndex_GetDistanceFrom(index[VecSimMetric_L2], 46, query);
+    dist = VecSimIndex_GetDistanceFrom_Unsafe(index[VecSimMetric_L2], 46, query);
     ASSERT_TRUE(std::isnan(dist));
 
     // Clean-up.
@@ -1578,7 +1578,7 @@ TYPED_TEST(HNSWMultiTest, testCosine) {
 
     auto verify_res = [&](size_t id, double score, size_t result_rank) {
         ASSERT_EQ(id, (n - result_rank));
-        TEST_DATA_T expected_score = index->getDistanceFrom(id, normalized_query);
+        TEST_DATA_T expected_score = index->getDistanceFrom_Unsafe(id, normalized_query);
         ASSERT_TYPE_EQ(TEST_DATA_T(score), expected_score);
     };
     runTopKSearchTest(index, query, 10, verify_res);
@@ -1633,7 +1633,7 @@ TYPED_TEST(HNSWMultiTest, testCosineBatchIterator) {
         std::vector<size_t> expected_ids(n_res);
         auto verify_res_batch = [&](size_t id, double score, size_t result_rank) {
             ASSERT_EQ(id, (n - n_res * iteration_num - result_rank));
-            TEST_DATA_T expected_score = index->getDistanceFrom(id, normalized_query);
+            TEST_DATA_T expected_score = index->getDistanceFrom_Unsafe(id, normalized_query);
             ASSERT_TYPE_EQ(TEST_DATA_T(score), expected_score);
         };
         runBatchIteratorSearchTest(batchIterator, n_res, verify_res_batch);

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -1289,9 +1289,9 @@ TYPED_TEST(HNSWTieredIndexTest, parallelInsertAdHoc) {
         bool isMulti =
             reinterpret_cast<TieredHNSWIndex<TEST_DATA_T, TEST_DIST_T> *>(search_job->index)
                 ->backendIndex->isMultiValue();
-
+        search_job->index->acquireLocks();
         ASSERT_EQ(0, VecSimIndex_GetDistanceFrom(search_job->index, label, query));
-
+        search_job->index->releaseLocks();
         (*search_job->successful_searches)++;
         delete job;
     };

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -109,7 +109,7 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
     // Execute the job from the queue and validate that the index was updated properly.
     mock_thread_pool.thread_iteration();
     ASSERT_EQ(tiered_index->indexSize(), 1);
-    ASSERT_EQ(tiered_index->getDistanceFrom(1, vector), 0);
+    ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(1, vector), 0);
     ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
     ASSERT_EQ(tiered_index->labelToInsertJobs.at(vector_label).size(), 0);
 }
@@ -229,7 +229,7 @@ TYPED_TEST(HNSWTieredIndexTest, addVector) {
     ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
     ASSERT_EQ(tiered_index->frontendIndex->indexCapacity(), DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(tiered_index->indexCapacity(), DEFAULT_BLOCK_SIZE);
-    ASSERT_EQ(tiered_index->frontendIndex->getDistanceFrom(vec_label, vector), 0);
+    ASSERT_EQ(tiered_index->frontendIndex->getDistanceFrom_Unsafe(vec_label, vector), 0);
     // Validate that the job was created properly
     ASSERT_EQ(tiered_index->labelToInsertJobs.at(vec_label).size(), 1);
     ASSERT_EQ(tiered_index->labelToInsertJobs.at(vec_label)[0]->label, vec_label);
@@ -377,7 +377,7 @@ TYPED_TEST(HNSWTieredIndexTest, insertJob) {
     ASSERT_EQ(tiered_index->backendIndex->indexCapacity(), DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(tiered_index->indexCapacity(), DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(tiered_index->frontendIndex->indexCapacity(), 0);
-    ASSERT_EQ(tiered_index->backendIndex->getDistanceFrom(vec_label, vector), 0);
+    ASSERT_EQ(tiered_index->backendIndex->getDistanceFrom_Unsafe(vec_label, vector), 0);
     // After the execution, the job should be removed from the labelToInsertJobs mapping.
     ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 0);
 }
@@ -411,7 +411,7 @@ TYPED_TEST(HNSWTieredIndexTestBasic, insertJobAsync) {
     for (size_t i = 0; i < n; i++) {
         TEST_DATA_T expected_vector[dim];
         GenerateVector<TEST_DATA_T>(expected_vector, dim, i);
-        ASSERT_EQ(tiered_index->backendIndex->getDistanceFrom(i, expected_vector), 0);
+        ASSERT_EQ(tiered_index->backendIndex->getDistanceFrom_Unsafe(i, expected_vector), 0);
     }
 }
 
@@ -451,8 +451,8 @@ TYPED_TEST(HNSWTieredIndexTestBasic, insertJobAsyncMulti) {
     for (size_t i = 0; i < n / per_label; i++) {
         for (size_t j = 0; j < per_label; j++) {
             // The distance from every vector that is stored under the label i should be zero
-            EXPECT_EQ(tiered_index->backendIndex->getDistanceFrom(i, vectors + i * per_label * dim +
-                                                                         j * dim),
+            EXPECT_EQ(tiered_index->backendIndex->getDistanceFrom_Unsafe(
+                          i, vectors + i * per_label * dim + j * dim),
                       0);
         }
     }
@@ -1147,10 +1147,10 @@ TYPED_TEST(HNSWTieredIndexTestBasic, AdHocSingle) {
     // copy memory context before querying the index.
     size_t cur_memory_usage = allocator->getAllocationSize();
 
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 1, vec1), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 2, vec2), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 3, vec3), 0);
-    ASSERT_TRUE(std::isnan(VecSimIndex_GetDistanceFrom(tiered_index, 4, vec4)));
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 1, vec1), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 2, vec2), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 3, vec3), 0);
+    ASSERT_TRUE(std::isnan(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 4, vec4)));
 
     ASSERT_EQ(cur_memory_usage, allocator->getAllocationSize());
 }
@@ -1236,20 +1236,20 @@ TYPED_TEST(HNSWTieredIndexTestBasic, AdHocMulti) {
     size_t cur_memory_usage = allocator->getAllocationSize();
 
     // Distance from any vector to its label should be 0.
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 1, vec1_1), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 1, vec1_2), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 1, vec1_3), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 2, vec2_1), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 2, vec2_2), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 2, vec2_3), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 3, vec3_1), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 3, vec3_2), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 3, vec3_3), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 4, vec4_1), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 4, vec4_2), 0);
-    ASSERT_EQ(VecSimIndex_GetDistanceFrom(tiered_index, 4, vec4_3), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 1, vec1_1), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 1, vec1_2), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 1, vec1_3), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 2, vec2_1), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 2, vec2_2), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 2, vec2_3), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 3, vec3_1), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 3, vec3_2), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 3, vec3_3), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 4, vec4_1), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 4, vec4_2), 0);
+    ASSERT_EQ(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 4, vec4_3), 0);
     // Distance from a non-existing label should be NaN.
-    ASSERT_TRUE(std::isnan(VecSimIndex_GetDistanceFrom(tiered_index, 5, vec5)));
+    ASSERT_TRUE(std::isnan(VecSimIndex_GetDistanceFrom_Unsafe(tiered_index, 5, vec5)));
 
     ASSERT_EQ(cur_memory_usage, allocator->getAllocationSize());
 }
@@ -1290,7 +1290,7 @@ TYPED_TEST(HNSWTieredIndexTest, parallelInsertAdHoc) {
             reinterpret_cast<TieredHNSWIndex<TEST_DATA_T, TEST_DIST_T> *>(search_job->index)
                 ->backendIndex->isMultiValue();
         VecSimTieredIndex_AcquireSharedLocks(search_job->index);
-        ASSERT_EQ(0, VecSimIndex_GetDistanceFrom(search_job->index, label, query));
+        ASSERT_EQ(0, VecSimIndex_GetDistanceFrom_Unsafe(search_job->index, label, query));
         VecSimTieredIndex_ReleaseSharedLocks(search_job->index);
         (*search_job->successful_searches)++;
         delete job;
@@ -1382,7 +1382,7 @@ TYPED_TEST(HNSWTieredIndexTest, deleteVector) {
     // to the new vector (L2 distance).
     TEST_DATA_T deleted_vector[dim];
     GenerateVector<TEST_DATA_T>(deleted_vector, dim, 0);
-    ASSERT_EQ(tiered_index->backendIndex->getDistanceFrom(vec_label, deleted_vector),
+    ASSERT_EQ(tiered_index->backendIndex->getDistanceFrom_Unsafe(vec_label, deleted_vector),
               dim * pow(new_vec_val, 2));
 }
 
@@ -2546,7 +2546,7 @@ TYPED_TEST(HNSWTieredIndexTestBasic, overwriteVectorBasic) {
     ASSERT_EQ(tiered_index->indexLabelCount(), 1);
     ASSERT_EQ(tiered_index->indexSize(), 1);
     ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
-    ASSERT_EQ(tiered_index->getDistanceFrom(0, overwritten_vec), 0);
+    ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(0, overwritten_vec), 0);
 
     // Validate that jobs were created properly - first job should be invalid after overwrite,
     // the second should be a pending insert job.
@@ -2577,14 +2577,14 @@ TYPED_TEST(HNSWTieredIndexTestBasic, overwriteVectorBasic) {
     // swap job execution prior to insert jobs.
     ASSERT_EQ(tiered_index->backendIndex->indexSize(), 0);
     ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
-    ASSERT_EQ(tiered_index->getDistanceFrom(0, overwritten_vec), 0);
+    ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(0, overwritten_vec), 0);
 
     // Ingest the updated vector to HNSW.
     mock_thread_pool.thread_iteration();
     ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
     ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
     ASSERT_EQ(tiered_index->indexLabelCount(), 1);
-    ASSERT_EQ(tiered_index->getDistanceFrom(0, overwritten_vec), 0);
+    ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(0, overwritten_vec), 0);
 }
 
 TYPED_TEST(HNSWTieredIndexTestBasic, overwriteVectorAsync) {
@@ -2873,7 +2873,7 @@ TYPED_TEST(HNSWTieredIndexTest, writeInPlaceMode) {
         ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
         ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
         ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 0);
-        ASSERT_EQ(tiered_index->getDistanceFrom(vec_label, overwritten_vec), 0);
+        ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(vec_label, overwritten_vec), 0);
     }
 
     // Validate that the vector is removed in place.
@@ -3004,7 +3004,7 @@ TYPED_TEST(HNSWTieredIndexTest, bufferLimit) {
         ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
         ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
         ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 1);
-        ASSERT_EQ(tiered_index->getDistanceFrom(vec_label, overwritten_vec), 0);
+        ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(vec_label, overwritten_vec), 0);
         // The first job in Q should be the invalid overwritten insert vector job.
         ASSERT_EQ(mock_thread_pool.jobQ.front().job->isValid, false);
         ASSERT_EQ(reinterpret_cast<HNSWInsertJob *>(mock_thread_pool.jobQ.front().job)->id, 0);
@@ -3030,7 +3030,7 @@ TYPED_TEST(HNSWTieredIndexTest, bufferLimit) {
         ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
         ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 1);
         ASSERT_EQ(tiered_index->indexLabelCount(), 3);
-        ASSERT_EQ(tiered_index->getDistanceFrom(vec_label, overwritten_vec), 0);
+        ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(vec_label, overwritten_vec), 0);
     }
 }
 

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -1289,9 +1289,9 @@ TYPED_TEST(HNSWTieredIndexTest, parallelInsertAdHoc) {
         bool isMulti =
             reinterpret_cast<TieredHNSWIndex<TEST_DATA_T, TEST_DIST_T> *>(search_job->index)
                 ->backendIndex->isMultiValue();
-        search_job->index->acquireLocks();
+        VecSimTieredIndex_AcquireSharedLocks(search_job->index);
         ASSERT_EQ(0, VecSimIndex_GetDistanceFrom(search_job->index, label, query));
-        search_job->index->releaseLocks();
+        VecSimTieredIndex_ReleaseSharedLocks(search_job->index);
         (*search_job->successful_searches)++;
         delete job;
     };


### PR DESCRIPTION
**Describe the changes in the pull request**

In ad-hoc BF mode of the tiered index, we call internally to `getDistanceFrom` of the flat and HNSW indexes. These calls access the indexes' data, and it is not safe to run insert/delete operations in parallel. Until now we were acquiring the locks internally, but since this is usually called for every vector individually, we see that the overhead of acquiring and releasing the locks is significant in that case.
Hence we introduce the new API for acquiring and releasing the locks for shared ownership and assume that the caller acquires the locks while calling the tiered index `getDistanceFrom`.

**Mark if applicable**

- [X] This PR introduces API changes
- [ ] This PR introduces serialization changes
