### PR TITLE
Fix the fix of flaky switch mode test

### DIFF
--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -2939,6 +2939,7 @@ TYPED_TEST(HNSWTieredIndexTest, switchWriteModes) {
 
     // Insert INPLACE another n vector (instead of the ones that were deleted).
     VecSim_SetWriteMode(VecSim_WriteInPlace);
+    auto hnsw_index = tiered_index->getHNSWIndex();
     // Run twice, at first run we insert non-existing labels, in the second run we overwrite them
     // (for single-value index only).
     for (auto overwrite : {0, 1}) {
@@ -2950,7 +2951,7 @@ TYPED_TEST(HNSWTieredIndexTest, switchWriteModes) {
             labelType cur_label = i % n_labels + n_labels;
             EXPECT_EQ(tiered_index->addVector(vector, cur_label),
                       TypeParam::isMulti() ? 1 : 1 - overwrite);
-            // Run a query and see that we only receive ids with label < n_labels+i
+            // Run a query over hnsw index and see that we only receive ids with label < n_labels+i
             // (the label that we just inserted), and the first result should be this vector
             // (unless it is unreachable)
             auto ver_res = [&](size_t res_label, double score, size_t index) {
@@ -2958,16 +2959,16 @@ TYPED_TEST(HNSWTieredIndexTest, switchWriteModes) {
                     if (res_label == cur_label) {
                         EXPECT_DOUBLE_EQ(score, 0);
                     } else {
-                        tiered_index->getHNSWIndex()->lockSharedIndexDataGuard();
-                        ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(cur_label, vector), 0);
-                        tiered_index->getHNSWIndex()->unlockSharedIndexDataGuard();
+                        hnsw_index->lockSharedIndexDataGuard();
+                        ASSERT_EQ(hnsw_index->getDistanceFrom_Unsafe(cur_label, vector), 0);
+                        hnsw_index->unlockSharedIndexDataGuard();
                     }
                 }
                 if (!overwrite) {
                     ASSERT_LE(res_label, i + n_labels);
                 }
             };
-            runTopKSearchTest(tiered_index, vector, 10, ver_res);
+            runTopKSearchTest(hnsw_index, vector, 10, ver_res);
         }
     }
 


### PR DESCRIPTION
**Describe the changes in the pull request**

This test validates that the newly inserted vector found in the query is the first result when the query is the new vector itself. The latest change in the test was to validate that the distance between the label matching the newly inserted vector and the query vector is zero, if it is not found in the query (since it may be unreachable). This was buggy since it tested the distance between the **result label** to the query rather than the **expected label**
Also, this includes testing directly on HNSW, since this is the purpose of the test (see that vectors were inserted to HNSW in place)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
