### PR TITLE
[MOD-7049] Change bm dimensions

### DIFF
--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -10,5 +10,5 @@ $MODE apt update
 $MODE apt-get install -yqq wget gcc-11 g++-11 make clang-format valgrind python3-pip lcov git
 $MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 --slave /usr/bin/g++ g++ /usr/bin/g++-11
 # align gcov version with gcc version
-update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 60
+$MODE update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 60
 source install_cmake.sh $MODE

--- a/.install/ubuntu_22.04.sh
+++ b/.install/ubuntu_22.04.sh
@@ -7,5 +7,5 @@ $MODE apt-get update -qq || true
 $MODE apt-get install -yqq gcc-12 g++-12 git wget build-essential valgrind lcov
 $MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 60 --slave /usr/bin/g++ g++ /usr/bin/g++-12
 # align gcov version with gcc version
-update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-12 60
+$MODE update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-12 60
 source install_cmake.sh $MODE

--- a/tests/benchmark/spaces_benchmarks/bm_spaces.h
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces.h
@@ -48,12 +48,13 @@
         ->Unit(benchmark::kNanosecond)
 
 /**
- * @param dim_opt: smallest dimension with no residual.
- * i.e smallest dimension to satisfy:
+ * @param dim_opt: Number of elements in 512 bits.
+ * Also, the smallest dimension to satisfy:
  * dim % num_elements_in_512_bits == 0.
- * @param min_no_res_th_dim: a number that is both divisible by 32 to ensure that we have at least
- * one full 512 bits iteration in all types, and higher than the minimum dimension requires to
- * choose all possible optimizations. (currently it's 500 for IP with AVX512_FP16)
+ * @param min_no_res_th_dim: A number that is
+ * 1. divisible by 32 to ensure that we have at least one full 512 bits iteration in all types
+ * 2. higher than the minimum dimension requires to choose all possible optimizations.
+ * (currently it's 500 for IP with AVX512_FP16)
  */
 static constexpr size_t min_no_res_th_dim = 512;
 

--- a/tests/benchmark/spaces_benchmarks/bm_spaces.h
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces.h
@@ -41,47 +41,54 @@
         }                                                                                          \
     }
 
-// dim_opt:   number of elements in 512 bits.
-//            i.e. 512/sizeof(type): FP32 = 16, FP64 = 8, BF16 = 32 ...
-//            The is the number of elements calculated in each distance function loop,
-//            regardless of the arch optimization type.
-// Run each function for {1, 4, 16} iterations.
-#define EXACT_512BIT_PARAMS(dim_opt) RangeMultiplier(4)->Range(dim_opt, 400)
-
-// elem_per_128_bits:   dim_opt / 4.  FP32 = 4, FP64 = 2, BF16 = 8...
-// Dimensions to test 128 bit chunks.
-// Run each function at least one full 512 bits iteration + 1/2/3 iterations of 128 bit chunks.
-#define EXACT_128BIT_PARAMS(elem_per_128_bits)                                                     \
-    DenseRange(128 + elem_per_128_bits, 128 + 3 * elem_per_128_bits, elem_per_128_bits)
-
-// Run each function at least one full 512 bits iteration + (1 * elements : elem_per_128_bits *
-// elements) FP32 = residual = 1,2,3, FP64 = residual = 1, BF16 = residual = 1,2,3,4,5,6,7...
-#define RESIDUAL_PARAMS(elem_per_128_bits) DenseRange(128 + 1, 128 + elem_per_128_bits - 1, 1)
-
 #define INITIALIZE_BM(bm_class, type_prefix, arch, metric, bm_name, arch_supported)                \
     BENCHMARK_DISTANCE_F(bm_class, type_prefix, arch, metric, bm_name, arch_supported)             \
     BENCHMARK_REGISTER_F(bm_class, type_prefix##_##arch##_##metric##_##bm_name)                    \
         ->ArgName("Dimension")                                                                     \
         ->Unit(benchmark::kNanosecond)
 
+/**
+ * @param dim_opt: smallest dimension with no residual.
+ * i.e smallest dimension to satisfy:
+ * dim % num_elements_in_512_bits == 0.
+ * @param min_no_res_th_dim: a number that is both divisible by 32 to ensure that we have at least
+ * one full 512 bits iteration in all types, and higher than the minimum dimension requires to
+ * choose all possible optimizations. (currently it's 500 for IP with AVX512_FP16)
+ */
+static constexpr size_t min_no_res_th_dim = 512;
+
+/**
+ * RangeMultiplier(val)->Range(start, end) generates powers of `val` in the range [start, end],
+ * including `start` and `end`.
+ */
 #define INITIALIZE_EXACT_512BIT_BM(bm_class, type_prefix, arch, metric, dim_opt, arch_supported)   \
     INITIALIZE_BM(bm_class, type_prefix, arch, metric, 512_bit_chunks, arch_supported)             \
-        ->EXACT_512BIT_PARAMS(dim_opt)
+        ->RangeMultiplier(4)                                                                       \
+        ->Range(dim_opt, 1024)
 
-#define INITIALIZE_EXACT_128BIT_BM(bm_class, type_prefix, arch, metric, dim_opt, arch_supported)   \
-    INITIALIZE_BM(bm_class, type_prefix, arch, metric, 128_bit_chunks, arch_supported)             \
-        ->EXACT_128BIT_PARAMS(dim_opt / 4)
-
+/** for `start` = min_no_res_th_dim, we run bm for all dimensions
+ * in the following range: (start, start + 1, start + 2, start + 3, ... start + dim_opt)
+ */
+static constexpr size_t start = min_no_res_th_dim;
 #define INITIALIZE_RESIDUAL_BM(bm_class, type_prefix, arch, metric, dim_opt, arch_supported)       \
     INITIALIZE_BM(bm_class, type_prefix, arch, metric, residual, arch_supported)                   \
-        ->RESIDUAL_PARAMS(dim_opt / 4)
+        ->DenseRange(start + 1, start + dim_opt - 1, 1)
 
+/** Test high dim
+ * This range satisfies at least one full 512 bits iteration in all types.
+ */
 #define INITIALIZE_HIGH_DIM(bm_class, type_prefix, arch, metric, arch_supported)                   \
     INITIALIZE_BM(bm_class, type_prefix, arch, metric, high_dim, arch_supported)                   \
         ->DenseRange(900, 1000, 15)
 
-// Naive algorithms
+/** Test low dim
+ * This range satisfies at least one full 512 bits iteration in all types.
+ */
+#define INITIALIZE_LOW_DIM(bm_class, type_prefix, arch, metric, arch_supported)                    \
+    INITIALIZE_BM(bm_class, type_prefix, arch, metric, low_dim, arch_supported)                    \
+        ->DenseRange(100, 200, 15)
 
+/* Naive algorithms */
 #define BENCHMARK_DEFINE_NAIVE(bm_class, type_prefix, metric)                                      \
     BENCHMARK_DEFINE_F(bm_class, type_prefix##_NAIVE_##metric)                                     \
     (benchmark::State & st) {                                                                      \
@@ -102,13 +109,13 @@
 
 #define INITIALIZE_BENCHMARKS_SET_L2(bm_class, type_prefix, arch, dim_opt, arch_supported)         \
     INITIALIZE_HIGH_DIM(bm_class, type_prefix, arch, L2, arch_supported);                          \
-    INITIALIZE_EXACT_128BIT_BM(bm_class, type_prefix, arch, L2, dim_opt, arch_supported);          \
+    INITIALIZE_LOW_DIM(bm_class, type_prefix, arch, L2, arch_supported);                           \
     INITIALIZE_EXACT_512BIT_BM(bm_class, type_prefix, arch, L2, dim_opt, arch_supported);          \
     INITIALIZE_RESIDUAL_BM(bm_class, type_prefix, arch, L2, dim_opt, arch_supported);
 
 #define INITIALIZE_BENCHMARKS_SET_IP(bm_class, type_prefix, arch, dim_opt, arch_supported)         \
     INITIALIZE_HIGH_DIM(bm_class, type_prefix, arch, IP, arch_supported);                          \
-    INITIALIZE_EXACT_128BIT_BM(bm_class, type_prefix, arch, IP, dim_opt, arch_supported);          \
+    INITIALIZE_LOW_DIM(bm_class, type_prefix, arch, IP, arch_supported);                           \
     INITIALIZE_EXACT_512BIT_BM(bm_class, type_prefix, arch, IP, dim_opt, arch_supported);          \
     INITIALIZE_RESIDUAL_BM(bm_class, type_prefix, arch, IP, dim_opt, arch_supported);
 

--- a/tests/benchmark/spaces_benchmarks/bm_spaces.h
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces.h
@@ -82,7 +82,7 @@ static constexpr size_t start = min_no_res_th_dim;
         ->DenseRange(900, 1000, 15)
 
 /** Test low dim
- * This range satisfies at least one full 512 bits iteration in all types.
+ * This range satisfies at least one full 512-bit iteration in all types (160).
  */
 #define INITIALIZE_LOW_DIM(bm_class, type_prefix, arch, metric, arch_supported)                    \
     INITIALIZE_BM(bm_class, type_prefix, arch, metric, low_dim, arch_supported)                    \

--- a/tests/benchmark/spaces_benchmarks/bm_spaces.h
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces.h
@@ -48,10 +48,7 @@
         ->Unit(benchmark::kNanosecond)
 
 /**
- * @param dim_opt: Number of elements in 512 bits.
- * Also, the smallest dimension to satisfy:
- * dim % num_elements_in_512_bits == 0.
- * @param min_no_res_th_dim: A number that is
+ * A number that is
  * 1. divisible by 32 to ensure that we have at least one full 512 bits iteration in all types
  * 2. higher than the minimum dimension requires to choose all possible optimizations.
  * (currently it's 500 for IP with AVX512_FP16)
@@ -59,6 +56,13 @@
 static constexpr size_t min_no_res_th_dim = 512;
 
 /**
+ * @param dim_opt: Number of elements in 512 bits.
+ */
+
+/**
+ * @param dim_opt is also, the smallest dimension to satisfy:
+ * dim % num_elements_in_512_bits == 0.
+ * We use it to start this set of BM from the smallest dimension that satisfies the above condition.
  * RangeMultiplier(val)->Range(start, end) generates powers of `val` in the range [start, end],
  * including `start` and `end`.
  */
@@ -67,8 +71,9 @@ static constexpr size_t min_no_res_th_dim = 512;
         ->RangeMultiplier(4)                                                                       \
         ->Range(dim_opt, 1024)
 
-/** for `start` = min_no_res_th_dim, we run bm for all dimensions
+/** for `start` = min_no_res_th_dim (defined above) we run bm for all dimensions
  * in the following range: (start, start + 1, start + 2, start + 3, ... start + dim_opt)
+ * to test all possible residual cases.
  */
 static constexpr size_t start = min_no_res_th_dim;
 #define INITIALIZE_RESIDUAL_BM(bm_class, type_prefix, arch, metric, dim_opt, arch_supported)       \


### PR DESCRIPTION
In this PR the spaces benchmarks were changed to cover:
1. high dimensions with at least one dimension satisfying `residual == 0` [900:1000:15]
3. low dimensions with at least one dimension satisfying `residual == 0`  [100:200:15]
4. dimensions common for all types
5. no-residual dimensions, starting from the lowest 
6. all residual possibilities for each type, starting for the minimal dimension supported by all optimizations


Data Type | High Dim | Low Dim | No Residual | Residual Range
-- | -- | -- | -- | --
float16 | 900, 915, ..., 990  |  100, 115, ..., 190 | **32**, 64, 256, 1024  | 513, 514, ... , **543**
bfloat16 | 900, 915, ..., 990 | 100, 115, ..., 190 | **32**, 64, 256, 1024 | 513, 514, ... , **543**
float | 900, 915, ..., 990 | 100, 115, ..., 190 | **16**, 64, 256, 1024 | 513, 514, ... , **527**
double | 900, 915, ..., 990 | 100, 115, ..., 190  | **8, 16**, 64, 256, 1024  | 513, 514, ... , **519**

<p></p>

## Additional (unrelated) fixes
add `$MODE` to ubuntu22 & 20 scripts

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
