### PR TITLE
bump up to ubuntu24

### DIFF
--- a/.install/ubuntu_24.04.sh
+++ b/.install/ubuntu_24.04.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+export DEBIAN_FRONTEND=noninteractive
+MODE=$1 # whether to install using sudo or not
+
+$MODE apt update -qq
+$MODE apt install -yqq git wget build-essential lcov openssl libssl-dev \
+    python3 python3-venv python3-dev unzip rsync clang curl
+source install_cmake.sh $MODE

--- a/src/VecSim/algorithms/hnsw/graph_data.h
+++ b/src/VecSim/algorithms/hnsw/graph_data.h
@@ -25,7 +25,7 @@ struct ElementLevelData {
     idType links[];
 
     explicit ElementLevelData(std::shared_ptr<VecSimAllocator> allocator)
-        : incomingUnidirectionalEdges(new (allocator) vecsim_stl::vector<idType>(allocator)),
+        : incomingUnidirectionalEdges(new(allocator) vecsim_stl::vector<idType>(allocator)),
           numLinks(0) {}
 
     linkListSize getNumLinks() const { return this->numLinks; }

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -48,8 +48,8 @@ py::object wrap_results(VecSimQueryReply **res, size_t num_res, size_t num_queri
         VecSimQueryReply_Free(res[i]);
     }
 
-    py::capsule free_when_done_l(data_numpy_l, [](void *labels) { delete[](long *) labels; });
-    py::capsule free_when_done_d(data_numpy_d, [](void *dists) { delete[](double *) dists; });
+    py::capsule free_when_done_l(data_numpy_l, [](void *labels) { delete[] (long *)labels; });
+    py::capsule free_when_done_d(data_numpy_d, [](void *dists) { delete[] (double *)dists; });
     return py::make_tuple(
         py::array_t<long>(
             {(size_t)num_queries, num_res},         // shape
@@ -132,7 +132,7 @@ private:
         }
 
         py::capsule free_when_done(data_numpy,
-                                   [](void *vector_data) { delete[](NPArrayType *) vector_data; });
+                                   [](void *vector_data) { delete[] (NPArrayType *)vector_data; });
         return py::array_t<NPArrayType>(
             {n_vectors, dim}, // shape
             {dim * sizeof(NPArrayType),

--- a/tests/module/redismodule.h
+++ b/tests/module/redismodule.h
@@ -855,10 +855,10 @@ RedisModuleString *(*RedisModule_HoldString)(RedisModuleCtx *ctx,
 REDISMODULE_API int (*RedisModule_StringCompare)(RedisModuleString *a,
                                                  RedisModuleString *b) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleCtx *(*RedisModule_GetContextFromIO)(RedisModuleIO *io)REDISMODULE_ATTR;
-REDISMODULE_API const
-    RedisModuleString *(*RedisModule_GetKeyNameFromIO)(RedisModuleIO *io)REDISMODULE_ATTR;
-REDISMODULE_API const
-    RedisModuleString *(*RedisModule_GetKeyNameFromModuleKey)(RedisModuleKey *key)REDISMODULE_ATTR;
+REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromIO)(RedisModuleIO *io)
+    REDISMODULE_ATTR;
+REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromModuleKey)(RedisModuleKey *key)
+    REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetDbIdFromModuleKey)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetDbIdFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetDbIdFromOptCtx)(RedisModuleKeyOptCtx *ctx) REDISMODULE_ATTR;
@@ -874,8 +874,8 @@ REDISMODULE_API void (*RedisModule_DigestAddLongLong)(RedisModuleDigest *md,
                                                       long long ele) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DigestEndSequence)(RedisModuleDigest *md) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetDbIdFromDigest)(RedisModuleDigest *dig) REDISMODULE_ATTR;
-REDISMODULE_API const
-    RedisModuleString *(*RedisModule_GetKeyNameFromDigest)(RedisModuleDigest *dig)REDISMODULE_ATTR;
+REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromDigest)(RedisModuleDigest *dig)
+    REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleDict *(*RedisModule_CreateDict)(RedisModuleCtx *ctx)REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeDict)(RedisModuleCtx *ctx,
                                              RedisModuleDict *d) REDISMODULE_ATTR;

--- a/tests/unit/test_hnsw_parallel.cpp
+++ b/tests/unit/test_hnsw_parallel.cpp
@@ -16,7 +16,7 @@
 #include <atomic>
 
 // Helper macro to get the closest even number which is equal or lower than x.
-#define FLOOR_EVEN(x) ((x) - ((x)&1))
+#define FLOOR_EVEN(x) ((x) - ((x) & 1))
 
 template <typename index_type_t>
 class HNSWTestParallel : public ::testing::Test {


### PR DESCRIPTION
`ubuntu-latest` GHA runner image is now ubuntu24.04
This PR aligns the library to support PR workflow on ubutnu24:
1. add ubuntu24 install script
2. format the code according to clang-format-18 version, which is the default version in ubuntu24

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
