### PR TITLE
Override missing intrinsincs in gcc <11

### DIFF
--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
   # jammy:
   #   uses: ./.github/workflows/task-unit-test.yml

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,13 +9,13 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
-  jammy:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: ubuntu:jammy
-      run-valgrind: true
+  # jammy:
+  #   uses: ./.github/workflows/task-unit-test.yml
+  #   with:
+  #     container: ubuntu:jammy
+  #     run-valgrind: true
   # alpine3:
   #   uses: ./.github/workflows/task-unit-test.yml
   #   with:
@@ -32,11 +32,11 @@ jobs:
   #   with:
   #     container: ubuntu:focal
   #     run-valgrind: false
-  # bullseye:
-  #   uses: ./.github/workflows/task-unit-test.yml
-  #   with:
-  #     container: debian:bullseye
-  #     run-valgrind: false
+  bullseye:
+    uses: ./.github/workflows/task-unit-test.yml
+    with:
+      container: debian:bullseye
+      run-valgrind: false
   # amazonlinux2:
   #   uses: ./.github/workflows/task-unit-test.yml
   #   with:

--- a/src/VecSim/spaces/space_includes.h
+++ b/src/VecSim/spaces/space_includes.h
@@ -16,6 +16,9 @@
 #if defined(__AVX512F__) || defined(__AVX__) || defined(__SSE__)
 #if defined(__GNUC__)
 #include <x86intrin.h>
+// Override missing implementations in GCC < 11
+// Full list and suggested alternatives for each missing function can be found here:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95483
 #if (__GNUC__ < 11)
 #define _mm256_loadu_epi8(ptr) _mm256_maskz_loadu_epi8(~0, ptr)
 #endif

--- a/src/VecSim/spaces/space_includes.h
+++ b/src/VecSim/spaces/space_includes.h
@@ -16,6 +16,9 @@
 #if defined(__AVX512F__) || defined(__AVX__) || defined(__SSE__)
 #if defined(__GNUC__)
 #include <x86intrin.h>
+#if (__GNUC__ < 11)
+#define _mm256_loadu_epi8(ptr) mm256_maskz_loadu_epi8(~0, ptr)
+#endif
 #elif defined(__clang__)
 #include <xmmintrin.h>
 #elif defined(_MSC_VER)

--- a/src/VecSim/spaces/space_includes.h
+++ b/src/VecSim/spaces/space_includes.h
@@ -17,7 +17,7 @@
 #if defined(__GNUC__)
 #include <x86intrin.h>
 #if (__GNUC__ < 11)
-#define _mm256_loadu_epi8(ptr) mm256_maskz_loadu_epi8(~0, ptr)
+#define _mm256_loadu_epi8(ptr) _mm256_maskz_loadu_epi8(~0, ptr)
 #endif
 #elif defined(__clang__)
 #include <xmmintrin.h>


### PR DESCRIPTION
There are missing implmnetation for several intrinsincs in gcc < 11 

full list and suggested alternatives for each missing function can be found here:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95483

The missing functions were added in gcc11.

in this PR we override `_mm256_loadu_epi8` with `mm256_maskz_loadu_epi8`, using ~0 mask as recommended by the gcc team.