### PR TITLE
initialize dataSize ion abstractInitParams in tiered factory NewIndex from hnsw file

### DIFF
--- a/src/VecSim/index_factories/tiered_factory.h
+++ b/src/VecSim/index_factories/tiered_factory.h
@@ -35,9 +35,12 @@ VecSimIndex *NewIndex(const TieredIndexParams *params, HNSWIndex<DataType, DistT
                           .blockSize = hnsw_index->getBlockSize()};
 
     std::shared_ptr<VecSimAllocator> flat_allocator = VecSimAllocator::newVecsimAllocator();
+    size_t dataSize = VecSimParams_GetDataSize(bf_params.type, bf_params.dim, bf_params.metric);
+
     AbstractIndexInitParams abstractInitParams = {.allocator = flat_allocator,
                                                   .dim = bf_params.dim,
                                                   .vecType = bf_params.type,
+                                                  .dataSize = dataSize,
                                                   .metric = bf_params.metric,
                                                   .blockSize = bf_params.blockSize,
                                                   .multi = bf_params.multi,


### PR DESCRIPTION
Add `datasize` to the brute force index params when building a tiered index from a serialized hnsw index file.