### PR TITLE
[MOD-7259] Restore bionic workkflow

### DIFF
--- a/.github/workflows/bionic.yml
+++ b/.github/workflows/bionic.yml
@@ -1,0 +1,10 @@
+
+name: bionic flow
+
+on: [workflow_dispatch]
+
+jobs:
+  bionic:
+    uses: ./.github/workflows/task-unit-test.yml
+    with:
+      container: ubuntu:bionic

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -22,6 +22,12 @@ jobs:
     uses: ./.github/workflows/task-unit-test.yml
     with:
       container: ubuntu:focal
+  bionic:
+    needs: [check-if-docs-only]
+    if: ${{ needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}
+    uses: ./.github/workflows/task-unit-test.yml
+    with:
+      container: ubuntu:bionic
   bullseye:
     needs: [check-if-docs-only]
     if: ${{ needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -21,6 +21,11 @@ jobs:
     with:
       container: ubuntu:focal
       run-valgrind: false
+  bionic:
+    uses: ./.github/workflows/task-unit-test.yml
+    with:
+      container: ubuntu:bionic
+      run-valgrind: false
   bullseye:
     uses: ./.github/workflows/task-unit-test.yml
     with:

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,37 +9,10 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
-  macos:
+  bionic:
     uses: ./.github/workflows/task-unit-test.yml
     with:
-      env: macos-latest
-      run-valgrind: false
-  rocky8:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: rockylinux:8
-      run-valgrind: false
-  amazonlinux2:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: amazonlinux:2
-      pre-checkout-script: yum install -y tar gzip
-      run-valgrind: false
-  mariner2:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: mcr.microsoft.com/cbl-mariner/base/core:2.0
-      pre-checkout-script: tdnf install -y --noplugins --skipsignature tar gzip
-      run-valgrind: false # TODO: enable valgrind? (requires to install valgrind)
-  rocky9:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: rockylinux:9
-      run-valgrind: false
-  jammy:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: ubuntu:jammy
+      container: ubuntu:bionic
       run-valgrind: false

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
   bionic:
     uses: ./.github/workflows/task-unit-test.yml

--- a/.install/ubuntu_18.04.sh
+++ b/.install/ubuntu_18.04.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+export DEBIAN_FRONTEND=noninteractive
+MODE=$1 # whether to install using sudo or not
+
+$MODE apt-get update -qq
+$MODE apt-get upgrade -yqq
+$MODE apt-get dist-upgrade -yqq
+$MODE apt install -yqq software-properties-common
+$MODE add-apt-repository ppa:ubuntu-toolchain-r/test -y
+$MODE apt update
+$MODE apt-get install -yqq git wget make gcc-11 g++-11 libc6-dbg
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 --slave /usr/bin/g++ g++ /usr/bin/g++-11
+
+wget https://sourceware.org/pub/valgrind/valgrind-3.18.0.tar.bz2
+tar -xjf valgrind-3.18.0.tar.bz2
+cd valgrind-3.18.0
+./configure
+make
+$MODE make install
+cd ..
+
+source install_cmake.sh $MODE

--- a/cmake/x86_64InstructionFlags.cmake
+++ b/cmake/x86_64InstructionFlags.cmake
@@ -19,6 +19,18 @@ if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
 	CHECK_CXX_COMPILER_FLAG(-msse3 CXX_SSE3)
 	CHECK_CXX_COMPILER_FLAG(-msse CXX_SSE)
 
+	# Turn off AVX512BF16 on Ubuntu 18.04 as it is not supported by its binutils assembler version.
+	if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+		execute_process(COMMAND lsb_release -rs
+					OUTPUT_VARIABLE UBUNTU_VERSION
+					OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+		if("${UBUNTU_VERSION}" STREQUAL "18.04")
+			message(STATUS "Compiling on Ubuntu 18.04, turning off CXX_AVX512BF16 flag.")
+			set(CXX_AVX512BF16 FALSE)
+		endif()
+	endif()
+
 	if(CXX_AVX512VL AND CXX_AVX512BF16)
 		add_compile_definitions(OPT_AVX512_BF16_VL)
 	endif()


### PR DESCRIPTION
This PR reinstates support for Ubuntu 18, which was previously removed in [PR #472](https://github.com/RedisAI/VectorSimilarity/pull/472).

The assembler provided by the binutils package in Ubuntu 18 does not support the assembly instructions included in the AVX512BF16 CPU flag. As a result, compilation errors are raised when attempting to compile code that requires this flag.

To avoid these errors, this PR disables the compilation of any code that requires the AVX512BF16 CPU flag when building on Ubuntu 18.
