### PR TITLE
[MOD-7474] fix valgrind on linux x86

### DIFF
--- a/.github/workflows/alpine3.yml
+++ b/.github/workflows/alpine3.yml
@@ -8,4 +8,4 @@ jobs:
     with:
       container: alpine:3
       pre-checkout-script: apk add bash
-      run-valgrind: false
+      run-valgrind: true

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -14,6 +14,11 @@ jobs:
   jammy:
     uses: ./.github/workflows/task-unit-test.yml
     with:
+      container: ubuntu:jammy
+      run-valgrind: true
+  alpine3:
+    uses: ./.github/workflows/task-unit-test.yml
+    with:
       container: alpine:3
       pre-checkout-script: apk add bash
       run-valgrind: true

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,54 +9,54 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
   jammy:
     uses: ./.github/workflows/task-unit-test.yml
     with:
-      container: ubuntu:jammy
-      run-valgrind: true
-  focal:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: ubuntu:focal
-      run-valgrind: false
-  bionic:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: ubuntu:focal
-      run-valgrind: false
-  bullseye:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: debian:bullseye
-      run-valgrind: false
-  amazonlinux2:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: amazonlinux:2
-      pre-checkout-script: yum install -y tar gzip
-      run-valgrind: false
-  mariner2:
-    uses: ./.github/workflows/mariner2.yml
-  rocky8:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: rockylinux:8
-      run-valgrind: false
-  rocky9:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: rockylinux:9
-      run-valgrind: false
-  alpine3:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
       container: alpine:3
-      pre-checkout-script: apk add bash
-      run-valgrind: false
-  macos:
-    uses: ./.github/workflows/macos.yml
-  arm:
-    uses: ./.github/workflows/arm.yml
-    secrets: inherit
+      run-valgrind: true
+  # focal:
+  #   uses: ./.github/workflows/task-unit-test.yml
+  #   with:
+  #     container: ubuntu:focal
+  #     run-valgrind: false
+  # bionic:
+  #   uses: ./.github/workflows/task-unit-test.yml
+  #   with:
+  #     container: ubuntu:focal
+  #     run-valgrind: false
+  # bullseye:
+  #   uses: ./.github/workflows/task-unit-test.yml
+  #   with:
+  #     container: debian:bullseye
+  #     run-valgrind: false
+  # amazonlinux2:
+  #   uses: ./.github/workflows/task-unit-test.yml
+  #   with:
+  #     container: amazonlinux:2
+  #     pre-checkout-script: yum install -y tar gzip
+  #     run-valgrind: false
+  # mariner2:
+  #   uses: ./.github/workflows/mariner2.yml
+  # rocky8:
+  #   uses: ./.github/workflows/task-unit-test.yml
+  #   with:
+  #     container: rockylinux:8
+  #     run-valgrind: false
+  # rocky9:
+  #   uses: ./.github/workflows/task-unit-test.yml
+  #   with:
+  #     container: rockylinux:9
+  #     run-valgrind: false
+  # alpine3:
+  #   uses: ./.github/workflows/task-unit-test.yml
+  #   with:
+  #     container: alpine:3
+  #     pre-checkout-script: apk add bash
+  #     run-valgrind: false
+  # macos:
+  #   uses: ./.github/workflows/macos.yml
+  # arm:
+  #   uses: ./.github/workflows/arm.yml
+  #   secrets: inherit

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -15,6 +15,7 @@ jobs:
     uses: ./.github/workflows/task-unit-test.yml
     with:
       container: alpine:3
+      pre-checkout-script: apk add bash
       run-valgrind: true
   # focal:
   #   uses: ./.github/workflows/task-unit-test.yml

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
   jammy:
     uses: ./.github/workflows/task-unit-test.yml

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
   jammy:
     uses: ./.github/workflows/task-unit-test.yml

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ endif
 ifeq ($(VALGRIND),1)
 _CTEST_ARGS += \
 	-T memcheck \
-	--overwrite MemoryCheckCommandOptions="--leak-check=full --error-exitcode=255"
+	--overwrite MemoryCheckCommandOptions="--leak-check=full --fair-sched=yes --error-exitcode=255"
 endif
 
 unit_test:

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,8 @@ pybind:
 _CTEST_ARGS=$(CTEST_ARGS)
 _CTEST_ARGS += \
 	--output-on-failure \
-	$(MAKE_J)
+	$(MAKE_J) \
+	-V
 
 ifeq ($(VERBOSE),1)
 _CTEST_ARGS += -V

--- a/Makefile
+++ b/Makefile
@@ -167,8 +167,7 @@ pybind:
 _CTEST_ARGS=$(CTEST_ARGS)
 _CTEST_ARGS += \
 	--output-on-failure \
-	$(MAKE_J) \
-	-V
+	$(MAKE_J)
 
 ifeq ($(VERBOSE),1)
 _CTEST_ARGS += -V

--- a/tests/unit/test_hnsw_parallel.cpp
+++ b/tests/unit/test_hnsw_parallel.cpp
@@ -139,7 +139,7 @@ TYPED_TEST(HNSWTestParallel, parallelSearchKnn) {
             // query_val+2, ...) The score is the L2 distance between the vectors that correspond
             // the ids.
             size_t diff_id = (id > query_val) ? (id - query_val) : (query_val - id);
-            if (diff_id != (res_index + 1 + 7) / 2) {
+            if (diff_id != (res_index + 1) / 2) {
                 ADD_FAILURE() << "Expected diff_id: " << (res_index + 1) / 2 << " got: " << diff_id;
                 this->printNeighboursOfId(index, id);
                 // Check the score without ending the test.
@@ -840,7 +840,7 @@ TYPED_TEST(HNSWTestParallel, parallelRepairInsert) {
         // res label and the query val (n/4, n/4 - 1, n/4 + 1, n/4 - 2 n/4 + 2, ...) The score
         // is the L2 distance between the vectors that correspond the ids.
         size_t diff_id = std::abs(int(id - query_val));
-        if (diff_id != (res_index + 1 + 7) / 2) {
+        if (diff_id != (res_index + 1) / 2) {
             ADD_FAILURE() << "Expected diff_id: " << (res_index + 1) / 2 << " got: " << diff_id;
             this->printNeighboursOfId(hnsw_index, id);
             // Check the score without ending the test.

--- a/tests/unit/test_hnsw_parallel.cpp
+++ b/tests/unit/test_hnsw_parallel.cpp
@@ -84,8 +84,7 @@ protected:
         auto *hnsw_index = CastToHNSW(index);
         int **neighbors_output;
         VecSimDebug_GetElementNeighborsInHNSWGraph(hnsw_index, id, &neighbors_output);
-        auto graph_data = hnsw_index->getGraphDataByInternalId(id);
-        for (size_t l = 0; l <= graph_data->toplevel; l++) {
+        for (size_t l = 0; neighbors_output[l]; l++) {
             std::cout << "Printing neighbors for level: " << l << std::endl;
             auto &neighbours = neighbors_output[l];
             auto neighbours_count = neighbours[0];
@@ -140,7 +139,7 @@ TYPED_TEST(HNSWTestParallel, parallelSearchKnn) {
             // query_val+2, ...) The score is the L2 distance between the vectors that correspond
             // the ids.
             size_t diff_id = (id > query_val) ? (id - query_val) : (query_val - id);
-            if (diff_id != (res_index + 1) / 2) {
+            if (diff_id != (res_index + 1 + 7) / 2) {
                 ADD_FAILURE() << "Expected diff_id: " << (res_index + 1) / 2 << " got: " << diff_id;
                 this->printNeighboursOfId(index, id);
                 // Check the score without ending the test.
@@ -841,7 +840,7 @@ TYPED_TEST(HNSWTestParallel, parallelRepairInsert) {
         // res label and the query val (n/4, n/4 - 1, n/4 + 1, n/4 - 2 n/4 + 2, ...) The score
         // is the L2 distance between the vectors that correspond the ids.
         size_t diff_id = std::abs(int(id - query_val));
-        if (diff_id != (res_index + 1) / 2) {
+        if (diff_id != (res_index + 1 + 7) / 2) {
             ADD_FAILURE() << "Expected diff_id: " << (res_index + 1) / 2 << " got: " << diff_id;
             this->printNeighboursOfId(hnsw_index, id);
             // Check the score without ending the test.


### PR DESCRIPTION
## Better resources management in Valgrind
This update addresses an issue where Valgrind hangs when running `HNSWTestParalle`l on x86 machines. The exact cause is unclear but appears related to Valgrind's thread management. By setting the `--fair-sched=yes` flag, Valgrind uses a different algorithm to synchronize threads, potentially avoiding the hang.

## Modifying Parallel Tests
- Added a test destructor to free the index to avoid false leak alerts.
- Print neighbors in case the search fails to identify unreachable nodes.
- Use `testing::Test::HasFatalFailure()` to halt tests early if they fail within a subroutine or thread.
- Modified `parallelInsertSearch` to continue running queries until 95% of vectors are indexed, rather than just a single query during indexing.
- Split the previous loop running on` is_multi = [false, true]` into two distinct tests—one for single index and one for multi-index scenarios.