### PR TITLE
Enhance bm files download and add dispatcher to bm flow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,12 +10,23 @@ on:
         type: choice
         options:
           - benchmarks-all
+          - benchmarks-default
           - bm-basics-fp32-single
           - bm-basics-fp32-multi
+          - bm-basics-fp64-single
+          - bm-basics-fp64-multi
           - bm-basics-bf16-single
           - bm-basics-bf16-multi
           - bm-basics-fp16-single
           - bm-basics-fp16-multi
+          - bm-batch-iter-fp32-single
+          - bm-batch-iter-fp32-multi
+          - bm-batch-iter-fp64-single
+          - bm-batch-iter-fp64-multi
+          - bm-batch-iter-bf16-single
+          - bm-batch-iter-bf16-multi
+          - bm-batch-iter-fp16-single
+          - bm-batch-iter-fp16-multi
           - bm-updated-fp32-single
           - bm-spaces
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,23 +10,12 @@ on:
         type: choice
         options:
           - benchmarks-all
-          - benchmarks-default
           - bm-basics-fp32-single
           - bm-basics-fp32-multi
-          - bm-basics-fp64-single
-          - bm-basics-fp64-multi
           - bm-basics-bf16-single
           - bm-basics-bf16-multi
           - bm-basics-fp16-single
           - bm-basics-fp16-multi
-          - bm-batch-iter-fp32-single
-          - bm-batch-iter-fp32-multi
-          - bm-batch-iter-fp64-single
-          - bm-batch-iter-fp64-multi
-          - bm-batch-iter-bf16-single
-          - bm-batch-iter-bf16-multi
-          - bm-batch-iter-fp16-single
-          - bm-batch-iter-fp16-multi
           - bm-updated-fp32-single
           - bm-spaces
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,6 +29,8 @@ on:
           - bm-batch-iter-fp16-multi
           - bm-updated-fp32-single
           - bm-spaces
+        description: 'Benchmarks set to run'
+        default: benchmarks-all
 
 jobs:
   start-runner:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,31 @@ on:
       setup:
         type: string
         required: true
+  workflow_dispatch:
+    inputs:
+      setup:
+        type: choice
+        options:
+          - benchmarks-all
+          - benchmarks-default
+          - bm-basics-fp32-single
+          - bm-basics-fp32-multi
+          - bm-basics-fp64-single
+          - bm-basics-fp64-multi
+          - bm-basics-bf16-single
+          - bm-basics-bf16-multi
+          - bm-basics-fp16-single
+          - bm-basics-fp16-multi
+          - bm-batch-iter-fp32-single
+          - bm-batch-iter-fp32-multi
+          - bm-batch-iter-fp64-single
+          - bm-batch-iter-fp64-multi
+          - bm-batch-iter-bf16-single
+          - bm-batch-iter-bf16-multi
+          - bm-batch-iter-fp16-single
+          - bm-batch-iter-fp16-multi
+          - bm-updated-fp32-single
+          - bm-spaces
 
 jobs:
   start-runner:

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -32,5 +32,4 @@ elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then
     file_name="updated"
 fi
 
-# wget --no-check-certificate -q -i tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt -P tests/benchmark/data
 cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -33,4 +33,4 @@ elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then
 fi
 
 # wget --no-check-certificate -q -i tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt -P tests/benchmark/data
-cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data
+cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -q -P tests/benchmark/data

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -33,4 +33,4 @@ elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then
 fi
 
 # wget --no-check-certificate -q -i tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt -P tests/benchmark/data
-cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 10 wget --no-check-certificate -q -P tests/benchmark/data
+cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 10 wget --no-check-certificate -P tests/benchmark/data

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -32,4 +32,5 @@ elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then
     file_name="updated"
 fi
 
-wget --no-check-certificate -q -i tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt -P tests/benchmark/data
+# wget --no-check-certificate -q -i tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt -P tests/benchmark/data
+cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 10 wget --no-check-certificate -q -P tests/benchmark/data

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -33,4 +33,4 @@ elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then
 fi
 
 # wget --no-check-certificate -q -i tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt -P tests/benchmark/data
-cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -q -P tests/benchmark/data
+cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -33,4 +33,4 @@ elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then
 fi
 
 # wget --no-check-certificate -q -i tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt -P tests/benchmark/data
-cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 10 wget --no-check-certificate -P tests/benchmark/data
+cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data

--- a/tests/benchmark/data/serializer.py
+++ b/tests/benchmark/data/serializer.py
@@ -191,7 +191,7 @@ def serialize(files=DEFAULT_FILES):
                 serialized_raw_name = serialized_raw_name + '-bf16'
             elif hnswparams.type == VecSimType_FLOAT16:
                 serialized_file_name = serialized_file_name + '-fp16'
-                serialized_raw_name = serialized_raw_name + '-fp16
+                serialized_raw_name = serialized_raw_name + '-fp16'
 
             print('first, exporting test set to binary')
             if not file.get('skipRaw', False):


### PR DESCRIPTION
1. Add workflow dispatcher that allows triggering the benchmarks manually
2. parallelize benchmark files download. Downloading all the benchmarks files takes ~5 min instead of more than 20 min.