### PR TITLE
Fix label deletion from an unordered map

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -184,7 +184,7 @@ int HNSWIndex_Multi<DataType, DistType>::deleteVector(const labelType label) {
         this->removeVectorInPlace(id);
         ret++;
     }
-    labelLookup.erase(ids);
+    labelLookup.erase(label);
     return ret;
 }
 


### PR DESCRIPTION
**Describe the changes in the pull request**

As stated in [the documentation of the unordered map](https://en.cppreference.com/w/cpp/container/unordered_map#Iterator_invalidation), iterators to an unordered map should be invalidated after reserving memory.

The bug was that we used the iterator we got from `find()` at the start of the function for deleting the IDs from the index and lastly deleting the label from the map.

Using the iterator returned from the previous lookup might be invalid as we might resize the index while deleting the IDs one by one.

The fix is to use a reference to the ids vector itself in the loop, and finally delete the label from the map using the label and not the iterator.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
