### PR TITLE
Parallel upload bm results to grafana

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Collect results
         run: |
-          ./tests/benchmark/benchmarks.sh ${{ inputs.setup }} | xargs -n 1 -P 0 -I {} redisbench-admin export     \
+          ./tests/benchmark/benchmarks.sh ${{ inputs.setup }} | xargs -P 0 -I {} redisbench-admin export     \
           --redistimeseries_host      ${{ secrets.PERFORMANCE_RTS_HOST }}           \
           --redistimeseries_port      ${{ secrets.PERFORMANCE_RTS_PORT }}           \
           --redistimeseries_user      default                                       \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Collect results
         run: |
-          ./tests/benchmark/benchmarks.sh ${{ inputs.setup }} | xargs -I {} redisbench-admin export     \
+          ./tests/benchmark/benchmarks.sh ${{ inputs.setup }} | xargs -n 1 -P 0 -I {} redisbench-admin export     \
           --redistimeseries_host      ${{ secrets.PERFORMANCE_RTS_HOST }}           \
           --redistimeseries_port      ${{ secrets.PERFORMANCE_RTS_PORT }}           \
           --redistimeseries_user      default                                       \


### PR DESCRIPTION
We now process benchmark's result files in parallel to improve the step duration.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
