### PR TITLE
[MOD-7297] Replace Variable Length Array on stack with heap allocation

### DIFF
--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,13 +9,13 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
   jammy:
     uses: ./.github/workflows/task-unit-test.yml
     with:
       container: ubuntu:jammy
-      run-valgrind: false
+      run-valgrind: true
   focal:
     uses: ./.github/workflows/task-unit-test.yml
     with:

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
   jammy:
     uses: ./.github/workflows/task-unit-test.yml

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -1820,7 +1820,7 @@ AddVectorCtx HNSWIndex<DataType, DistType>::storeNewElement(labelType label,
     // Create the new element's graph metadata.
     // We must assign manually enough memory on the stack and not just declare an `ElementGraphData`
     // variable, since it has a flexible array member.
-    char tmpData[this->elementGraphDataSize];
+    void *tmpData = this->allocator->allocate_unique(this->elementGraphDataSize).get();
     memset(tmpData, 0, this->elementGraphDataSize);
     ElementGraphData *cur_egd = (ElementGraphData *)tmpData;
     // Allocate memory (inside `ElementGraphData` constructor) for the links in higher levels and

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -1820,7 +1820,7 @@ AddVectorCtx HNSWIndex<DataType, DistType>::storeNewElement(labelType label,
     // Create the new element's graph metadata.
     // We must assign manually enough memory on the stack and not just declare an `ElementGraphData`
     // variable, since it has a flexible array member.
-    void *tmpData = this->allocator->allocate_unique(this->elementGraphDataSize);
+    auto tmpData = this->allocator->allocate_unique(this->elementGraphDataSize);
     memset(tmpData.get(), 0, this->elementGraphDataSize);
     ElementGraphData *cur_egd = (ElementGraphData *)(tmpData.get());
     // Allocate memory (inside `ElementGraphData` constructor) for the links in higher levels and

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -1820,9 +1820,9 @@ AddVectorCtx HNSWIndex<DataType, DistType>::storeNewElement(labelType label,
     // Create the new element's graph metadata.
     // We must assign manually enough memory on the stack and not just declare an `ElementGraphData`
     // variable, since it has a flexible array member.
-    void *tmpData = this->allocator->allocate_unique(this->elementGraphDataSize).get();
-    memset(tmpData, 0, this->elementGraphDataSize);
-    ElementGraphData *cur_egd = (ElementGraphData *)tmpData;
+    void *tmpData = this->allocator->allocate_unique(this->elementGraphDataSize);
+    memset(tmpData.get(), 0, this->elementGraphDataSize);
+    ElementGraphData *cur_egd = (ElementGraphData *)(tmpData.get());
     // Allocate memory (inside `ElementGraphData` constructor) for the links in higher levels and
     // initialize this memory to zeros. The reason for doing it here is that we might mark this
     // vector as deleted BEFORE we finish its indexing. In that case, we will collect the incoming

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer.h
@@ -160,15 +160,19 @@ void HNSWIndex<DataType, DistType>::restoreGraph(std::ifstream &input) {
         unsigned int block_len = 0;
         readBinaryPOD(input, block_len);
         for (size_t j = 0; j < block_len; j++) {
-            char cur_vec[this->dataSize];
+            // char cur_vec[this->dataSize];
+            auto cur_vec = static_cast<char *>(this->getAllocator()->allocate(this->dataSize));
             input.read(cur_vec, this->dataSize);
             this->vectorBlocks.back().addElement(cur_vec);
+            this->getAllocator()->free_allocation(cur_vec);
         }
     }
 
     // Get graph data blocks
     ElementGraphData *cur_egt;
-    char tmpData[this->elementGraphDataSize];
+    auto tmpData = this->getAllocator()->allocate(this->elementGraphDataSize);
+
+    // char tmpData[this->elementGraphDataSize];
     size_t toplevel = 0;
     for (size_t i = 0; i < num_blocks; i++) {
         this->graphDataBlocks.emplace_back(this->blockSize, this->elementGraphDataSize,
@@ -198,6 +202,7 @@ void HNSWIndex<DataType, DistType>::restoreGraph(std::ifstream &input) {
             }
         }
     }
+    this->getAllocator()->free_allocation(tmpData);
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer.h
@@ -160,19 +160,16 @@ void HNSWIndex<DataType, DistType>::restoreGraph(std::ifstream &input) {
         unsigned int block_len = 0;
         readBinaryPOD(input, block_len);
         for (size_t j = 0; j < block_len; j++) {
-            // char cur_vec[this->dataSize];
-            auto cur_vec = static_cast<char *>(this->getAllocator()->allocate(this->dataSize));
+            auto cur_vec =
+                static_cast<char *>(this->getAllocator()->allocate_unique(this->dataSize).get());
             input.read(cur_vec, this->dataSize);
             this->vectorBlocks.back().addElement(cur_vec);
-            this->getAllocator()->free_allocation(cur_vec);
         }
     }
 
     // Get graph data blocks
     ElementGraphData *cur_egt;
-    auto tmpData = this->getAllocator()->allocate(this->elementGraphDataSize);
-
-    // char tmpData[this->elementGraphDataSize];
+    auto tmpData = this->getAllocator()->allocate_unique(this->elementGraphDataSize).get();
     size_t toplevel = 0;
     for (size_t i = 0; i < num_blocks; i++) {
         this->graphDataBlocks.emplace_back(this->blockSize, this->elementGraphDataSize,
@@ -202,7 +199,6 @@ void HNSWIndex<DataType, DistType>::restoreGraph(std::ifstream &input) {
             }
         }
     }
-    this->getAllocator()->free_allocation(tmpData);
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer.h
@@ -161,15 +161,15 @@ void HNSWIndex<DataType, DistType>::restoreGraph(std::ifstream &input) {
         readBinaryPOD(input, block_len);
         for (size_t j = 0; j < block_len; j++) {
             auto cur_vec =
-                static_cast<char *>(this->getAllocator()->allocate_unique(this->dataSize).get());
-            input.read(cur_vec, this->dataSize);
-            this->vectorBlocks.back().addElement(cur_vec);
+                static_cast<char *>(this->getAllocator()->allocate_unique(this->dataSize));
+            input.read(cur_vec.get(), this->dataSize);
+            this->vectorBlocks.back().addElement(cur_vec.get());
         }
     }
 
     // Get graph data blocks
     ElementGraphData *cur_egt;
-    auto tmpData = this->getAllocator()->allocate_unique(this->elementGraphDataSize).get();
+    auto tmpData = this->getAllocator()->allocate_unique(this->elementGraphDataSize);
     size_t toplevel = 0;
     for (size_t i = 0; i < num_blocks; i++) {
         this->graphDataBlocks.emplace_back(this->blockSize, this->elementGraphDataSize,
@@ -178,12 +178,13 @@ void HNSWIndex<DataType, DistType>::restoreGraph(std::ifstream &input) {
         readBinaryPOD(input, block_len);
         for (size_t j = 0; j < block_len; j++) {
             // Reset tmpData
-            memset(tmpData, 0, this->elementGraphDataSize);
+            memset(tmpData.get(), 0, this->elementGraphDataSize);
             // Read the current element top level
             readBinaryPOD(input, toplevel);
             // Allocate space and structs for the current element
             try {
-                new (tmpData) ElementGraphData(toplevel, this->levelDataSize, this->allocator);
+                new (tmpData.get())
+                    ElementGraphData(toplevel, this->levelDataSize, this->allocator);
             } catch (std::runtime_error &e) {
                 this->log(VecSimCommonStrings::LOG_WARNING_STRING,
                           "Error - allocating memory for new element failed due to low memory");

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer.h
@@ -160,9 +160,8 @@ void HNSWIndex<DataType, DistType>::restoreGraph(std::ifstream &input) {
         unsigned int block_len = 0;
         readBinaryPOD(input, block_len);
         for (size_t j = 0; j < block_len; j++) {
-            auto cur_vec =
-                static_cast<char *>(this->getAllocator()->allocate_unique(this->dataSize));
-            input.read(cur_vec.get(), this->dataSize);
+            auto cur_vec = this->getAllocator()->allocate_unique(this->dataSize);
+            input.read(static_cast<char *>(cur_vec.get()), this->dataSize);
             this->vectorBlocks.back().addElement(cur_vec.get());
         }
     }
@@ -191,7 +190,7 @@ void HNSWIndex<DataType, DistType>::restoreGraph(std::ifstream &input) {
                 throw e;
             }
             // Add the current element to the current block, and update cur_egt to point to it.
-            this->graphDataBlocks.back().addElement(tmpData);
+            this->graphDataBlocks.back().addElement(tmpData.get());
             cur_egt = (ElementGraphData *)this->graphDataBlocks.back().getElement(j);
 
             // Restore the current element's graph data

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -504,7 +504,9 @@ void TieredHNSWIndex<DataType, DistType>::executeInsertJob(HNSWInsertJob *job) {
     HNSWIndex<DataType, DistType> *hnsw_index = this->getHNSWIndex();
     // Copy the vector blob from the flat buffer, so we can release the flat lock while we are
     // indexing the vector into HNSW index.
-    DataType blob_copy[this->frontendIndex->getDim()];
+    // DataType blob_copy[this->frontendIndex->getDim()];
+    auto blob_copy = this->getAllocator()->allocate(this->frontendIndex->getDataSize());
+
     memcpy(blob_copy, this->frontendIndex->getDataByInternalId(job->id),
            this->frontendIndex->getDim() * sizeof(DataType));
 
@@ -545,6 +547,7 @@ void TieredHNSWIndex<DataType, DistType>::executeInsertJob(HNSWInsertJob *job) {
         this->invalidJobsLookupGuard.unlock();
     }
     this->flatIndexGuard.unlock();
+    this->getAllocator()->free_allocation(blob_copy);
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -504,13 +504,12 @@ void TieredHNSWIndex<DataType, DistType>::executeInsertJob(HNSWInsertJob *job) {
     HNSWIndex<DataType, DistType> *hnsw_index = this->getHNSWIndex();
     // Copy the vector blob from the flat buffer, so we can release the flat lock while we are
     // indexing the vector into HNSW index.
-    auto blob_copy =
-        this->getAllocator()->allocate_unique(this->frontendIndex->getDataSize()).get();
+    auto blob_copy = this->getAllocator()->allocate_unique(this->frontendIndex->getDataSize());
 
-    memcpy(blob_copy, this->frontendIndex->getDataByInternalId(job->id),
+    memcpy(blob_copy.get(), this->frontendIndex->getDataByInternalId(job->id),
            this->frontendIndex->getDim() * sizeof(DataType));
 
-    this->insertVectorToHNSW<true>(hnsw_index, job->label, blob_copy);
+    this->insertVectorToHNSW<true>(hnsw_index, job->label, blob_copy.get());
 
     // Remove the vector and the insert job from the flat buffer.
     this->flatIndexGuard.lock();

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -504,8 +504,8 @@ void TieredHNSWIndex<DataType, DistType>::executeInsertJob(HNSWInsertJob *job) {
     HNSWIndex<DataType, DistType> *hnsw_index = this->getHNSWIndex();
     // Copy the vector blob from the flat buffer, so we can release the flat lock while we are
     // indexing the vector into HNSW index.
-    // DataType blob_copy[this->frontendIndex->getDim()];
-    auto blob_copy = this->getAllocator()->allocate(this->frontendIndex->getDataSize());
+    auto blob_copy =
+        this->getAllocator()->allocate_unique(this->frontendIndex->getDataSize()).get();
 
     memcpy(blob_copy, this->frontendIndex->getDataByInternalId(job->id),
            this->frontendIndex->getDim() * sizeof(DataType));
@@ -547,7 +547,6 @@ void TieredHNSWIndex<DataType, DistType>::executeInsertJob(HNSWInsertJob *job) {
         this->invalidJobsLookupGuard.unlock();
     }
     this->flatIndexGuard.unlock();
-    this->getAllocator()->free_allocation(blob_copy);
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/batch_iterator.h
+++ b/src/VecSim/batch_iterator.h
@@ -25,7 +25,7 @@ public:
     explicit VecSimBatchIterator(void *query_vector, void *tctx,
                                  std::shared_ptr<VecSimAllocator> allocator)
         : VecsimBaseObject(allocator), query_vector(query_vector), returned_results_count(0),
-          timeoutCtx(tctx) {};
+          timeoutCtx(tctx){};
 
     inline const void *getQueryBlob() const { return query_vector; }
 

--- a/src/VecSim/batch_iterator.h
+++ b/src/VecSim/batch_iterator.h
@@ -25,7 +25,7 @@ public:
     explicit VecSimBatchIterator(void *query_vector, void *tctx,
                                  std::shared_ptr<VecSimAllocator> allocator)
         : VecsimBaseObject(allocator), query_vector(query_vector), returned_results_count(0),
-          timeoutCtx(tctx){};
+          timeoutCtx(tctx) {};
 
     inline const void *getQueryBlob() const { return query_vector; }
 

--- a/src/VecSim/memory/vecsim_malloc.cpp
+++ b/src/VecSim/memory/vecsim_malloc.cpp
@@ -99,6 +99,17 @@ void *VecSimAllocator::callocate(size_t size) {
     return nullptr;
 }
 
+std::unique_ptr<void, VecSimAllocator::Deleter>
+VecSimAllocator::allocate_aligned_unique(size_t size, size_t alignment) {
+    void *ptr = this->allocate_aligned(size, alignment);
+    return {ptr, Deleter(this)};
+}
+
+std::unique_ptr<void, VecSimAllocator::Deleter> VecSimAllocator::allocate_unique(size_t size) {
+    void *ptr = this->allocate(size);
+    return {ptr, Deleter(this)};
+}
+
 void *VecSimAllocator::operator new(size_t size) { return vecsim_malloc(size); }
 
 void *VecSimAllocator::operator new[](size_t size) { return vecsim_malloc(size); }

--- a/src/VecSim/memory/vecsim_malloc.cpp
+++ b/src/VecSim/memory/vecsim_malloc.cpp
@@ -102,12 +102,12 @@ void *VecSimAllocator::callocate(size_t size) {
 std::unique_ptr<void, VecSimAllocator::Deleter>
 VecSimAllocator::allocate_aligned_unique(size_t size, size_t alignment) {
     void *ptr = this->allocate_aligned(size, alignment);
-    return {ptr, Deleter(this)};
+    return {ptr, Deleter(*this)};
 }
 
 std::unique_ptr<void, VecSimAllocator::Deleter> VecSimAllocator::allocate_unique(size_t size) {
     void *ptr = this->allocate(size);
-    return {ptr, Deleter(this)};
+    return {ptr, Deleter(*this)};
 }
 
 void *VecSimAllocator::operator new(size_t size) { return vecsim_malloc(size); }

--- a/src/VecSim/memory/vecsim_malloc.h
+++ b/src/VecSim/memory/vecsim_malloc.h
@@ -65,9 +65,9 @@ private:
     inline size_t getPointerAllocationSize(void *p) { return *(((size_t *)p) - 1); }
 
     struct Deleter {
-        VecSimAllocator *allocator;
-        explicit constexpr Deleter(VecSimAllocator *allocator) : allocator(allocator) {}
-        void operator()(void *ptr) const { allocator->free_allocation(ptr); }
+        VecSimAllocator &allocator;
+        explicit constexpr Deleter(VecSimAllocator &allocator) : allocator(allocator) {}
+        void operator()(void *ptr) const { allocator.free_allocation(ptr); }
     };
 };
 

--- a/src/VecSim/memory/vecsim_malloc.h
+++ b/src/VecSim/memory/vecsim_malloc.h
@@ -19,38 +19,28 @@ struct VecSimAllocator {
     friend inline void vecsim_free(void *p);
 
 private:
-    struct Deleter {
-        VecSimAllocator *allocator;
-        explicit constexpr Deleter(VecSimAllocator *allocator) : allocator(allocator) {}
-        void operator()(void *ptr) const { allocator->free_allocation(ptr); }
-    };
     std::atomic_uint64_t allocated;
 
     // Static member that indicates each allocation additional size.
     static size_t allocation_header_size;
     static VecSimMemoryFunctions memFunctions;
 
+    // Forward declaration of the deleter for the unique_ptr.
+    struct Deleter;
     VecSimAllocator() : allocated(std::atomic_uint64_t(sizeof(VecSimAllocator))) {}
 
 public:
     static std::shared_ptr<VecSimAllocator> newVecsimAllocator();
     void *allocate(size_t size);
     void *allocate_aligned(size_t size, unsigned char alignment);
-    // Custom deleter
-
-    std::unique_ptr<void, Deleter> allocate_aligned_unique(size_t size, size_t alignment) {
-        void *ptr = this->allocate_aligned(size, alignment);
-        return {ptr, Deleter(this)};
-    }
-
-    std::unique_ptr<void, Deleter> allocate_unique(size_t size) {
-        void *ptr = this->allocate(size);
-        return {ptr, Deleter(this)};
-    }
     void *callocate(size_t size);
     void deallocate(void *p, size_t size);
     void *reallocate(void *p, size_t size);
     void free_allocation(void *p);
+
+    // Allocations for scope-life-time memory.
+    std::unique_ptr<void, Deleter> allocate_aligned_unique(size_t size, size_t alignment);
+    std::unique_ptr<void, Deleter> allocate_unique(size_t size);
 
     void *operator new(size_t size);
     void *operator new[](size_t size);
@@ -71,8 +61,14 @@ public:
     static size_t getAllocationOverheadSize() { return allocation_header_size; }
 
 private:
-    // Retrive the original requested allocation size. Required for remalloc.
+    // Retrieve the original requested allocation size. Required for remalloc.
     inline size_t getPointerAllocationSize(void *p) { return *(((size_t *)p) - 1); }
+
+    struct Deleter {
+        VecSimAllocator *allocator;
+        explicit constexpr Deleter(VecSimAllocator *allocator) : allocator(allocator) {}
+        void operator()(void *ptr) const { allocator->free_allocation(ptr); }
+    };
 };
 
 /**

--- a/src/VecSim/spaces/normalize/normalize_naive.h
+++ b/src/VecSim/spaces/normalize/normalize_naive.h
@@ -9,6 +9,7 @@
 #include "VecSim/types/bfloat16.h"
 #include "VecSim/types/float16.h"
 #include <cmath>
+// #include <vector>
 
 using bfloat16 = vecsim_types::bfloat16;
 using float16 = vecsim_types::float16;
@@ -35,7 +36,8 @@ template <bool is_little>
 static inline void bfloat16_normalizeVector(void *vec, const size_t dim) {
     bfloat16 *input_vector = (bfloat16 *)vec;
 
-    float f32_tmp[dim];
+    // float f32_tmp[dim];
+    // std::vector<float> f32_tmp(dim);
 
     float sum = 0;
 
@@ -55,7 +57,8 @@ static inline void bfloat16_normalizeVector(void *vec, const size_t dim) {
 static inline void float16_normalizeVector(void *vec, const size_t dim) {
     float16 *input_vector = (float16 *)vec;
 
-    float f32_tmp[dim];
+    // float f32_tmp[dim];
+    // std::vector<float> f32_tmp(dim);
 
     float sum = 0;
 

--- a/src/VecSim/spaces/normalize/normalize_naive.h
+++ b/src/VecSim/spaces/normalize/normalize_naive.h
@@ -36,7 +36,7 @@ template <bool is_little>
 static inline void bfloat16_normalizeVector(void *vec, const size_t dim) {
     bfloat16 *input_vector = (bfloat16 *)vec;
 
-    // float f32_tmp[dim];
+    float f32_tmp[dim];
     // std::vector<float> f32_tmp(dim);
 
     float sum = 0;
@@ -57,7 +57,7 @@ static inline void bfloat16_normalizeVector(void *vec, const size_t dim) {
 static inline void float16_normalizeVector(void *vec, const size_t dim) {
     float16 *input_vector = (float16 *)vec;
 
-    // float f32_tmp[dim];
+    float f32_tmp[dim];
     // std::vector<float> f32_tmp(dim);
 
     float sum = 0;

--- a/src/VecSim/spaces/normalize/normalize_naive.h
+++ b/src/VecSim/spaces/normalize/normalize_naive.h
@@ -36,7 +36,6 @@ template <bool is_little>
 static inline void bfloat16_normalizeVector(void *vec, const size_t dim) {
     bfloat16 *input_vector = (bfloat16 *)vec;
 
-    // float f32_tmp[dim];
     std::vector<float> f32_tmp(dim);
 
     float sum = 0;
@@ -57,7 +56,6 @@ static inline void bfloat16_normalizeVector(void *vec, const size_t dim) {
 static inline void float16_normalizeVector(void *vec, const size_t dim) {
     float16 *input_vector = (float16 *)vec;
 
-    // float f32_tmp[dim];
     std::vector<float> f32_tmp(dim);
 
     float sum = 0;

--- a/src/VecSim/spaces/normalize/normalize_naive.h
+++ b/src/VecSim/spaces/normalize/normalize_naive.h
@@ -9,7 +9,7 @@
 #include "VecSim/types/bfloat16.h"
 #include "VecSim/types/float16.h"
 #include <cmath>
-// #include <vector>
+#include <vector>
 
 using bfloat16 = vecsim_types::bfloat16;
 using float16 = vecsim_types::float16;
@@ -36,8 +36,8 @@ template <bool is_little>
 static inline void bfloat16_normalizeVector(void *vec, const size_t dim) {
     bfloat16 *input_vector = (bfloat16 *)vec;
 
-    float f32_tmp[dim];
-    // std::vector<float> f32_tmp(dim);
+    // float f32_tmp[dim];
+    std::vector<float> f32_tmp(dim);
 
     float sum = 0;
 
@@ -57,8 +57,8 @@ static inline void bfloat16_normalizeVector(void *vec, const size_t dim) {
 static inline void float16_normalizeVector(void *vec, const size_t dim) {
     float16 *input_vector = (float16 *)vec;
 
-    float f32_tmp[dim];
-    // std::vector<float> f32_tmp(dim);
+    // float f32_tmp[dim];
+    std::vector<float> f32_tmp(dim);
 
     float sum = 0;
 

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -208,7 +208,6 @@ protected:
     virtual int addVectorWrapper(const void *blob, labelType label, void *auxiliaryCtx) override {
         auto aligned_mem =
             this->getAllocator()->allocate_aligned_unique(this->dataSize, this->alignment);
-        // char PORTABLE_ALIGN aligned_mem[this->dataSize];
         const void *processed_blob = processBlob(blob, aligned_mem.get());
 
         return this->addVector(processed_blob, label, auxiliaryCtx);
@@ -216,7 +215,6 @@ protected:
 
     virtual VecSimQueryReply *topKQueryWrapper(const void *queryBlob, size_t k,
                                                VecSimQueryParams *queryParams) const override {
-        // char PORTABLE_ALIGN aligned_mem[this->dataSize];
         auto aligned_mem =
             this->getAllocator()->allocate_aligned_unique(this->dataSize, this->alignment);
         const void *processed_blob = processBlob(queryBlob, aligned_mem.get());
@@ -227,7 +225,6 @@ protected:
     virtual VecSimQueryReply *rangeQueryWrapper(const void *queryBlob, double radius,
                                                 VecSimQueryParams *queryParams,
                                                 VecSimQueryReply_Order order) const override {
-        // char PORTABLE_ALIGN aligned_mem[this->dataSize];
         auto aligned_mem =
             this->getAllocator()->allocate_aligned_unique(this->dataSize, this->alignment);
         const void *processed_blob = processBlob(queryBlob, aligned_mem.get());
@@ -237,7 +234,6 @@ protected:
 
     virtual VecSimBatchIterator *
     newBatchIteratorWrapper(const void *queryBlob, VecSimQueryParams *queryParams) const override {
-        // char PORTABLE_ALIGN aligned_mem[this->dataSize];
         auto aligned_mem =
             this->getAllocator()->allocate_aligned_unique(this->dataSize, this->alignment);
         const void *processed_blob = processBlob(queryBlob, aligned_mem.get());

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -206,47 +206,43 @@ public:
 
 protected:
     virtual int addVectorWrapper(const void *blob, labelType label, void *auxiliaryCtx) override {
-        auto aligned_mem = this->getAllocator()->allocate_aligned(this->dataSize, this->alignment);
+        auto aligned_mem =
+            this->getAllocator()->allocate_aligned_unique(this->dataSize, this->alignment);
         // char PORTABLE_ALIGN aligned_mem[this->dataSize];
-        const void *processed_blob = processBlob(blob, aligned_mem);
+        const void *processed_blob = processBlob(blob, aligned_mem.get());
 
-        auto ret = this->addVector(processed_blob, label, auxiliaryCtx);
-        this->getAllocator()->free_allocation(aligned_mem);
-        return ret;
+        return this->addVector(processed_blob, label, auxiliaryCtx);
     }
 
     virtual VecSimQueryReply *topKQueryWrapper(const void *queryBlob, size_t k,
                                                VecSimQueryParams *queryParams) const override {
         // char PORTABLE_ALIGN aligned_mem[this->dataSize];
-        auto aligned_mem = this->getAllocator()->allocate_aligned(this->dataSize, this->alignment);
-        const void *processed_blob = processBlob(queryBlob, aligned_mem);
+        auto aligned_mem =
+            this->getAllocator()->allocate_aligned_unique(this->dataSize, this->alignment);
+        const void *processed_blob = processBlob(queryBlob, aligned_mem.get());
 
-        auto ret = this->topKQuery(processed_blob, k, queryParams);
-        this->getAllocator()->free_allocation(aligned_mem);
-        return ret;
+        return this->topKQuery(processed_blob, k, queryParams);
     }
 
     virtual VecSimQueryReply *rangeQueryWrapper(const void *queryBlob, double radius,
                                                 VecSimQueryParams *queryParams,
                                                 VecSimQueryReply_Order order) const override {
         // char PORTABLE_ALIGN aligned_mem[this->dataSize];
-        auto aligned_mem = this->getAllocator()->allocate_aligned(this->dataSize, this->alignment);
-        const void *processed_blob = processBlob(queryBlob, aligned_mem);
+        auto aligned_mem =
+            this->getAllocator()->allocate_aligned_unique(this->dataSize, this->alignment);
+        const void *processed_blob = processBlob(queryBlob, aligned_mem.get());
 
-        auto ret = this->rangeQuery(processed_blob, radius, queryParams, order);
-        this->getAllocator()->free_allocation(aligned_mem);
-        return ret;
+        return this->rangeQuery(processed_blob, radius, queryParams, order);
     }
 
     virtual VecSimBatchIterator *
     newBatchIteratorWrapper(const void *queryBlob, VecSimQueryParams *queryParams) const override {
         // char PORTABLE_ALIGN aligned_mem[this->dataSize];
-        auto aligned_mem = this->getAllocator()->allocate_aligned(this->dataSize, this->alignment);
-        const void *processed_blob = processBlob(queryBlob, aligned_mem);
+        auto aligned_mem =
+            this->getAllocator()->allocate_aligned_unique(this->dataSize, this->alignment);
+        const void *processed_blob = processBlob(queryBlob, aligned_mem.get());
 
-        auto ret = this->newBatchIterator(processed_blob, queryParams);
-        this->getAllocator()->free_allocation(aligned_mem);
-        return ret;
+        return this->newBatchIterator(processed_blob, queryParams);
     }
 
     void runGC() override {}              // Do nothing, relevant for tiered index only.

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -206,35 +206,47 @@ public:
 
 protected:
     virtual int addVectorWrapper(const void *blob, labelType label, void *auxiliaryCtx) override {
-        char PORTABLE_ALIGN aligned_mem[this->dataSize];
+        auto aligned_mem = this->getAllocator()->allocate_aligned(this->dataSize, this->alignment);
+        // char PORTABLE_ALIGN aligned_mem[this->dataSize];
         const void *processed_blob = processBlob(blob, aligned_mem);
 
-        return this->addVector(processed_blob, label, auxiliaryCtx);
+        auto ret = this->addVector(processed_blob, label, auxiliaryCtx);
+        this->getAllocator()->free_allocation(aligned_mem);
+        return ret;
     }
 
     virtual VecSimQueryReply *topKQueryWrapper(const void *queryBlob, size_t k,
                                                VecSimQueryParams *queryParams) const override {
-        char PORTABLE_ALIGN aligned_mem[this->dataSize];
+        // char PORTABLE_ALIGN aligned_mem[this->dataSize];
+        auto aligned_mem = this->getAllocator()->allocate_aligned(this->dataSize, this->alignment);
         const void *processed_blob = processBlob(queryBlob, aligned_mem);
 
-        return this->topKQuery(processed_blob, k, queryParams);
+        auto ret = this->topKQuery(processed_blob, k, queryParams);
+        this->getAllocator()->free_allocation(aligned_mem);
+        return ret;
     }
 
     virtual VecSimQueryReply *rangeQueryWrapper(const void *queryBlob, double radius,
                                                 VecSimQueryParams *queryParams,
                                                 VecSimQueryReply_Order order) const override {
-        char PORTABLE_ALIGN aligned_mem[this->dataSize];
+        // char PORTABLE_ALIGN aligned_mem[this->dataSize];
+        auto aligned_mem = this->getAllocator()->allocate_aligned(this->dataSize, this->alignment);
         const void *processed_blob = processBlob(queryBlob, aligned_mem);
 
-        return this->rangeQuery(processed_blob, radius, queryParams, order);
+        auto ret = this->rangeQuery(processed_blob, radius, queryParams, order);
+        this->getAllocator()->free_allocation(aligned_mem);
+        return ret;
     }
 
     virtual VecSimBatchIterator *
     newBatchIteratorWrapper(const void *queryBlob, VecSimQueryParams *queryParams) const override {
-        char PORTABLE_ALIGN aligned_mem[this->dataSize];
+        // char PORTABLE_ALIGN aligned_mem[this->dataSize];
+        auto aligned_mem = this->getAllocator()->allocate_aligned(this->dataSize, this->alignment);
         const void *processed_blob = processBlob(queryBlob, aligned_mem);
 
-        return this->newBatchIterator(processed_blob, queryParams);
+        auto ret = this->newBatchIterator(processed_blob, queryParams);
+        this->getAllocator()->free_allocation(aligned_mem);
+        return ret;
     }
 
     void runGC() override {}              // Do nothing, relevant for tiered index only.

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -109,50 +109,39 @@ public:
 
 private:
     virtual int addVectorWrapper(const void *blob, labelType label, void *auxiliaryCtx) override {
-        auto aligned_mem = this->getAllocator()->allocate_aligned(
+        auto aligned_mem = this->getAllocator()->allocate_aligned_unique(
             this->backendIndex->getDataSize(), this->backendIndex->getAlignment());
+        const void *processed_blob = this->backendIndex->processBlob(blob, aligned_mem.get());
 
-        // char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
-        const void *processed_blob = this->backendIndex->processBlob(blob, aligned_mem);
-        auto ret = this->addVector(processed_blob, label, auxiliaryCtx);
-        this->getAllocator()->free_allocation(aligned_mem);
-        return ret;
+        return this->addVector(processed_blob, label, auxiliaryCtx);
     }
 
     virtual VecSimQueryReply *topKQueryWrapper(const void *queryBlob, size_t k,
                                                VecSimQueryParams *queryParams) const override {
-        // char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
-        auto aligned_mem = this->getAllocator()->allocate_aligned(
+        auto aligned_mem = this->getAllocator()->allocate_aligned_unique(
             this->backendIndex->getDataSize(), this->backendIndex->getAlignment());
-        const void *processed_blob = this->backendIndex->processBlob(queryBlob, aligned_mem);
-        auto ret = this->topKQuery(processed_blob, k, queryParams);
-        this->getAllocator()->free_allocation(aligned_mem);
-        return ret;
+        const void *processed_blob = this->backendIndex->processBlob(queryBlob, aligned_mem.get());
+
+        return this->topKQuery(processed_blob, k, queryParams);
     }
 
     virtual VecSimQueryReply *rangeQueryWrapper(const void *queryBlob, double radius,
                                                 VecSimQueryParams *queryParams,
                                                 VecSimQueryReply_Order order) const override {
-        // char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
-        auto aligned_mem = this->getAllocator()->allocate_aligned(
+        auto aligned_mem = this->getAllocator()->allocate_aligned_unique(
             this->backendIndex->getDataSize(), this->backendIndex->getAlignment());
-        const void *processed_blob = this->backendIndex->processBlob(queryBlob, aligned_mem);
+        const void *processed_blob = this->backendIndex->processBlob(queryBlob, aligned_mem.get());
 
-        auto ret = this->rangeQuery(processed_blob, radius, queryParams, order);
-        this->getAllocator()->free_allocation(aligned_mem);
-        return ret;
+        return this->rangeQuery(processed_blob, radius, queryParams, order);
     }
 
     virtual VecSimBatchIterator *
     newBatchIteratorWrapper(const void *queryBlob, VecSimQueryParams *queryParams) const override {
-        // char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
-        auto aligned_mem = this->getAllocator()->allocate_aligned(
+        auto aligned_mem = this->getAllocator()->allocate_aligned_unique(
             this->backendIndex->getDataSize(), this->backendIndex->getAlignment());
-        const void *processed_blob = this->backendIndex->processBlob(queryBlob, aligned_mem);
+        const void *processed_blob = this->backendIndex->processBlob(queryBlob, aligned_mem.get());
 
-        auto ret = this->newBatchIterator(processed_blob, queryParams);
-        this->getAllocator()->free_allocation(aligned_mem);
-        return ret;
+        return this->newBatchIterator(processed_blob, queryParams);
     }
 };
 

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -109,33 +109,50 @@ public:
 
 private:
     virtual int addVectorWrapper(const void *blob, labelType label, void *auxiliaryCtx) override {
-        char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
+        auto aligned_mem = this->getAllocator()->allocate_aligned(
+            this->backendIndex->getDataSize(), this->backendIndex->getAlignment());
+
+        // char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
         const void *processed_blob = this->backendIndex->processBlob(blob, aligned_mem);
-        return this->addVector(processed_blob, label, auxiliaryCtx);
+        auto ret = this->addVector(processed_blob, label, auxiliaryCtx);
+        this->getAllocator()->free_allocation(aligned_mem);
+        return ret;
     }
 
     virtual VecSimQueryReply *topKQueryWrapper(const void *queryBlob, size_t k,
                                                VecSimQueryParams *queryParams) const override {
-        char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
+        // char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
+        auto aligned_mem = this->getAllocator()->allocate_aligned(
+            this->backendIndex->getDataSize(), this->backendIndex->getAlignment());
         const void *processed_blob = this->backendIndex->processBlob(queryBlob, aligned_mem);
-        return this->topKQuery(processed_blob, k, queryParams);
+        auto ret = this->topKQuery(processed_blob, k, queryParams);
+        this->getAllocator()->free_allocation(aligned_mem);
+        return ret;
     }
 
     virtual VecSimQueryReply *rangeQueryWrapper(const void *queryBlob, double radius,
                                                 VecSimQueryParams *queryParams,
                                                 VecSimQueryReply_Order order) const override {
-        char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
+        // char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
+        auto aligned_mem = this->getAllocator()->allocate_aligned(
+            this->backendIndex->getDataSize(), this->backendIndex->getAlignment());
         const void *processed_blob = this->backendIndex->processBlob(queryBlob, aligned_mem);
 
-        return this->rangeQuery(processed_blob, radius, queryParams, order);
+        auto ret = this->rangeQuery(processed_blob, radius, queryParams, order);
+        this->getAllocator()->free_allocation(aligned_mem);
+        return ret;
     }
 
     virtual VecSimBatchIterator *
     newBatchIteratorWrapper(const void *queryBlob, VecSimQueryParams *queryParams) const override {
-        char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
+        // char PORTABLE_ALIGN aligned_mem[this->backendIndex->getDataSize()];
+        auto aligned_mem = this->getAllocator()->allocate_aligned(
+            this->backendIndex->getDataSize(), this->backendIndex->getAlignment());
         const void *processed_blob = this->backendIndex->processBlob(queryBlob, aligned_mem);
 
-        return this->newBatchIterator(processed_blob, queryParams);
+        auto ret = this->newBatchIterator(processed_blob, queryParams);
+        this->getAllocator()->free_allocation(aligned_mem);
+        return ret;
     }
 };
 


### PR DESCRIPTION
Variable length array (vla) is not part of c standard. Therefor, in this PR all stack arrays with length determined at runtime were replaced with allocations managed by a `unique_ptr` and tracked by the library allocator.
The new allocator methods are:
1. `allocate_aligned_unique`
2. `allocate_unique`

Both generate a `unique_ptr` to the allocated memory with a  `Deleter` to release this allocation at the end of the `unique_ptr` object lifetime.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
