### PR TITLE
[MOD-8206] INT8 flow tests

### DIFF
--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -300,6 +300,9 @@ public:
         } else if (type == VecSimType_FLOAT16) {
             auto *hnsw = dynamic_cast<HNSWIndex<float16, float> *>(index.get());
             hnsw->saveIndex(location);
+        } else if (type == VecSimType_INT8) {
+            auto *hnsw = dynamic_cast<HNSWIndex<int8_t, float> *>(index.get());
+            hnsw->saveIndex(location);
         } else {
             throw std::runtime_error("Invalid index data type");
         }
@@ -430,6 +433,10 @@ public:
                 .valid_state;
         } else if (type == VecSimType_FLOAT16) {
             return dynamic_cast<HNSWIndex<float16, float> *>(this->index.get())
+                ->checkIntegrity()
+                .valid_state;
+        } else if (type == VecSimType_INT8) {
+            return dynamic_cast<HNSWIndex<int8_t, float> *>(this->index.get())
                 ->checkIntegrity()
                 .valid_state;
         } else {

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -84,7 +84,7 @@ def create_int8_vectors(shape, rng: np.random.Generator = None):
     return rng.integers(low=-128, high=127, size=shape, dtype=np.int8)
 
 def get_ground_truth_results(dist_func, query, vectors, k):
-    results = [{"dist": dist_func(query, vec), "label": key} for key, vec in vectors]
+    results = [{"dist": dist_func(query.flat, vec), "label": key} for key, vec in vectors]
     results = sorted(results, key=lambda x: x["dist"])
     keys = [res["label"] for res in results[:k]]
 
@@ -93,6 +93,8 @@ def get_ground_truth_results(dist_func, query, vectors, k):
 def fp32_expand_and_calc_cosine_dist(a, b):
     # stupid numpy doesn't make any intermediate conversions when handling small types
     # so we might get overflow. We need to convert to float32 ourselves.
-    a_float32 = a.astype(np.float32)
-    b_float32 = b.astype(np.float32)
+    # a_float32 = a.astype(np.float32)
+    # b_float32 = b.astype(np.float32)
+    a_float32 = a
+    b_float32 = b
     return spatial.distance.cosine(a_float32, b_float32)

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -61,6 +61,10 @@ def vec_to_bfloat16(vec):
 def vec_to_float16(vec):
     return vec.astype(np.float16)
 
+def create_int8_vectors(num_elements, dim, rng: np.random.Generator = None):
+    rng = np.random.default_rng(seed=42) if rng is None else rng
+    return rng.integers(low=-128, high=127, size=(num_elements, dim), dtype=np.int8)
+
 def get_ground_truth_results(dist_func, query, vectors, k):
     results = [{"dist": dist_func(query, vec), "label": key} for key, vec in vectors]
     results = sorted(results, key=lambda x: x["dist"])

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -79,9 +79,9 @@ def vec_to_bfloat16(vec):
 def vec_to_float16(vec):
     return vec.astype(np.float16)
 
-def create_int8_vectors(num_elements, dim, rng: np.random.Generator = None):
+def create_int8_vectors(shape, rng: np.random.Generator = None):
     rng = np.random.default_rng(seed=42) if rng is None else rng
-    return rng.integers(low=-128, high=127, size=(num_elements, dim), dtype=np.int8)
+    return rng.integers(low=-128, high=127, size=shape, dtype=np.int8)
 
 def get_ground_truth_results(dist_func, query, vectors, k):
     results = [{"dist": dist_func(query, vec), "label": key} for key, vec in vectors]

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -84,7 +84,7 @@ def create_int8_vectors(shape, rng: np.random.Generator = None):
     return rng.integers(low=-128, high=127, size=shape, dtype=np.int8)
 
 def get_ground_truth_results(dist_func, query, vectors, k):
-    results = [{"dist": dist_func(query.flat, vec), "label": key} for key, vec in vectors]
+    results = [{"dist": dist_func(query, vec), "label": key} for key, vec in vectors]
     results = sorted(results, key=lambda x: x["dist"])
     keys = [res["label"] for res in results[:k]]
 
@@ -93,8 +93,6 @@ def get_ground_truth_results(dist_func, query, vectors, k):
 def fp32_expand_and_calc_cosine_dist(a, b):
     # stupid numpy doesn't make any intermediate conversions when handling small types
     # so we might get overflow. We need to convert to float32 ourselves.
-    # a_float32 = a.astype(np.float32)
-    # b_float32 = b.astype(np.float32)
-    a_float32 = a
-    b_float32 = b
+    a_float32 = a.astype(np.float32)
+    b_float32 = b.astype(np.float32)
     return spatial.distance.cosine(a_float32, b_float32)

--- a/tests/flow/test_bruteforce.py
+++ b/tests/flow/test_bruteforce.py
@@ -33,7 +33,7 @@ class Data:
 
     @staticmethod
     def calculate_dists(query, vectors, k, dist_func):
-        dists = [(dist_func(query, vec), key) for key, vec in vectors]
+        dists = [(dist_func(query.flat, vec), key) for key, vec in vectors]
         dists = sorted(dists)[:k]
         keys = [key for _, key in dists]
         dists = [dist for dist, _ in dists]

--- a/tests/flow/test_bruteforce.py
+++ b/tests/flow/test_bruteforce.py
@@ -682,7 +682,7 @@ class GeneralTest():
         num_labels = self.num_elements // num_per_label
         k = 10
 
-        data = create_data_func(num_labels, self.dim, self.rng)
+        data = create_data_func((num_labels, self.dim), self.rng)
 
         index = self.create_index(is_multi=True)
 
@@ -719,10 +719,10 @@ class TestINT8(GeneralTest):
     GeneralTest.data_type = VecSimType_INT8
 
     #### Create vectors
-    GeneralTest.vectors_data = create_int8_vectors(GeneralTest.num_elements, GeneralTest.dim, GeneralTest.rng)
+    GeneralTest.vectors_data = create_int8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
 
     #### Create queries
-    GeneralTest.query_data = create_int8_vectors(GeneralTest.num_queries, GeneralTest.dim, GeneralTest.rng)
+    GeneralTest.query_data = create_int8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
 
     def test_Cosine(self):
 

--- a/tests/flow/test_bruteforce.py
+++ b/tests/flow/test_bruteforce.py
@@ -495,7 +495,7 @@ class TestFloat16():
         print(f'\nlookup time for {self.num_labels} vectors with dim={self.dim} took {end - start} seconds, got {res_num} results')
 
         # Verify that we got exactly all vectors within the range
-        results, keys = get_ground_truth_results(spatial.distance.sqeuclidean, query_data.flat, self.data.vectors, res_num)
+        results, keys = get_ground_truth_results(spatial.distance.sqeuclidean, query_data[0], self.data.vectors, res_num)
 
         assert_allclose(max(bf_distances[0]), results[res_num-1]["dist"], rtol=1e-05)
         assert np.array_equal(np.array(bf_labels[0]), np.array(keys))

--- a/tests/flow/test_hnsw.py
+++ b/tests/flow/test_hnsw.py
@@ -903,11 +903,7 @@ class GeneralTest():
     @classmethod
     def create_add_vectors(cls, hnsw_index):
         assert cls.data is not None
-        label_to_vec_list = []
-        for i, vector in enumerate(cls.data):
-            hnsw_index.add_vector(vector, i)
-            label_to_vec_list.append((i, vector))
-        return label_to_vec_list
+        return create_add_vectors(hnsw_index, cls.data)
 
     @classmethod
     def get_cached_single_L2_index(cls):
@@ -1028,6 +1024,7 @@ class GeneralTest():
         hnsw_index.set_ef(self.efRuntime)
 
     ##### Should be explicitly called #####
+
     def range_query(self, dist_func):
         hnsw_index = self.create_index(VecSimMetric_Cosine)
         label_to_vec_list = self.create_add_vectors(hnsw_index)
@@ -1119,22 +1116,14 @@ class TestINT8(GeneralTest):
     #### Create queries
     GeneralTest.query_data = create_int8_vectors(GeneralTest.num_queries, GeneralTest.dim, GeneralTest.rng)
 
-    @staticmethod
-    def fp32_expand_and_calc_cosine_dist(a, b):
-        # stupid numpy doesn't make any intermediate conversions when handling small types
-        # so we might get overflow. We need to convert to float32 ourselves.
-        a_float32 = a.astype(np.float32)
-        b_float32 = b.astype(np.float32)
-        return spatial.distance.cosine(a_float32, b_float32)
-
     def test_Cosine(self):
         hnsw_index = self.create_index(VecSimMetric_Cosine)
         label_to_vec_list = self.create_add_vectors(hnsw_index)
 
-        self.knn(hnsw_index, label_to_vec_list, self.fp32_expand_and_calc_cosine_dist)
+        self.knn(hnsw_index, label_to_vec_list, fp32_expand_and_calc_cosine_dist)
 
     def test_range_query(self):
-        self.range_query(self.fp32_expand_and_calc_cosine_dist)
+        self.range_query(fp32_expand_and_calc_cosine_dist)
 
     def test_multi_value(self):
         self.multi_value(create_int8_vectors)

--- a/tests/flow/test_hnsw.py
+++ b/tests/flow/test_hnsw.py
@@ -1066,7 +1066,7 @@ class GeneralTest():
         num_labels = self.num_elements // num_per_label
         k = 10
 
-        data = create_data_func(num_labels, self.dim, self.rng)
+        data = create_data_func((num_labels, self.dim), self.rng)
 
         hnsw_index = self.create_index(is_multi=True)
 
@@ -1111,10 +1111,10 @@ class TestINT8(GeneralTest):
     GeneralTest.data_type = VecSimType_INT8
 
     #### Create vectors
-    GeneralTest.data = create_int8_vectors(GeneralTest.num_elements, GeneralTest.dim, GeneralTest.rng)
+    GeneralTest.data = create_int8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
 
     #### Create queries
-    GeneralTest.query_data = create_int8_vectors(GeneralTest.num_queries, GeneralTest.dim, GeneralTest.rng)
+    GeneralTest.query_data = create_int8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
 
     def test_Cosine(self):
         hnsw_index = self.create_index(VecSimMetric_Cosine)


### PR DESCRIPTION
This pull request introduces flow tests for `VecSimType_INT8` data type.

### Generalized Test Classes
* Implemented `GeneralTest` class for running common tests on BF and HNSW indices. Currently only used by `TestINT8`.
* Created `TestINT8` class, inherits from `GeneralTest`

### Bindings support
* Added support for `VecSimType_INT8` in the `PyHNSWLibIndex`:
  * `HNSWIndex::saveIndex`
  * `HNSWIndex::checkIntegrity`

### New Helper Functions
* Introduced `create_flat_index` and `create_add_vectors` functions to facilitate the creation and addition of vectors to an index.
* Added a function `create_int8_vectors` to generate INT8 vectors for testing purposes.
* `fp32_expand_and_calc_cosine_dist` takes 2 numpy arrays and converts them to `np.float32` to avoid overflow in distance calculations. 

### Additional Improvements
* Updated `IndexCtx` class to include `type_to_dtype` mapping for various data types to their numpy type.
* Modified `__init__` method in `IndexCtx` to accept a `create_data_func` parameter, allowing custom data creation functions to be passed.