### PR TITLE
Improve updatable heap - [MOD-5489]

### DIFF
--- a/check-format.sh
+++ b/check-format.sh
@@ -2,13 +2,8 @@
 CLANG_FMT_SRCS=$(find ./src/ \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))
 CLANG_FMT_TESTS="$(find ./tests/ -type d \( -path ./tests/unit/build \) -prune -false -o  \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))"
 
-E=0
-for filename in $CLANG_FMT_SRCS $CLANG_FMT_TESTS; do
-    if [[ $FIX == 1 ]]; then
-        clang-format --verbose -style=file -i $filename
-    else
-        echo "Checking $filename ..."
-        { clang-format -style=file -Werror --dry-run $filename; (( E |= $? )); } || true
-    fi
-done
-exit $E
+if [[ $FIX == 1 ]]; then
+    clang-format --verbose -style=file -i $CLANG_FMT_SRCS $CLANG_FMT_TESTS
+else
+    clang-format -style=file -Werror --dry-run $CLANG_FMT_SRCS $CLANG_FMT_TESTS
+fi

--- a/src/VecSim/algorithms/brute_force/brute_force_multi.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_multi.h
@@ -21,7 +21,7 @@ public:
         : BruteForceIndex<DataType, DistType>(params, abstractInitParams),
           labelToIdsLookup(this->allocator) {}
 
-    ~BruteForceIndex_Multi() {}
+    ~BruteForceIndex_Multi() = default;
 
     int addVector(const void *vector_data, labelType label, void *auxiliaryCtx = nullptr) override;
     int deleteVector(labelType labelType) override;

--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -19,7 +19,7 @@ protected:
 public:
     BruteForceIndex_Single(const BFParams *params,
                            const AbstractIndexInitParams &abstractInitParams);
-    ~BruteForceIndex_Single();
+    ~BruteForceIndex_Single() = default;
 
     int addVector(const void *vector_data, labelType label, void *auxiliaryCtx = nullptr) override;
     int deleteVector(labelType label) override;
@@ -113,9 +113,6 @@ BruteForceIndex_Single<DataType, DistType>::BruteForceIndex_Single(
     const BFParams *params, const AbstractIndexInitParams &abstractInitParams)
     : BruteForceIndex<DataType, DistType>(params, abstractInitParams),
       labelToIdLookup(this->allocator) {}
-
-template <typename DataType, typename DistType>
-BruteForceIndex_Single<DataType, DistType>::~BruteForceIndex_Single() {}
 
 template <typename DataType, typename DistType>
 int BruteForceIndex_Single<DataType, DistType>::addVector(const void *vector_data, labelType label,

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -76,7 +76,7 @@ public:
         }
     }
 #endif
-    ~HNSWIndex_Multi() {}
+    ~HNSWIndex_Multi() = default;
 
     inline candidatesLabelsMaxHeap<DistType> *getNewMaxPriorityQueue() const override {
         return new (this->allocator)

--- a/src/VecSim/algorithms/hnsw/hnsw_multi_batch_iterator.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi_batch_iterator.h
@@ -27,7 +27,7 @@ public:
         : HNSW_BatchIterator<DataType, DistType>(query_vector, index, queryParams, allocator),
           returned(this->index->indexSize(), this->allocator) {}
 
-    ~HNSWMulti_BatchIterator() override {}
+    ~HNSWMulti_BatchIterator() override = default;
 
     void reset() override;
 };

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -50,7 +50,7 @@ public:
         vectors_output.push_back(vec);
     }
 #endif
-    ~HNSWIndex_Single() {}
+    ~HNSWIndex_Single() = default;
 
     inline candidatesLabelsMaxHeap<DistType> *getNewMaxPriorityQueue() const override {
         return new (this->allocator)

--- a/src/VecSim/algorithms/hnsw/hnsw_single_batch_iterator.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single_batch_iterator.h
@@ -25,7 +25,7 @@ public:
                              std::shared_ptr<VecSimAllocator> allocator)
         : HNSW_BatchIterator<DataType, DistType>(query_vector, index, queryParams, allocator) {}
 
-    ~HNSWSingle_BatchIterator() override {}
+    ~HNSWSingle_BatchIterator() override = default;
 };
 
 /******************** Implementation **************/

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -5,7 +5,6 @@
 #include "hnsw.h"
 #include "VecSim/index_factories/hnsw_factory.h"
 
-#include <unordered_map>
 /**
  * Definition of a job that inserts a new vector from flat into HNSW Index.
  */
@@ -660,6 +659,7 @@ size_t TieredHNSWIndex<DataType, DistType>::indexLabelCount() const {
     auto flat_labels = this->frontendIndex->getLabelsSet();
     auto hnsw_labels = this->getHNSWIndex()->getLabelsSet();
     std::vector<labelType> output;
+    output.reserve(flat_labels.size() + hnsw_labels.size());
     std::set_union(flat_labels.begin(), flat_labels.end(), hnsw_labels.begin(), hnsw_labels.end(),
                    std::back_inserter(output));
     this->flatIndexGuard.unlock();

--- a/src/VecSim/algorithms/hnsw/visited_nodes_handler.cpp
+++ b/src/VecSim/algorithms/hnsw/visited_nodes_handler.cpp
@@ -36,7 +36,7 @@ tag_t VisitedNodesHandler::getFreshTag() {
     return cur_tag;
 }
 
-VisitedNodesHandler::~VisitedNodesHandler() { allocator->free_allocation(elements_tags); }
+VisitedNodesHandler::~VisitedNodesHandler() noexcept { allocator->free_allocation(elements_tags); }
 
 /**
  * VisitedNodesHandlerPool methods to enable parallel graph scans.

--- a/src/VecSim/algorithms/hnsw/visited_nodes_handler.h
+++ b/src/VecSim/algorithms/hnsw/visited_nodes_handler.h
@@ -44,7 +44,7 @@ public:
     // Get the tag in which node_id is marked currently.
     inline tag_t getNodeTag(unsigned int node_id) { return elements_tags[node_id]; }
 
-    ~VisitedNodesHandler() override;
+    ~VisitedNodesHandler() noexcept override;
 };
 
 /**

--- a/src/VecSim/batch_iterator.h
+++ b/src/VecSim/batch_iterator.h
@@ -47,5 +47,5 @@ public:
     // Reset the iterator to the initial state, before any results has been returned.
     virtual void reset() = 0;
 
-    virtual ~VecSimBatchIterator() { allocator->free_allocation(this->query_vector); };
+    virtual ~VecSimBatchIterator() noexcept { allocator->free_allocation(this->query_vector); };
 };

--- a/src/VecSim/memory/vecsim_base.h
+++ b/src/VecSim/memory/vecsim_base.h
@@ -32,5 +32,5 @@ public:
         return this->allocator->getAllocationSize();
     }
 
-    virtual ~VecsimBaseObject() {}
+    virtual ~VecsimBaseObject() = default;
 };

--- a/src/VecSim/utils/query_result_utils.h
+++ b/src/VecSim/utils/query_result_utils.h
@@ -8,7 +8,6 @@
 
 #include "VecSim/query_result_definitions.h"
 #include <VecSim/utils/vec_utils.h>
-#include <unordered_set>
 
 // Compare two results by score, and if the scores are equal, by id.
 inline int cmpVecSimQueryResultByScoreThenId(const VecSimQueryResultContainer::iterator res1,

--- a/src/VecSim/utils/vecsim_stl.h
+++ b/src/VecSim/utils/vecsim_stl.h
@@ -35,7 +35,7 @@ struct abstract_priority_queue : public VecsimBaseObject {
 public:
     abstract_priority_queue(const std::shared_ptr<VecSimAllocator> &alloc)
         : VecsimBaseObject(alloc) {}
-    ~abstract_priority_queue() {}
+    ~abstract_priority_queue() = default;
 
     virtual inline void emplace(Priority p, Value v) = 0;
     virtual inline bool empty() const = 0;
@@ -53,7 +53,7 @@ struct max_priority_queue : public abstract_priority_queue<Priority, Value>, pub
 public:
     max_priority_queue(const std::shared_ptr<VecSimAllocator> &alloc)
         : abstract_priority_queue<Priority, Value>(alloc), std_queue(alloc) {}
-    ~max_priority_queue() {}
+    ~max_priority_queue() = default;
 
     inline void emplace(Priority p, Value v) override { std_queue::emplace(p, v); }
     inline bool empty() const override { return std_queue::empty(); }

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -96,7 +96,7 @@ public:
      * @brief Destroy the Vec Sim Index object
      *
      */
-    virtual ~VecSimIndexAbstract() {}
+    virtual ~VecSimIndexAbstract() = default;
 
     inline dist_func_t<DistType> getDistFunc() const { return distFunc; }
     inline size_t getDim() const { return dim; }

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -31,7 +31,7 @@ public:
      * @brief Destroy the Vec Sim Index object
      *
      */
-    virtual ~VecSimIndexInterface() {}
+    virtual ~VecSimIndexInterface() = default;
 
     /**
      * @brief This Function prepares the blob before sending it to addVector.

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -86,7 +86,7 @@ public:
         return wrap_results(&results, actual_n_res);
     }
     void reset() { VecSimBatchIterator_Reset(batchIterator.get()); }
-    virtual ~PyBatchIterator() {}
+    virtual ~PyBatchIterator() = default;
 };
 
 // @input or @query arguments are a py::object object. (numpy arrays are acceptable)

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_class.h
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_class.h
@@ -19,7 +19,7 @@ protected:
 
 public:
     BM_VecSimSpaces();
-    ~BM_VecSimSpaces() {}
+    ~BM_VecSimSpaces() = default;
 
     void SetUp(const ::benchmark::State &state);
     void TearDown(const ::benchmark::State &state);


### PR DESCRIPTION
**Describe the changes in the pull request**

Replacing the `valueToPriority` unordered map of the updatable heap with `valueToNode`.

Instead of having a multimap from priority to values, and an unordered map from value to priority, we will have the same multimap, but with a map from value to its node in the multimap. This way we have less lookup work to do when updating a value's priority.

Additional changes:

1. Replacing empty destructors with default (good practice)
2. Simplifying formatting script

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
