### PR TITLE
format according to clang 14

### DIFF
--- a/src/VecSim/algorithms/hnsw/graph_data.h
+++ b/src/VecSim/algorithms/hnsw/graph_data.h
@@ -25,7 +25,7 @@ struct ElementLevelData {
     idType links[];
 
     explicit ElementLevelData(std::shared_ptr<VecSimAllocator> allocator)
-        : incomingUnidirectionalEdges(new(allocator) vecsim_stl::vector<idType>(allocator)),
+        : incomingUnidirectionalEdges(new (allocator) vecsim_stl::vector<idType>(allocator)),
           numLinks(0) {}
 
     linkListSize getNumLinks() const { return this->numLinks; }

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -48,8 +48,8 @@ py::object wrap_results(VecSimQueryReply **res, size_t num_res, size_t num_queri
         VecSimQueryReply_Free(res[i]);
     }
 
-    py::capsule free_when_done_l(data_numpy_l, [](void *labels) { delete[] (long *)labels; });
-    py::capsule free_when_done_d(data_numpy_d, [](void *dists) { delete[] (double *)dists; });
+    py::capsule free_when_done_l(data_numpy_l, [](void *labels) { delete[](long *) labels; });
+    py::capsule free_when_done_d(data_numpy_d, [](void *dists) { delete[](double *) dists; });
     return py::make_tuple(
         py::array_t<long>(
             {(size_t)num_queries, num_res},         // shape
@@ -132,7 +132,7 @@ private:
         }
 
         py::capsule free_when_done(data_numpy,
-                                   [](void *vector_data) { delete[] (NPArrayType *)vector_data; });
+                                   [](void *vector_data) { delete[](NPArrayType *) vector_data; });
         return py::array_t<NPArrayType>(
             {n_vectors, dim}, // shape
             {dim * sizeof(NPArrayType),

--- a/tests/module/redismodule.h
+++ b/tests/module/redismodule.h
@@ -855,10 +855,10 @@ RedisModuleString *(*RedisModule_HoldString)(RedisModuleCtx *ctx,
 REDISMODULE_API int (*RedisModule_StringCompare)(RedisModuleString *a,
                                                  RedisModuleString *b) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleCtx *(*RedisModule_GetContextFromIO)(RedisModuleIO *io)REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromIO)(RedisModuleIO *io)
-    REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromModuleKey)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
+REDISMODULE_API const
+    RedisModuleString *(*RedisModule_GetKeyNameFromIO)(RedisModuleIO *io)REDISMODULE_ATTR;
+REDISMODULE_API const
+    RedisModuleString *(*RedisModule_GetKeyNameFromModuleKey)(RedisModuleKey *key)REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetDbIdFromModuleKey)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetDbIdFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetDbIdFromOptCtx)(RedisModuleKeyOptCtx *ctx) REDISMODULE_ATTR;
@@ -874,8 +874,8 @@ REDISMODULE_API void (*RedisModule_DigestAddLongLong)(RedisModuleDigest *md,
                                                       long long ele) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DigestEndSequence)(RedisModuleDigest *md) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetDbIdFromDigest)(RedisModuleDigest *dig) REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromDigest)(RedisModuleDigest *dig)
-    REDISMODULE_ATTR;
+REDISMODULE_API const
+    RedisModuleString *(*RedisModule_GetKeyNameFromDigest)(RedisModuleDigest *dig)REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleDict *(*RedisModule_CreateDict)(RedisModuleCtx *ctx)REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeDict)(RedisModuleCtx *ctx,
                                              RedisModuleDict *d) REDISMODULE_ATTR;

--- a/tests/unit/test_hnsw_parallel.cpp
+++ b/tests/unit/test_hnsw_parallel.cpp
@@ -16,7 +16,7 @@
 #include <atomic>
 
 // Helper macro to get the closest even number which is equal or lower than x.
-#define FLOOR_EVEN(x) ((x) - ((x) & 1))
+#define FLOOR_EVEN(x) ((x) - ((x)&1))
 
 template <typename index_type_t>
 class HNSWTestParallel : public ::testing::Test {


### PR DESCRIPTION
### Background
Our pr workflow runs on 'ubuntu-latest' image. In this workflow we also check the code format with clang-format. Diffrent clang-format versions define diffrently the "correct" format of the code.
clang-format-14 is the default version for ubuntu22.

### changes in ubuntu-latest image
when `ubuntu-latest` pointer was changed to ubuntu24, we merged PR #547 to format the library's code with clang-format-18, which default clang-format version of ubuntu 24.
A few days later this change was rolled back and ubuntu-latest points to ubuntu22 again.
Following that we are re-formating the library with clang-format-14