### PR TITLE
Fix flaky test_tiered_hnsw:bufferLimitAsync

### DIFF
--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -3071,8 +3071,11 @@ TYPED_TEST(HNSWTieredIndexTest, bufferLimitAsync) {
                       TypeParam::isMulti() ? 1 : 1 - overwrite);
             EXPECT_LE(tiered_index->frontendIndex->indexSize(), flat_buffer_limit);
         }
+        // In first run, wait until all vectors are moved from flat index to HNSW backend index.
+        while (tiered_index->backendIndex->indexSize() < n) {
+            /*do nothing*/
+        }
     }
-
     mock_thread_pool.thread_pool_join();
     EXPECT_EQ(tiered_index->backendIndex->indexSize(), 2 * n);
     EXPECT_EQ(tiered_index->indexLabelCount(), n_labels);


### PR DESCRIPTION
**Describe the changes in the pull request**

The flakiness derived from the fact that we are overriding vectors right after we insert them to the tiered index, then we verify that the backend index contains `2n` vectors where `n` is the number of vectors inserted (and overwritten). We expect to find `2n` vectors since we do not perform GC in the tiered index. However, if we overwrite a vector BEFORE it was moved to the backend HNSW index, it will be erased directly from the flat index and will not be at the backend index eventually, hence the number of vectors in the HNSW is not constant.
The solution - waiting for all vectors to be moved into HNSW after insertion of the first `n` vectors and before overiting starts.  

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
