### PR TITLE
[MOD-7981] fix concurrency group name in PR workflow

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -14,7 +14,7 @@ jobs:
     needs: check-if-docs-only
     if: needs.check-if-docs-only.outputs.only-docs-changed == 'false'
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
       - name: checkout


### PR DESCRIPTION
use github.event.pull_request.number to give a unique name to the concurrency group in the PR workflow