### PR TITLE
[MOD-7325] Re-design benchmark class:

### DIFF
--- a/tests/benchmark/spaces_benchmarks/bm_spaces.h
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces.h
@@ -25,8 +25,8 @@
 
 // Defining the generic benchmark flow: if there is support for the optimization, benchmark the
 // function.
-#define BENCHMARK_DISTANCE_F(type_prefix, arch, metric, bm_name, arch_supported)                   \
-    BENCHMARK_DEFINE_F(BM_VecSimSpaces, type_prefix##_##arch##_##metric##_##bm_name)               \
+#define BENCHMARK_DISTANCE_F(bm_class, type_prefix, arch, metric, bm_name, arch_supported)         \
+    BENCHMARK_DEFINE_F(bm_class, type_prefix##_##arch##_##metric##_##bm_name)                      \
     (benchmark::State & st) {                                                                      \
         if (!arch_supported) {                                                                     \
             st.SkipWithError("This benchmark requires " #arch ", which is not available");         \
@@ -55,36 +55,41 @@
 // elements) FP32 = residual = 1,2,3, FP64 = residual = 1, BF16 = residual = 1,2,3,4,5,6,7...
 #define RESIDUAL_PARAMS(elem_per_128_bits) DenseRange(128 + 1, 128 + elem_per_128_bits - 1, 1)
 
-#define INITIALIZE_BM(type_prefix, arch, metric, bm_name, arch_supported)                          \
-    BENCHMARK_DISTANCE_F(type_prefix, arch, metric, bm_name, arch_supported)                       \
-    BENCHMARK_REGISTER_F(BM_VecSimSpaces, type_prefix##_##arch##_##metric##_##bm_name)             \
+#define INITIALIZE_BM(bm_class, type_prefix, arch, metric, bm_name, arch_supported)                \
+    BENCHMARK_DISTANCE_F(bm_class, type_prefix, arch, metric, bm_name, arch_supported)             \
+    BENCHMARK_REGISTER_F(bm_class, type_prefix##_##arch##_##metric##_##bm_name)                    \
         ->ArgName("Dimension")                                                                     \
         ->Unit(benchmark::kNanosecond)
 
-#define INITIALIZE_EXACT_512BIT_BM(type_prefix, arch, metric, dim_opt, arch_supported)             \
-    INITIALIZE_BM(type_prefix, arch, metric, 512_bit_chunks, arch_supported)                       \
+#define INITIALIZE_EXACT_512BIT_BM(bm_class, type_prefix, arch, metric, dim_opt, arch_supported)   \
+    INITIALIZE_BM(bm_class, type_prefix, arch, metric, 512_bit_chunks, arch_supported)             \
         ->EXACT_512BIT_PARAMS(dim_opt)
 
-#define INITIALIZE_EXACT_128BIT_BM(type_prefix, arch, metric, dim_opt, arch_supported)             \
-    INITIALIZE_BM(type_prefix, arch, metric, 128_bit_chunks, arch_supported)                       \
+#define INITIALIZE_EXACT_128BIT_BM(bm_class, type_prefix, arch, metric, dim_opt, arch_supported)   \
+    INITIALIZE_BM(bm_class, type_prefix, arch, metric, 128_bit_chunks, arch_supported)             \
         ->EXACT_128BIT_PARAMS(dim_opt / 4)
 
-#define INITIALIZE_RESIDUAL_BM(type_prefix, arch, metric, dim_opt, arch_supported)                 \
-    INITIALIZE_BM(type_prefix, arch, metric, residual, arch_supported)->RESIDUAL_PARAMS(dim_opt / 4)
+#define INITIALIZE_RESIDUAL_BM(bm_class, type_prefix, arch, metric, dim_opt, arch_supported)       \
+    INITIALIZE_BM(bm_class, type_prefix, arch, metric, residual, arch_supported)                   \
+        ->RESIDUAL_PARAMS(dim_opt / 4)
+
+#define INITIALIZE_HIGH_DIM(bm_class, type_prefix, arch, metric, arch_supported)                   \
+    INITIALIZE_BM(bm_class, type_prefix, arch, metric, high_dim, arch_supported)                   \
+        ->DenseRange(900, 1000, 15)
 
 // Naive algorithms
 
-#define BENCHMARK_DEFINE_NAIVE(type_prefix, metric)                                                \
-    BENCHMARK_DEFINE_F(BM_VecSimSpaces, type_prefix##_NAIVE_##metric)                              \
+#define BENCHMARK_DEFINE_NAIVE(bm_class, type_prefix, metric)                                      \
+    BENCHMARK_DEFINE_F(bm_class, type_prefix##_NAIVE_##metric)                                     \
     (benchmark::State & st) {                                                                      \
         for (auto _ : st) {                                                                        \
             type_prefix##_##metric(v1, v2, dim);                                                   \
         }                                                                                          \
     }
 
-#define INITIALIZE_NAIVE_BM(type_prefix, metric, dim_opt)                                          \
-    BENCHMARK_DEFINE_NAIVE(type_prefix, metric)                                                    \
-    BENCHMARK_REGISTER_F(BM_VecSimSpaces, type_prefix##_NAIVE_##metric)                            \
+#define INITIALIZE_NAIVE_BM(bm_class, type_prefix, metric, dim_opt)                                \
+    BENCHMARK_DEFINE_NAIVE(bm_class, type_prefix, metric)                                          \
+    BENCHMARK_REGISTER_F(bm_class, type_prefix##_NAIVE_##metric)                                   \
         ->ArgName("Dimension")                                                                     \
         ->Unit(benchmark::kNanosecond)                                                             \
         ->Arg(100)                                                                                 \
@@ -92,16 +97,18 @@
         ->Arg(dim_opt + dim_opt / 4)                                                               \
         ->Arg(dim_opt - 1)
 
-#define INITIALIZE_BENCHMARKS_SET_L2(type_prefix, arch, dim_opt, arch_supported)                   \
-    INITIALIZE_EXACT_128BIT_BM(type_prefix, arch, L2, dim_opt, arch_supported);                    \
-    INITIALIZE_EXACT_512BIT_BM(type_prefix, arch, L2, dim_opt, arch_supported);                    \
-    INITIALIZE_RESIDUAL_BM(type_prefix, arch, L2, dim_opt, arch_supported);
+#define INITIALIZE_BENCHMARKS_SET_L2(bm_class, type_prefix, arch, dim_opt, arch_supported)         \
+    INITIALIZE_HIGH_DIM(bm_class, type_prefix, arch, L2, arch_supported);                          \
+    INITIALIZE_EXACT_128BIT_BM(bm_class, type_prefix, arch, L2, dim_opt, arch_supported);          \
+    INITIALIZE_EXACT_512BIT_BM(bm_class, type_prefix, arch, L2, dim_opt, arch_supported);          \
+    INITIALIZE_RESIDUAL_BM(bm_class, type_prefix, arch, L2, dim_opt, arch_supported);
 
-#define INITIALIZE_BENCHMARKS_SET_IP(type_prefix, arch, dim_opt, arch_supported)                   \
-    INITIALIZE_EXACT_128BIT_BM(type_prefix, arch, IP, dim_opt, arch_supported);                    \
-    INITIALIZE_EXACT_512BIT_BM(type_prefix, arch, IP, dim_opt, arch_supported);                    \
-    INITIALIZE_RESIDUAL_BM(type_prefix, arch, IP, dim_opt, arch_supported);
+#define INITIALIZE_BENCHMARKS_SET_IP(bm_class, type_prefix, arch, dim_opt, arch_supported)         \
+    INITIALIZE_HIGH_DIM(bm_class, type_prefix, arch, IP, arch_supported);                          \
+    INITIALIZE_EXACT_128BIT_BM(bm_class, type_prefix, arch, IP, dim_opt, arch_supported);          \
+    INITIALIZE_EXACT_512BIT_BM(bm_class, type_prefix, arch, IP, dim_opt, arch_supported);          \
+    INITIALIZE_RESIDUAL_BM(bm_class, type_prefix, arch, IP, dim_opt, arch_supported);
 
-#define INITIALIZE_BENCHMARKS_SET(type_prefix, arch, dim_opt, arch_supported)                      \
-    INITIALIZE_BENCHMARKS_SET_L2(type_prefix, arch, dim_opt, arch_supported)                       \
-    INITIALIZE_BENCHMARKS_SET_IP(type_prefix, arch, dim_opt, arch_supported)
+#define INITIALIZE_BENCHMARKS_SET(bm_class, type_prefix, arch, dim_opt, arch_supported)            \
+    INITIALIZE_BENCHMARKS_SET_L2(bm_class, type_prefix, arch, dim_opt, arch_supported)             \
+    INITIALIZE_BENCHMARKS_SET_IP(bm_class, type_prefix, arch, dim_opt, arch_supported)

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_bf16.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_bf16.cpp
@@ -5,8 +5,13 @@
  */
 
 #include "VecSim/types/bfloat16.h"
-#define DATA_TYPE vecsim_types::bfloat16
 #include "bm_spaces.h"
+
+class BM_VecSimSpaces_BF16 : public BM_VecSimSpaces<vecsim_types::bfloat16> {
+    vecsim_types::bfloat16 DoubleToType(double val) override {
+        return vecsim_types::float_to_bf16(val);
+    }
+};
 
 #ifdef CPU_FEATURES_ARCH_X86_64
 cpu_features::X86Features opt = cpu_features::GetX86Info().features;
@@ -14,29 +19,31 @@ cpu_features::X86Features opt = cpu_features::GetX86Info().features;
 // AVX512_BF16 functions
 #ifdef OPT_AVX512_BF16_VL
 bool avx512_bf16_vl_supported = opt.avx512_bf16 && opt.avx512vl;
-INITIALIZE_BENCHMARKS_SET_IP(BF16, AVX512BF16_VL, 32, avx512_bf16_vl_supported);
+INITIALIZE_BENCHMARKS_SET_IP(BM_VecSimSpaces_BF16, BF16, AVX512BF16_VL, 32,
+                             avx512_bf16_vl_supported);
 #endif // AVX512_BF16
 
 // AVX512 functions
 #ifdef OPT_AVX512_BW_VBMI2
 bool avx512_bw_vbmi2_supported = opt.avx512bw && opt.avx512vbmi2;
-INITIALIZE_BENCHMARKS_SET(BF16, AVX512BW_VBMI2, 32, avx512_bw_vbmi2_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_BF16, BF16, AVX512BW_VBMI2, 32,
+                          avx512_bw_vbmi2_supported);
 #endif // AVX512F
 
 // AVX functions
 #ifdef OPT_AVX2
 bool avx2_supported = opt.avx2;
-INITIALIZE_BENCHMARKS_SET(BF16, AVX2, 32, avx2_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_BF16, BF16, AVX2, 32, avx2_supported);
 #endif // AVX
 
 // SSE functions
 #ifdef OPT_SSE3
 bool sse3_supported = opt.sse3;
-INITIALIZE_BENCHMARKS_SET(BF16, SSE3, 32, sse3_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_BF16, BF16, SSE3, 32, sse3_supported);
 #endif // SSE
 
 #endif // x86_64
 
-INITIALIZE_NAIVE_BM(BF16, InnerProduct_LittleEndian, 32);
-INITIALIZE_NAIVE_BM(BF16, L2Sqr_LittleEndian, 32);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_BF16, BF16, InnerProduct_LittleEndian, 32);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_BF16, BF16, L2Sqr_LittleEndian, 32);
 BENCHMARK_MAIN();

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_class.h
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_class.h
@@ -10,34 +10,31 @@
 
 #pragma once
 
+template <typename DATA_TYPE>
 class BM_VecSimSpaces : public benchmark::Fixture {
 protected:
     std::mt19937 rng;
     size_t dim;
     DATA_TYPE *v1, *v2;
 
+    virtual DATA_TYPE DoubleToType(double val) { return val; }
+
 public:
-    BM_VecSimSpaces();
+    BM_VecSimSpaces() { rng.seed(47); }
     ~BM_VecSimSpaces() = default;
 
-    void SetUp(const ::benchmark::State &state);
-    void TearDown(const ::benchmark::State &state);
-};
-
-BM_VecSimSpaces::BM_VecSimSpaces() { rng.seed(47); }
-
-void BM_VecSimSpaces::SetUp(const ::benchmark::State &state) {
-    dim = state.range(0);
-    v1 = new DATA_TYPE[dim];
-    v2 = new DATA_TYPE[dim];
-    std::uniform_real_distribution<double> distrib(-1.0, 1.0);
-    for (size_t i = 0; i < dim; i++) {
-        v1[i] = (DATA_TYPE)distrib(rng);
-        v2[i] = (DATA_TYPE)distrib(rng);
+    void SetUp(const ::benchmark::State &state) {
+        dim = state.range(0);
+        v1 = new DATA_TYPE[dim];
+        v2 = new DATA_TYPE[dim];
+        std::uniform_real_distribution<double> distrib(-1.0, 1.0);
+        for (size_t i = 0; i < dim; i++) {
+            v1[i] = DoubleToType(distrib(rng));
+            v2[i] = DoubleToType(distrib(rng));
+        }
     }
-}
-
-void BM_VecSimSpaces::TearDown(const ::benchmark::State &state) {
-    delete v1;
-    delete v2;
-}
+    void TearDown(const ::benchmark::State &state) {
+        delete v1;
+        delete v2;
+    }
+};

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_fp16.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_fp16.cpp
@@ -5,8 +5,13 @@
  */
 
 #include "VecSim/types/float16.h"
-#define DATA_TYPE vecsim_types::float16
 #include "bm_spaces.h"
+
+class BM_VecSimSpaces_FP16 : public BM_VecSimSpaces<vecsim_types::float16> {
+    vecsim_types::float16 DoubleToType(double val) override {
+        return vecsim_types::FP32_to_FP16(val);
+    }
+};
 
 #ifdef CPU_FEATURES_ARCH_X86_64
 cpu_features::X86Features opt = cpu_features::GetX86Info().features;
@@ -14,18 +19,18 @@ cpu_features::X86Features opt = cpu_features::GetX86Info().features;
 // AVX512_BW_VL functions
 #ifdef OPT_AVX512F
 bool avx512_supported = opt.avx512f;
-INITIALIZE_BENCHMARKS_SET(FP16, AVX512, 32, avx512_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_FP16, FP16, AVX512, 32, avx512_supported);
 #endif // OPT_AVX512F
 
 // AVX functions
 #ifdef OPT_F16C
 bool avx512_bw_f16c_supported = opt.f16c && opt.fma3 && opt.avx;
-INITIALIZE_BENCHMARKS_SET(FP16, F16C, 32, avx512_bw_f16c_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_FP16, FP16, F16C, 32, avx512_bw_f16c_supported);
 #endif // OPT_F16C
 
 #endif // x86_64
 
-INITIALIZE_NAIVE_BM(FP16, InnerProduct, 32);
-INITIALIZE_NAIVE_BM(FP16, L2Sqr, 32);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_FP16, FP16, InnerProduct, 32);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_FP16, FP16, L2Sqr, 32);
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_fp32.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_fp32.cpp
@@ -3,8 +3,9 @@
  *Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
  *the Server Side Public License v1 (SSPLv1).
  */
-#define DATA_TYPE float
 #include "bm_spaces.h"
+
+class BM_VecSimSpaces_FP32 : public BM_VecSimSpaces<float> {};
 
 #ifdef CPU_FEATURES_ARCH_X86_64
 cpu_features::X86Features opt = cpu_features::GetX86Info().features;
@@ -12,27 +13,27 @@ cpu_features::X86Features opt = cpu_features::GetX86Info().features;
 // AVX512 functions
 #ifdef OPT_AVX512F
 bool avx512_supported = opt.avx512f;
-INITIALIZE_BENCHMARKS_SET(FP32, AVX512, 16, avx512_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_FP32, FP32, AVX512, 16, avx512_supported);
 #endif // AVX512F
 
 // AVX functions
 #ifdef OPT_AVX
 bool avx_supported = opt.avx;
-INITIALIZE_BENCHMARKS_SET(FP32, AVX, 16, avx_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_FP32, FP32, AVX, 16, avx_supported);
 #endif // AVX
 
 // SSE functions
 #ifdef OPT_SSE
 bool sse_supported = opt.sse;
-INITIALIZE_BENCHMARKS_SET(FP32, SSE, 16, sse_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_FP32, FP32, SSE, 16, sse_supported);
 #endif // SSE
 
 #endif // x86_64
 
 // Naive algorithms
 
-INITIALIZE_NAIVE_BM(FP32, InnerProduct, 16);
-INITIALIZE_NAIVE_BM(FP32, L2Sqr, 16);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_FP32, FP32, InnerProduct, 16);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_FP32, FP32, L2Sqr, 16);
 
 // Naive
 

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_fp64.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_fp64.cpp
@@ -3,8 +3,9 @@
  *Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
  *the Server Side Public License v1 (SSPLv1).
  */
-#define DATA_TYPE double
 #include "bm_spaces.h"
+
+class BM_VecSimSpaces_FP64 : public BM_VecSimSpaces<double> {};
 
 #ifdef CPU_FEATURES_ARCH_X86_64
 cpu_features::X86Features opt = cpu_features::GetX86Info().features;
@@ -12,26 +13,26 @@ cpu_features::X86Features opt = cpu_features::GetX86Info().features;
 // AVX512 functions
 #ifdef OPT_AVX512F
 bool avx512_supported = opt.avx512f;
-INITIALIZE_BENCHMARKS_SET(FP64, AVX512, 8, avx512_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_FP64, FP64, AVX512, 8, avx512_supported);
 #endif // AVX512F
 
 // AVX functions
 #ifdef OPT_AVX
 bool avx_supported = opt.avx;
-INITIALIZE_BENCHMARKS_SET(FP64, AVX, 8, avx_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_FP64, FP64, AVX, 8, avx_supported);
 #endif // AVX
 
 // SSE functions
 #ifdef OPT_SSE
 bool sse_supported = opt.sse;
-INITIALIZE_BENCHMARKS_SET(FP64, SSE, 8, sse_supported);
+INITIALIZE_BENCHMARKS_SET(BM_VecSimSpaces_FP64, FP64, SSE, 8, sse_supported);
 #endif // SSE
 
 #endif // x86_64
 
 // Naive algorithms
-INITIALIZE_NAIVE_BM(FP64, InnerProduct, 8);
-INITIALIZE_NAIVE_BM(FP64, L2Sqr, 8);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_FP64, FP64, InnerProduct, 8);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_FP64, FP64, L2Sqr, 8);
 // Naive
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
**Template spaces benchmarks class**

Each type inherits the base class and can modify the conversion method if needed.
This way we can apply conversion for non-native types such as `vecsim_types::float16` and `vecsim_types::bfloat16`, where a c-style cast is not defined.

**Add high dimensions benchmarks**

Another set of spaces benchmarks was added to cover high dimension vectors.
The bm is within the range [900:1000:15]. 
Note that a 32 multiplier exits in this range (dim = 960)