### PR TITLE
exit if bm_files.sh input is not one of the expected inputs

### DIFF
--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -1,8 +1,6 @@
 BM_TYPE=$1
 if [ -z "$BM_TYPE"  ] || [ "$BM_TYPE" = "benchmarks-all" ]; then
     file_name="all"
-elif [ "$BM_TYPE" = "bm-spaces" ]; then
-    exit 0
 elif [ "$BM_TYPE" = "benchmarks-default" ] \
 || [ "$BM_TYPE" = "bm-basics-fp32-single" ] \
 || [ "$BM_TYPE" = "bm-basics-fp32-multi" ] \
@@ -30,6 +28,8 @@ then
     file_name="basic_fp16"
 elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then
     file_name="updated"
+else
+    echo "No files to download for BM_TYPE=$BM_TYPE"
 fi
 
 cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -30,6 +30,7 @@ elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then
     file_name="updated"
 else
     echo "No files to download for BM_TYPE=$BM_TYPE"
+    exit 0
 fi
 
 cat tests/benchmark/data/hnsw_indices/hnsw_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -2,7 +2,7 @@ BM_TYPE=$1
 if [ -z "$BM_TYPE"  ] || [ "$BM_TYPE" = "benchmarks-all" ]; then
     file_name="all"
 elif [ "$BM_TYPE" = "bm-spaces" ]; then
-    :
+    exit 0
 elif [ "$BM_TYPE" = "benchmarks-default" ] \
 || [ "$BM_TYPE" = "bm-basics-fp32-single" ] \
 || [ "$BM_TYPE" = "bm-basics-fp32-multi" ] \


### PR DESCRIPTION
bm_files.sh script fails when we pass `bm-spaces` since there is no such file.
Fix that by exit if not one of the expected inputs


**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
