### PR TITLE
[MOD-8244] fix TieredFactory::EstimateInitialSize

### DIFF
--- a/src/VecSim/index_factories/brute_force_factory.cpp
+++ b/src/VecSim/index_factories/brute_force_factory.cpp
@@ -98,7 +98,7 @@ inline size_t EstimateInitialSize_ChooseMultiOrSingle(bool is_multi) {
         return sizeof(BruteForceIndex_Single<DataType, DistType>);
 }
 
-size_t EstimateInitialSize(const BFParams *params) {
+size_t EstimateInitialSize(const BFParams *params, bool is_normalized) {
 
     size_t allocations_overhead = VecSimAllocator::getAllocationOverheadSize();
 
@@ -106,16 +106,16 @@ size_t EstimateInitialSize(const BFParams *params) {
     size_t est = sizeof(VecSimAllocator) + allocations_overhead;
 
     if (params->type == VecSimType_FLOAT32) {
-        est += EstimateComponentsMemory<float, float>(params->metric);
+        est += EstimateComponentsMemory<float, float>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<float>(params->multi);
     } else if (params->type == VecSimType_FLOAT64) {
-        est += EstimateComponentsMemory<double, double>(params->metric);
+        est += EstimateComponentsMemory<double, double>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<double>(params->multi);
     } else if (params->type == VecSimType_BFLOAT16) {
-        est += EstimateComponentsMemory<bfloat16, float>(params->metric);
+        est += EstimateComponentsMemory<bfloat16, float>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<bfloat16, float>(params->multi);
     } else if (params->type == VecSimType_FLOAT16) {
-        est += EstimateComponentsMemory<float16, float>(params->metric);
+        est += EstimateComponentsMemory<float16, float>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<float16, float>(params->multi);
     }
 

--- a/src/VecSim/index_factories/brute_force_factory.h
+++ b/src/VecSim/index_factories/brute_force_factory.h
@@ -25,7 +25,7 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized = false);
 VecSimIndex *NewIndex(const BFParams *bfparams, bool is_normalized = false);
 VecSimIndex *NewIndex(const BFParams *bfparams, const AbstractIndexInitParams &abstractInitParams,
                       bool is_normalized);
-size_t EstimateInitialSize(const BFParams *params);
+size_t EstimateInitialSize(const BFParams *params, bool is_normalized = false);
 size_t EstimateElementSize(const BFParams *params);
 
 }; // namespace BruteForceFactory

--- a/src/VecSim/index_factories/components/components_factory.h
+++ b/src/VecSim/index_factories/components/components_factory.h
@@ -28,13 +28,13 @@ CreateIndexComponents(std::shared_ptr<VecSimAllocator> allocator, VecSimMetric m
 }
 
 template <typename DataType, typename DistType>
-size_t EstimateComponentsMemory(VecSimMetric metric) {
+size_t EstimateComponentsMemory(VecSimMetric metric, bool is_normalized) {
     size_t allocations_overhead = VecSimAllocator::getAllocationOverheadSize();
 
     // Currently we have only one distance calculator implementation
     size_t est = allocations_overhead + sizeof(DistanceCalculatorCommon<DistType>);
 
-    est += EstimatePreprocessorsContainerMemory<DataType>(metric);
+    est += EstimatePreprocessorsContainerMemory<DataType>(metric, is_normalized);
 
     return est;
 }

--- a/src/VecSim/index_factories/components/preprocessors_factory.h
+++ b/src/VecSim/index_factories/components/preprocessors_factory.h
@@ -35,10 +35,16 @@ CreatePreprocessorsContainer(std::shared_ptr<VecSimAllocator> allocator,
 }
 
 template <typename DataType>
-size_t EstimatePreprocessorsContainerMemory(VecSimMetric metric) {
+size_t EstimatePreprocessorsContainerMemory(VecSimMetric metric, bool is_normalized = false) {
     size_t allocations_overhead = VecSimAllocator::getAllocationOverheadSize();
+    VecSimMetric pp_metric;
+    if (is_normalized && metric == VecSimMetric_Cosine) {
+        pp_metric = VecSimMetric_IP;
+    } else {
+        pp_metric = metric;
+    }
 
-    if (metric == VecSimMetric_Cosine) {
+    if (pp_metric == VecSimMetric_Cosine) {
         constexpr size_t n_preprocessors = 1;
         // One entry in preprocessors array
         size_t est =

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -98,21 +98,21 @@ inline size_t EstimateInitialSize_ChooseMultiOrSingle(bool is_multi) {
         return sizeof(HNSWIndex_Single<DataType, DistType>);
 }
 
-size_t EstimateInitialSize(const HNSWParams *params) {
+size_t EstimateInitialSize(const HNSWParams *params, bool is_normalized) {
     size_t allocations_overhead = VecSimAllocator::getAllocationOverheadSize();
 
     size_t est = sizeof(VecSimAllocator) + allocations_overhead;
     if (params->type == VecSimType_FLOAT32) {
-        est += EstimateComponentsMemory<float, float>(params->metric);
+        est += EstimateComponentsMemory<float, float>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<float>(params->multi);
     } else if (params->type == VecSimType_FLOAT64) {
-        est += EstimateComponentsMemory<double, double>(params->metric);
+        est += EstimateComponentsMemory<double, double>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<double>(params->multi);
     } else if (params->type == VecSimType_BFLOAT16) {
-        est += EstimateComponentsMemory<bfloat16, float>(params->metric);
+        est += EstimateComponentsMemory<bfloat16, float>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<bfloat16, float>(params->multi);
     } else if (params->type == VecSimType_FLOAT16) {
-        est += EstimateComponentsMemory<float16, float>(params->metric);
+        est += EstimateComponentsMemory<float16, float>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<float16, float>(params->multi);
     }
     return est;

--- a/src/VecSim/index_factories/hnsw_factory.h
+++ b/src/VecSim/index_factories/hnsw_factory.h
@@ -22,7 +22,7 @@ namespace HNSWFactory {
  */
 VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized = false);
 VecSimIndex *NewIndex(const HNSWParams *params, bool is_normalized = false);
-size_t EstimateInitialSize(const HNSWParams *params);
+size_t EstimateInitialSize(const HNSWParams *params, bool is_normalized = false);
 size_t EstimateElementSize(const HNSWParams *params);
 
 #ifdef BUILD_TESTS

--- a/src/VecSim/index_factories/tiered_factory.cpp
+++ b/src/VecSim/index_factories/tiered_factory.cpp
@@ -18,6 +18,18 @@ using float16 = vecsim_types::float16;
 namespace TieredFactory {
 
 namespace TieredHNSWFactory {
+
+static inline BFParams NewBFParams(const TieredIndexParams *params) {
+    auto hnsw_params = params->primaryIndexParams->algoParams.hnswParams;
+    BFParams bf_params = {.type = hnsw_params.type,
+                          .dim = hnsw_params.dim,
+                          .metric = hnsw_params.metric,
+                          .multi = hnsw_params.multi,
+                          .blockSize = hnsw_params.blockSize};
+
+    return bf_params;
+}
+
 template <typename DataType, typename DistType = DataType>
 inline VecSimIndex *NewIndex(const TieredIndexParams *params) {
 
@@ -27,11 +39,7 @@ inline VecSimIndex *NewIndex(const TieredIndexParams *params) {
         HNSWFactory::NewIndex(params->primaryIndexParams, true));
     // initialize brute force index
 
-    BFParams bf_params = {.type = params->primaryIndexParams->algoParams.hnswParams.type,
-                          .dim = params->primaryIndexParams->algoParams.hnswParams.dim,
-                          .metric = params->primaryIndexParams->algoParams.hnswParams.metric,
-                          .multi = params->primaryIndexParams->algoParams.hnswParams.multi,
-                          .blockSize = params->primaryIndexParams->algoParams.hnswParams.blockSize};
+    BFParams bf_params = NewBFParams(params);
 
     std::shared_ptr<VecSimAllocator> flat_allocator = VecSimAllocator::newVecsimAllocator();
     AbstractIndexInitParams abstractInitParams = {.allocator = flat_allocator,
@@ -52,7 +60,7 @@ inline VecSimIndex *NewIndex(const TieredIndexParams *params) {
         hnsw_index, frontendIndex, *params, management_layer_allocator);
 }
 
-inline size_t EstimateInitialSize(const TieredIndexParams *params, BFParams &bf_params_output) {
+inline size_t EstimateInitialSize(const TieredIndexParams *params) {
     HNSWParams hnsw_params = params->primaryIndexParams->algoParams.hnswParams;
 
     // Add size estimation of VecSimTieredIndex sub indexes.
@@ -72,8 +80,6 @@ inline size_t EstimateInitialSize(const TieredIndexParams *params, BFParams &bf_
     } else if (hnsw_params.type == VecSimType_FLOAT16) {
         est += sizeof(TieredHNSWIndex<float16, float>);
     }
-    bf_params_output.type = hnsw_params.type;
-    bf_params_output.multi = hnsw_params.multi;
 
     return est;
 }
@@ -107,7 +113,8 @@ size_t EstimateInitialSize(const TieredIndexParams *params) {
 
     BFParams bf_params{};
     if (params->primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
-        est += TieredHNSWFactory::EstimateInitialSize(params, bf_params);
+        est += TieredHNSWFactory::EstimateInitialSize(params);
+        bf_params = TieredHNSWFactory::NewBFParams(params);
     }
 
     est += BruteForceFactory::EstimateInitialSize(&bf_params);

--- a/src/VecSim/index_factories/tiered_factory.cpp
+++ b/src/VecSim/index_factories/tiered_factory.cpp
@@ -64,7 +64,8 @@ inline size_t EstimateInitialSize(const TieredIndexParams *params) {
     HNSWParams hnsw_params = params->primaryIndexParams->algoParams.hnswParams;
 
     // Add size estimation of VecSimTieredIndex sub indexes.
-    size_t est = HNSWFactory::EstimateInitialSize(&hnsw_params);
+    // Normalization is done by the frontend index.
+    size_t est = HNSWFactory::EstimateInitialSize(&hnsw_params, true);
 
     // Management layer allocator overhead.
     size_t allocations_overhead = VecSimAllocator::getAllocationOverheadSize();
@@ -117,7 +118,7 @@ size_t EstimateInitialSize(const TieredIndexParams *params) {
         bf_params = TieredHNSWFactory::NewBFParams(params);
     }
 
-    est += BruteForceFactory::EstimateInitialSize(&bf_params);
+    est += BruteForceFactory::EstimateInitialSize(&bf_params, false);
     return est;
 }
 

--- a/src/VecSim/spaces/computer/preprocessor_container.h
+++ b/src/VecSim/spaces/computer/preprocessor_container.h
@@ -87,6 +87,12 @@ public:
 
     void preprocessQueryInPlace(void *blob, size_t processed_bytes_count) const override;
 
+#ifdef BUILD_TESTS
+    std::array<PreprocessorInterface *, n_preprocessors> getPreprocessors() const {
+        return preprocessors;
+    }
+#endif
+
 private:
     using Base = PreprocessorsContainerAbstract;
 };

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -250,6 +250,10 @@ public:
         delete this->preprocessors;
         this->preprocessors = newPPContainer;
     }
+
+    IndexComponents<DataType, DistType> get_components() const {
+        return {.indexCalculator = this->indexCalculator, .preprocessors = this->preprocessors};
+    }
 #endif
 
 protected:

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -129,7 +129,7 @@ TYPED_TEST(HNSWTieredIndexTest, testSizeEstimation) {
 
     HNSWParams hnsw_params = {.type = TypeParam::get_index_type(),
                               .dim = dim,
-                              .metric = VecSimMetric_L2,
+                              .metric = VecSimMetric_Cosine,
                               .multi = isMulti,
                               .M = M};
     VecSimParams vecsim_hnsw_params = CreateParams(hnsw_params);

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -159,9 +159,6 @@ TYPED_TEST(HNSWTieredIndexTest, testIndexesAttributes) {
     const std::type_info &bf_pp_container_actual_type = typeid(*bf_preprocessors);
     ASSERT_EQ(bf_pp_container_actual_type, bf_pp_container_expected_type);
 
-    // CosinePreprocessor<TEST_DATA_T> cosine_pp =
-    // dynamic_cast<MultiPreprocessorsContainer<TEST_DATA_T, 1>
-    // *>(bf_preprocessors)->preprocessors[0];
     std::array<PreprocessorInterface *, 1> pp_arr =
         dynamic_cast<MultiPreprocessorsContainer<TEST_DATA_T, 1> *>(bf_preprocessors)
             ->getPreprocessors();

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -120,6 +120,62 @@ TYPED_TEST(HNSWTieredIndexTest, CreateIndexInstance) {
     ASSERT_EQ(tiered_index->labelToInsertJobs.at(vector_label).size(), 0);
 }
 
+TYPED_TEST(HNSWTieredIndexTest, testIndexesAttributes) {
+    // Create TieredHNSW index instance with a mock queue.
+    HNSWParams params = {.type = TypeParam::get_index_type(),
+                         .dim = 4,
+                         .metric = VecSimMetric_Cosine,
+                         .multi = TypeParam::isMulti()};
+    VecSimParams hnsw_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+    auto *tiered_index = this->CreateTieredHNSWIndex(hnsw_params, mock_thread_pool);
+
+    HNSWIndex<TEST_DATA_T, TEST_DIST_T> *hnsw_index = this->CastToHNSW(tiered_index);
+    BruteForceIndex<TEST_DATA_T, TEST_DIST_T> *bf_index = this->GetFlatIndex(tiered_index);
+
+    VecSimIndexBasicInfo hnsw_info = VecSimIndex_Info(hnsw_index).commonInfo.basicInfo;
+    VecSimIndexBasicInfo bf_info = VecSimIndex_Info(bf_index).commonInfo.basicInfo;
+
+    // assert metric
+    ASSERT_EQ(hnsw_info.metric, params.metric);
+    ASSERT_EQ(bf_info.metric, params.metric);
+    // assert type
+    ASSERT_EQ(hnsw_info.type, params.type);
+    ASSERT_EQ(bf_info.type, params.type);
+    // assert dim
+    ASSERT_EQ(hnsw_info.dim, params.dim);
+    ASSERT_EQ(bf_info.dim, params.dim);
+    // assert multi
+    ASSERT_EQ(hnsw_info.isMulti, params.multi);
+    ASSERT_EQ(bf_info.isMulti, params.multi);
+
+    // assert containers
+
+    // bf - multi with cosine
+    IndexComponents<TEST_DATA_T, TEST_DIST_T> bf_components = bf_index->get_components();
+    PreprocessorsContainerAbstract *bf_preprocessors = bf_components.preprocessors;
+    const std::type_info &bf_pp_container_expected_type =
+        typeid(MultiPreprocessorsContainer<TEST_DATA_T, 1>);
+    const std::type_info &bf_pp_container_actual_type = typeid(*bf_preprocessors);
+    ASSERT_EQ(bf_pp_container_actual_type, bf_pp_container_expected_type);
+
+    // CosinePreprocessor<TEST_DATA_T> cosine_pp =
+    // dynamic_cast<MultiPreprocessorsContainer<TEST_DATA_T, 1>
+    // *>(bf_preprocessors)->preprocessors[0];
+    std::array<PreprocessorInterface *, 1> pp_arr =
+        dynamic_cast<MultiPreprocessorsContainer<TEST_DATA_T, 1> *>(bf_preprocessors)
+            ->getPreprocessors();
+    const std::type_info &bf_pp_expected_type = typeid(CosinePreprocessor<TEST_DATA_T>);
+    const std::type_info &bf_pp_actual_type = typeid(*pp_arr[0]);
+    ASSERT_EQ(bf_pp_actual_type, bf_pp_expected_type);
+
+    // hnsw - simple
+    IndexComponents<TEST_DATA_T, TEST_DIST_T> hnsw_components = hnsw_index->get_components();
+    const std::type_info &hnsw_pp_expected_type = typeid(PreprocessorsContainerAbstract);
+    const std::type_info &hnsw_pp_actual_type = typeid(*hnsw_components.preprocessors);
+    ASSERT_EQ(hnsw_pp_expected_type, hnsw_pp_actual_type);
+}
+
 TYPED_TEST(HNSWTieredIndexTest, testSizeEstimation) {
     size_t dim = 128;
     size_t n = DEFAULT_BLOCK_SIZE;


### PR DESCRIPTION
This PR addresses two bugs affecting the initial size estimation of the tiered index.

### 1. Missing Initialization of `BFParams` members in `TieredFactory::EstimateInitialSize` 
Before this fix, the `TieredHNSWFactory::EstimateInitialSize` was responsible for initializing specific members of the `BFParams` struct as follows:
```
    bf_params_output.type = hnsw_params.type;
    bf_params_output.multi = hnsw_params.multi;
```
However, all other members of `BFParams,` including metric, were left uninitialized, defaulting to zero. As a result, the metric defaulted to `VecSimMetric_L2` the default value for `VecSimMetric.`
This caused the memory size of the brute-force index components to be calculated as if it were a `VecSimMetric_L2` index. Consequently, if the actual metric of the index was `VecSimMetric_Cosine,` the size of the cosine preprocessor was omitted from the estimation.

After properly initializing all `BFParams` members, the size estimation for the frontend index of a tiered index using a cosine metric now includes the memory of the cosine preprocessor. 
**As expected, this change caused the tiered index size estimation test for the cosine index to fail, as seen in the first commit’s checks.** 

### 2. Accounting for Cosine Preprocessor Size in `TieredHNSWFactory::EstimateInitialSize`
For an HNSW index within a tiered index using the `VecSimMetric_Cosine` metric, the cosine preprocessor is typically absent, as normalization is expected to be performed by the frontend index. This behavior was not accounted for in the initial size estimation logic.
We now pass a `bool is_normalized` argument to the size estimation functions of the HNSW and brute-force indices. This argument ensures that the logic for size estimation mirrors the logic used during index construction.

The `is_normalized` argument is propagated to the `EstimateComponentsMemory` method, which adds the memory size of the cosine preprocessor only if:

* The metric is `VecSimMetric_Cosine,` and
* `is_normalized == false`



