### PR TITLE
Use pull request target in gha

### DIFF
--- a/.github/workflows/benchmark-labeled.yml
+++ b/.github/workflows/benchmark-labeled.yml
@@ -1,7 +1,7 @@
 name: benchmark
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, labeled] # Default ([opened, reopened, synchronize]) + labeled
     branches-ignore:
       - '*docs'

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -1,7 +1,7 @@
 name: Pull Request CI
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review] # Defaults + ready_for_review
 
 jobs:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -1,8 +1,8 @@
 name: Pull Request CI
 
 on:
-  pull_request:
-    types: [opened, synchronize,  reopened, ready_for_review] # Defaults + ready_for_review
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review] # Defaults + ready_for_review
 
 jobs:
   check-if-docs-only:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -1,42 +1,41 @@
 name: Pull Request CI
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review] # Defaults + ready_for_review
 
 jobs:
   check-if-docs-only:
     uses: ./.github/workflows/task-check-docs.yml
 
-#  basic-tests:
-#    name: basic tests
-#    runs-on: ubuntu-latest
-#    needs: check-if-docs-only
-#    if: needs.check-if-docs-only.outputs.only-docs-changed == 'false'
-#    concurrency:
-#      group: ${{ github.workflow }}-${{ github.ref }}
-#      cancel-in-progress: true
-#    steps:
-#      - name: checkout
-#        uses: actions/checkout@v4
-#      - name: setup python
-#        uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.10'
-#      - name: install dependencies
-#        run: sudo .install/install_script.sh
-#      - name: install python packages
-#        run: pip3 install -r requirements.txt
-#      - name: check format
-#        run: make check-format
-#      - name: unit tests
-#        run: make unit_test
-#      - name: flow tests
-#        run: make flow_test VERBOSE=1
+  basic-tests:
+    name: basic tests
+    runs-on: ubuntu-latest
+    needs: check-if-docs-only
+    if: needs.check-if-docs-only.outputs.only-docs-changed == 'false'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: install dependencies
+        run: sudo .install/install_script.sh
+      - name: install python packages
+        run: pip3 install -r requirements.txt
+      - name: check format
+        run: make check-format
+      - name: unit tests
+        run: make unit_test
+      - name: flow tests
+        run: make flow_test VERBOSE=1
 
   coverage:
-    # needs: [basic-tests, check-if-docs-only]
-    needs: [check-if-docs-only]
+    needs: [basic-tests, check-if-docs-only]
     if: ${{ !github.event.pull_request.draft && needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}
     uses: ./.github/workflows/coverage.yml
     secrets: inherit
@@ -60,7 +59,7 @@ jobs:
   pr-validation:
     needs:
       - check-if-docs-only
-#      - basic-tests
+      - basic-tests
       - coverage
       - codeql-analysis
       - spellcheck

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -1,7 +1,7 @@
 name: Pull Request CI
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize,  reopened, ready_for_review] # Defaults + ready_for_review
 
 jobs:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: setup python
         uses: actions/setup-python@v5
         with:
@@ -52,8 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@v0
         with:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -60,7 +60,7 @@ jobs:
   pr-validation:
     needs:
       - check-if-docs-only
-      - basic-tests
+#      - basic-tests
       - coverage
       - codeql-analysis
       - spellcheck

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: setup python
         uses: actions/setup-python@v5
         with:
@@ -50,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@v0
         with:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -2,7 +2,7 @@ name: Pull Request CI
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review] # Defaults + ready_for_review
+    types: [opened, synchronize,  reopened, ready_for_review] # Defaults + ready_for_review
 
 jobs:
   check-if-docs-only:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -1,41 +1,42 @@
 name: Pull Request CI
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review] # Defaults + ready_for_review
 
 jobs:
   check-if-docs-only:
     uses: ./.github/workflows/task-check-docs.yml
 
-  basic-tests:
-    name: basic tests
-    runs-on: ubuntu-latest
-    needs: check-if-docs-only
-    if: needs.check-if-docs-only.outputs.only-docs-changed == 'false'
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - name: install dependencies
-        run: sudo .install/install_script.sh
-      - name: install python packages
-        run: pip3 install -r requirements.txt
-      - name: check format
-        run: make check-format
-      - name: unit tests
-        run: make unit_test
-      - name: flow tests
-        run: make flow_test VERBOSE=1
+#  basic-tests:
+#    name: basic tests
+#    runs-on: ubuntu-latest
+#    needs: check-if-docs-only
+#    if: needs.check-if-docs-only.outputs.only-docs-changed == 'false'
+#    concurrency:
+#      group: ${{ github.workflow }}-${{ github.ref }}
+#      cancel-in-progress: true
+#    steps:
+#      - name: checkout
+#        uses: actions/checkout@v4
+#      - name: setup python
+#        uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.10'
+#      - name: install dependencies
+#        run: sudo .install/install_script.sh
+#      - name: install python packages
+#        run: pip3 install -r requirements.txt
+#      - name: check format
+#        run: make check-format
+#      - name: unit tests
+#        run: make unit_test
+#      - name: flow tests
+#        run: make flow_test VERBOSE=1
 
   coverage:
-    needs: [basic-tests, check-if-docs-only]
+    # needs: [basic-tests, check-if-docs-only]
+    needs: [check-if-docs-only]
     if: ${{ !github.event.pull_request.draft && needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}
     uses: ./.github/workflows/coverage.yml
     secrets: inherit

--- a/.github/workflows/task-check-docs.yml
+++ b/.github/workflows/task-check-docs.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # required for changed-files action to work
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Check if only docs were changed
         id: check-docs
         uses: tj-actions/changed-files@v44


### PR DESCRIPTION
**Describe the changes in the pull request**

Replace pull_request with pull_request_target to enable forked PRs to run our basic flow which includes creating EC2 instance for  coverage flow (forked PRs still required maintainer approval to run)
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
