### PR TITLE
Implement UINT8 vector type - [MOD-8230, MOD-8408]

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw_tiered_tests_friends.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered_tests_friends.h
@@ -58,6 +58,7 @@ INDEX_TEST_FRIEND_CLASS(HNSWTieredIndexTestBasic_switchDeleteModes_Test)
 friend class BF16TieredTest;
 friend class FP16TieredTest;
 friend class INT8TieredTest;
+friend class UINT8TieredTest;
 friend class CommonTypeMetricTieredTests_TestDataSizeTieredHNSW_Test;
 
 INDEX_TEST_FRIEND_CLASS(BM_VecSimBasics)

--- a/src/VecSim/index_factories/brute_force_factory.cpp
+++ b/src/VecSim/index_factories/brute_force_factory.cpp
@@ -78,6 +78,11 @@ VecSimIndex *NewIndex(const BFParams *bfparams, const AbstractIndexInitParams &a
             abstractInitParams.allocator, bfparams->metric, bfparams->dim, is_normalized);
         return NewIndex_ChooseMultiOrSingle<int8_t, float>(bfparams, abstractInitParams,
                                                            indexComponents);
+    } else if (bfparams->type == VecSimType_UINT8) {
+        IndexComponents<uint8_t, float> indexComponents = CreateIndexComponents<uint8_t, float>(
+            abstractInitParams.allocator, bfparams->metric, bfparams->dim, is_normalized);
+        return NewIndex_ChooseMultiOrSingle<uint8_t, float>(bfparams, abstractInitParams,
+                                                           indexComponents);
     }
 
     // If we got here something is wrong.
@@ -120,6 +125,9 @@ size_t EstimateInitialSize(const BFParams *params, bool is_normalized) {
     } else if (params->type == VecSimType_INT8) {
         est += EstimateComponentsMemory<int8_t, float>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<int8_t, float>(params->multi);
+    } else if (params->type == VecSimType_UINT8) {
+        est += EstimateComponentsMemory<uint8_t, float>(params->metric, is_normalized);
+        est += EstimateInitialSize_ChooseMultiOrSingle<uint8_t, float>(params->multi);
     } else {
         throw std::invalid_argument("Invalid params->type");
     }

--- a/src/VecSim/index_factories/brute_force_factory.cpp
+++ b/src/VecSim/index_factories/brute_force_factory.cpp
@@ -82,7 +82,7 @@ VecSimIndex *NewIndex(const BFParams *bfparams, const AbstractIndexInitParams &a
         IndexComponents<uint8_t, float> indexComponents = CreateIndexComponents<uint8_t, float>(
             abstractInitParams.allocator, bfparams->metric, bfparams->dim, is_normalized);
         return NewIndex_ChooseMultiOrSingle<uint8_t, float>(bfparams, abstractInitParams,
-                                                           indexComponents);
+                                                            indexComponents);
     }
 
     // If we got here something is wrong.

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -78,6 +78,11 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
             abstractInitParams.allocator, hnswParams->metric, hnswParams->dim, is_normalized);
         return NewIndex_ChooseMultiOrSingle<int8_t, float>(hnswParams, abstractInitParams,
                                                            indexComponents);
+    } else if (hnswParams->type == VecSimType_UINT8) {
+        IndexComponents<uint8_t, float> indexComponents = CreateIndexComponents<uint8_t, float>(
+            abstractInitParams.allocator, hnswParams->metric, hnswParams->dim, is_normalized);
+        return NewIndex_ChooseMultiOrSingle<uint8_t, float>(hnswParams, abstractInitParams,
+                                                           indexComponents);
     }
 
     // If we got here something is wrong.
@@ -117,6 +122,9 @@ size_t EstimateInitialSize(const HNSWParams *params, bool is_normalized) {
     } else if (params->type == VecSimType_INT8) {
         est += EstimateComponentsMemory<int8_t, float>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<int8_t, float>(params->multi);
+    } else if (params->type == VecSimType_UINT8) {
+        est += EstimateComponentsMemory<uint8_t, float>(params->metric, is_normalized);
+        est += EstimateInitialSize_ChooseMultiOrSingle<uint8_t, float>(params->multi);
     } else {
         throw std::invalid_argument("Invalid params->type");
     }
@@ -235,6 +243,11 @@ VecSimIndex *NewIndex(const std::string &location, bool is_normalized) {
         IndexComponents<int8_t, float> indexComponents = CreateIndexComponents<int8_t, float>(
             abstractInitParams.allocator, params.metric, abstractInitParams.dim, is_normalized);
         return NewIndex_ChooseMultiOrSingle<int8_t, float>(input, &params, abstractInitParams,
+                                                           indexComponents, version);
+    } else if (params.type == VecSimType_UINT8) {
+        IndexComponents<uint8_t, float> indexComponents = CreateIndexComponents<uint8_t, float>(
+            abstractInitParams.allocator, params.metric, abstractInitParams.dim, is_normalized);
+        return NewIndex_ChooseMultiOrSingle<uint8_t, float>(input, &params, abstractInitParams,
                                                            indexComponents, version);
     } else {
         auto bad_name = VecSimType_ToString(params.type);

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -82,7 +82,7 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
         IndexComponents<uint8_t, float> indexComponents = CreateIndexComponents<uint8_t, float>(
             abstractInitParams.allocator, hnswParams->metric, hnswParams->dim, is_normalized);
         return NewIndex_ChooseMultiOrSingle<uint8_t, float>(hnswParams, abstractInitParams,
-                                                           indexComponents);
+                                                            indexComponents);
     }
 
     // If we got here something is wrong.
@@ -248,7 +248,7 @@ VecSimIndex *NewIndex(const std::string &location, bool is_normalized) {
         IndexComponents<uint8_t, float> indexComponents = CreateIndexComponents<uint8_t, float>(
             abstractInitParams.allocator, params.metric, abstractInitParams.dim, is_normalized);
         return NewIndex_ChooseMultiOrSingle<uint8_t, float>(input, &params, abstractInitParams,
-                                                           indexComponents, version);
+                                                            indexComponents, version);
     } else {
         auto bad_name = VecSimType_ToString(params.type);
         if (bad_name == nullptr) {

--- a/src/VecSim/index_factories/tiered_factory.cpp
+++ b/src/VecSim/index_factories/tiered_factory.cpp
@@ -85,6 +85,8 @@ inline size_t EstimateInitialSize(const TieredIndexParams *params) {
         est += sizeof(TieredHNSWIndex<float16, float>);
     } else if (hnsw_params.type == VecSimType_INT8) {
         est += sizeof(TieredHNSWIndex<int8_t, float>);
+    } else if (hnsw_params.type == VecSimType_UINT8) {
+        est += sizeof(TieredHNSWIndex<uint8_t, float>);
     } else {
         throw std::invalid_argument("Invalid hnsw_params.type");
     }
@@ -105,6 +107,8 @@ VecSimIndex *NewIndex(const TieredIndexParams *params) {
         return TieredHNSWFactory::NewIndex<float16, float>(params);
     } else if (type == VecSimType_INT8) {
         return TieredHNSWFactory::NewIndex<int8_t, float>(params);
+    } else if (type == VecSimType_UINT8) {
+        return TieredHNSWFactory::NewIndex<uint8_t, float>(params);
     }
     return nullptr; // Invalid type.
 }

--- a/src/VecSim/spaces/IP/IP.cpp
+++ b/src/VecSim/spaces/IP/IP.cpp
@@ -90,3 +90,28 @@ float INT8_Cosine(const void *pVect1v, const void *pVect2v, size_t dimension) {
         *reinterpret_cast<const float *>(static_cast<const int8_t *>(pVect2v) + dimension);
     return 1.0f - float(INT8_InnerProductImp(pVect1v, pVect2v, dimension)) / (norm_v1 * norm_v2);
 }
+
+static inline int UINT8_InnerProductImp(const void *pVect1v, const void *pVect2v,
+                                        size_t dimension) {
+    uint8_t *pVect1 = (uint8_t *)pVect1v;
+    uint8_t *pVect2 = (uint8_t *)pVect2v;
+
+    int res = 0; // signed int is used to avoid overflow and unsigned arithmetic
+    for (size_t i = 0; i < dimension; i++) {
+        res += pVect1[i] * pVect2[i];
+    }
+    return res;
+}
+
+float UINT8_InnerProduct(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    return 1 - UINT8_InnerProductImp(pVect1v, pVect2v, dimension);
+}
+
+float UINT8_Cosine(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    // We expect the vectors' norm to be stored at the end of the vector.
+    float norm_v1 =
+        *reinterpret_cast<const float *>(static_cast<const uint8_t *>(pVect1v) + dimension);
+    float norm_v2 =
+        *reinterpret_cast<const float *>(static_cast<const uint8_t *>(pVect2v) + dimension);
+    return 1.0f - float(UINT8_InnerProductImp(pVect1v, pVect2v, dimension)) / (norm_v1 * norm_v2);
+}

--- a/src/VecSim/spaces/IP/IP.cpp
+++ b/src/VecSim/spaces/IP/IP.cpp
@@ -67,11 +67,18 @@ float FP16_InnerProduct(const void *pVect1, const void *pVect2, size_t dimension
     return 1.0f - res;
 }
 
-static inline int INT8_InnerProductImp(const void *pVect1v, const void *pVect2v, size_t dimension) {
-    int8_t *pVect1 = (int8_t *)pVect1v;
-    int8_t *pVect2 = (int8_t *)pVect2v;
+// Return type for the inner product functions.
+// The type should be able to hold `dimension * MAX_VAL(int_elem_t) * MAX_VAL(int_elem_t)`.
+// To support dimension up to 2^16, we need the difference between the type and int_elem_t to be at
+// least 2 bytes. We assert that in the implementation.
+template <typename int_elem_t>
+using ret_t = std::conditional_t<sizeof(int_elem_t) == 1, int, long long>;
 
-    int res = 0;
+template <typename int_elem_t>
+static inline ret_t<int_elem_t>
+INTEGER_InnerProductImp(const int_elem_t *pVect1, const int_elem_t *pVect2, size_t dimension) {
+    static_assert(sizeof(ret_t<int_elem_t>) - sizeof(int_elem_t) * 2 >= sizeof(uint16_t));
+    ret_t<int_elem_t> res = 0;
     for (size_t i = 0; i < dimension; i++) {
         res += pVect1[i] * pVect2[i];
     }
@@ -79,39 +86,31 @@ static inline int INT8_InnerProductImp(const void *pVect1v, const void *pVect2v,
 }
 
 float INT8_InnerProduct(const void *pVect1v, const void *pVect2v, size_t dimension) {
-    return 1 - INT8_InnerProductImp(pVect1v, pVect2v, dimension);
+    const auto *pVect1 = static_cast<const int8_t *>(pVect1v);
+    const auto *pVect2 = static_cast<const int8_t *>(pVect2v);
+    return 1 - INTEGER_InnerProductImp(pVect1, pVect2, dimension);
 }
 
 float INT8_Cosine(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    const auto *pVect1 = static_cast<const int8_t *>(pVect1v);
+    const auto *pVect2 = static_cast<const int8_t *>(pVect2v);
     // We expect the vectors' norm to be stored at the end of the vector.
-    float norm_v1 =
-        *reinterpret_cast<const float *>(static_cast<const int8_t *>(pVect1v) + dimension);
-    float norm_v2 =
-        *reinterpret_cast<const float *>(static_cast<const int8_t *>(pVect2v) + dimension);
-    return 1.0f - float(INT8_InnerProductImp(pVect1v, pVect2v, dimension)) / (norm_v1 * norm_v2);
-}
-
-static inline int UINT8_InnerProductImp(const void *pVect1v, const void *pVect2v,
-                                        size_t dimension) {
-    uint8_t *pVect1 = (uint8_t *)pVect1v;
-    uint8_t *pVect2 = (uint8_t *)pVect2v;
-
-    int res = 0; // signed int is used to avoid overflow and unsigned arithmetic
-    for (size_t i = 0; i < dimension; i++) {
-        res += pVect1[i] * pVect2[i];
-    }
-    return res;
+    float norm_v1 = *reinterpret_cast<const float *>(pVect1 + dimension);
+    float norm_v2 = *reinterpret_cast<const float *>(pVect2 + dimension);
+    return 1.0f - float(INTEGER_InnerProductImp(pVect1, pVect2, dimension)) / (norm_v1 * norm_v2);
 }
 
 float UINT8_InnerProduct(const void *pVect1v, const void *pVect2v, size_t dimension) {
-    return 1 - UINT8_InnerProductImp(pVect1v, pVect2v, dimension);
+    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);
+    const auto *pVect2 = static_cast<const uint8_t *>(pVect2v);
+    return 1 - INTEGER_InnerProductImp(pVect1, pVect2, dimension);
 }
 
 float UINT8_Cosine(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);
+    const auto *pVect2 = static_cast<const uint8_t *>(pVect2v);
     // We expect the vectors' norm to be stored at the end of the vector.
-    float norm_v1 =
-        *reinterpret_cast<const float *>(static_cast<const uint8_t *>(pVect1v) + dimension);
-    float norm_v2 =
-        *reinterpret_cast<const float *>(static_cast<const uint8_t *>(pVect2v) + dimension);
-    return 1.0f - float(UINT8_InnerProductImp(pVect1v, pVect2v, dimension)) / (norm_v1 * norm_v2);
+    float norm_v1 = *reinterpret_cast<const float *>(pVect1 + dimension);
+    float norm_v2 = *reinterpret_cast<const float *>(pVect2 + dimension);
+    return 1.0f - float(INTEGER_InnerProductImp(pVect1, pVect2, dimension)) / (norm_v1 * norm_v2);
 }

--- a/src/VecSim/spaces/IP/IP.h
+++ b/src/VecSim/spaces/IP/IP.h
@@ -19,3 +19,6 @@ float BF16_InnerProduct_BigEndian(const void *pVect1v, const void *pVect2v, size
 
 float INT8_InnerProduct(const void *pVect1, const void *pVect2, size_t dimension);
 float INT8_Cosine(const void *pVect1, const void *pVect2, size_t dimension);
+
+float UINT8_InnerProduct(const void *pVect1, const void *pVect2, size_t dimension);
+float UINT8_Cosine(const void *pVect1, const void *pVect2, size_t dimension);

--- a/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_INT8.h
+++ b/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_INT8.h
@@ -22,7 +22,7 @@ static inline void InnerProductStep(int8_t *&pVect1, int8_t *&pVect2, __m512i &s
     sum = _mm512_dpwssd_epi32(sum, va, vb);
 }
 
-template <unsigned char residual> // 0..64
+template <unsigned char residual> // 0..63
 static inline int INT8_InnerProductImp(const void *pVect1v, const void *pVect2v, size_t dimension) {
     int8_t *pVect1 = (int8_t *)pVect1v;
     int8_t *pVect2 = (int8_t *)pVect2v;
@@ -59,13 +59,13 @@ static inline int INT8_InnerProductImp(const void *pVect1v, const void *pVect2v,
     return _mm512_reduce_add_epi32(sum);
 }
 
-template <unsigned char residual> // 0..64
+template <unsigned char residual> // 0..63
 float INT8_InnerProductSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVect2v,
                                                  size_t dimension) {
 
     return 1 - INT8_InnerProductImp<residual>(pVect1v, pVect2v, dimension);
 }
-template <unsigned char residual> // 0..64
+template <unsigned char residual> // 0..63
 float INT8_CosineSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVect2v,
                                            size_t dimension) {
     float ip = INT8_InnerProductImp<residual>(pVect1v, pVect2v, dimension);

--- a/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
+++ b/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
@@ -7,68 +7,79 @@
 #include "VecSim/spaces/space_includes.h"
 
 static inline void InnerProductStep(uint8_t *&pVect1, uint8_t *&pVect2, __m512i &sum) {
-    // __m256i temp_a = _mm256_loadu_epi8(pVect1);
-    // __m512i va = _mm512_cvtepi8_epi16(temp_a);
-    // pVect1 += 32;
+    __m512i va = _mm512_loadu_epi8(pVect1); // AVX512BW
+    pVect1 += 64;
 
-    // __m256i temp_b = _mm256_loadu_epi8(pVect2);
-    // __m512i vb = _mm512_cvtepi8_epi16(temp_b);
-    // pVect2 += 32;
+    __m512i vb = _mm512_loadu_epi8(pVect2); // AVX512BW
+    pVect2 += 64;
 
-    // // _mm512_dpwssd_epi32(src, a, b)
-    // // Multiply groups of 2 adjacent pairs of signed 16-bit integers in `a` with corresponding
-    // // 16-bit integers in `b`, producing 2 intermediate signed 32-bit results. Sum these 2
-    // results
-    // // with the corresponding 32-bit integer in src, and store the packed 32-bit results in dst.
-    // sum = _mm512_dpwssd_epi32(sum, va, vb);
+    __m512i va_hi = _mm512_unpackhi_epi8(va, _mm512_setzero_si512()); // AVX512BW
+    __m512i vb_hi = _mm512_unpackhi_epi8(vb, _mm512_setzero_si512());
+    sum = _mm512_dpwssd_epi32(sum, va_hi, vb_hi);
+
+    __m512i va_lo = _mm512_unpacklo_epi8(va, _mm512_setzero_si512()); // AVX512BW
+    __m512i vb_lo = _mm512_unpacklo_epi8(vb, _mm512_setzero_si512());
+    sum = _mm512_dpwssd_epi32(sum, va_lo, vb_lo);
+
+    // _mm512_dpwssd_epi32(src, a, b)
+    // Multiply groups of 2 adjacent pairs of signed 16-bit integers in `a` with corresponding
+    // 16-bit integers in `b`, producing 2 intermediate signed 32-bit results. Sum these 2 results
+    // with the corresponding 32-bit integer in src, and store the packed 32-bit results in dst.
 }
 
-template <unsigned char residual> // 0..64
+template <unsigned char residual> // 0..63
 static inline int UINT8_InnerProductImp(const void *pVect1v, const void *pVect2v,
                                         size_t dimension) {
-    // uint8_t *pVect1 = (uint8_t *)pVect1v;
-    // uint8_t *pVect2 = (uint8_t *)pVect2v;
+    uint8_t *pVect1 = (uint8_t *)pVect1v;
+    uint8_t *pVect2 = (uint8_t *)pVect2v;
 
-    // const uint8_t *pEnd1 = pVect1 + dimension;
+    const uint8_t *pEnd1 = pVect1 + dimension;
 
-    // __m512i sum = _mm512_setzero_epi32();
+    __m512i sum = _mm512_setzero_epi32();
 
-    // // Deal with remainder first. `dim` is more than 32, so we have at least one 32-int_8 block,
-    // // so mask loading is guaranteed to be safe
-    // if constexpr (residual % 32) {
-    //     constexpr __mmask32 mask = (1LU << (residual % 32)) - 1;
-    //     __m256i temp_a = _mm256_maskz_loadu_epi8(mask, pVect1);
-    //     __m512i va = _mm512_cvtepi8_epi16(temp_a);
-    //     pVect1 += residual % 32;
+    // Deal with remainder first. `dim` is more than 32, so we have at least one 32-int_8 block,
+    // so mask loading is guaranteed to be safe
+    // TODO: unify the two steps for dim>64 with a single mask loading?
+    if constexpr (residual % 32) {
+        constexpr __mmask32 mask = (1LU << (residual % 32)) - 1;
+        __m256i temp_a = _mm256_maskz_loadu_epi8(mask, pVect1);
+        __m512i va = _mm512_cvtepu8_epi16(temp_a);
+        pVect1 += residual % 32;
 
-    //     __m256i temp_b = _mm256_maskz_loadu_epi8(mask, pVect2);
-    //     __m512i vb = _mm512_cvtepi8_epi16(temp_b);
-    //     pVect2 += residual % 32;
+        __m256i temp_b = _mm256_maskz_loadu_epi8(mask, pVect2);
+        __m512i vb = _mm512_cvtepu8_epi16(temp_b);
+        pVect2 += residual % 32;
 
-    //     sum = _mm512_dpwssd_epi32(sum, va, vb);
-    // }
+        sum = _mm512_dpwssd_epi32(sum, va, vb);
+    }
 
-    // if constexpr (residual >= 32) {
-    //     InnerProductStep(pVect1, pVect2, sum);
-    // }
+    if constexpr (residual >= 32) {
+        __m256i temp_a = _mm256_loadu_epi8(pVect1);
+        __m512i va = _mm512_cvtepu8_epi16(temp_a);
+        pVect1 += 32;
 
-    // // We dealt with the residual part. We are left with some multiple of 64-int_8.
-    // while (pVect1 < pEnd1) {
-    //     InnerProductStep(pVect1, pVect2, sum);
-    //     InnerProductStep(pVect1, pVect2, sum);
-    // }
+        __m256i temp_b = _mm256_loadu_epi8(pVect2);
+        __m512i vb = _mm512_cvtepu8_epi16(temp_b);
+        pVect2 += 32;
 
-    // return _mm512_reduce_add_epi32(sum);
-    return 0;
+        sum = _mm512_dpwssd_epi32(sum, va, vb);
+    }
+
+    // We dealt with the residual part. We are left with some multiple of 64-int_8.
+    while (pVect1 < pEnd1) {
+        InnerProductStep(pVect1, pVect2, sum);
+    }
+
+    return _mm512_reduce_add_epi32(sum);
 }
 
-template <unsigned char residual> // 0..64
+template <unsigned char residual> // 0..63
 float UINT8_InnerProductSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVect2v,
                                                   size_t dimension) {
 
     return 1 - UINT8_InnerProductImp<residual>(pVect1v, pVect2v, dimension);
 }
-template <unsigned char residual> // 0..64
+template <unsigned char residual> // 0..63
 float UINT8_CosineSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVect2v,
                                             size_t dimension) {
     float ip = UINT8_InnerProductImp<residual>(pVect1v, pVect2v, dimension);

--- a/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
+++ b/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
@@ -39,7 +39,6 @@ static inline int UINT8_InnerProductImp(const void *pVect1v, const void *pVect2v
 
     // Deal with remainder first. `dim` is more than 32, so we have at least one 32-int_8 block,
     // so mask loading is guaranteed to be safe
-    // TODO: unify the two steps for dim>64 with a single mask loading?
     if constexpr (residual % 32) {
         constexpr __mmask32 mask = (1LU << (residual % 32)) - 1;
         __m256i temp_a = _mm256_maskz_loadu_epi8(mask, pVect1);
@@ -53,6 +52,7 @@ static inline int UINT8_InnerProductImp(const void *pVect1v, const void *pVect2v
         sum = _mm512_dpwssd_epi32(sum, va, vb);
     }
 
+    // TODO: unify this and the above steps for dim>64 with a single mask loading?
     if constexpr (residual >= 32) {
         __m256i temp_a = _mm256_loadu_epi8(pVect1);
         __m512i va = _mm512_cvtepu8_epi16(temp_a);

--- a/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
+++ b/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
@@ -1,0 +1,80 @@
+/*
+ *Copyright Redis Ltd. 2021 - present
+ *Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ *the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "VecSim/spaces/space_includes.h"
+
+static inline void InnerProductStep(uint8_t *&pVect1, uint8_t *&pVect2, __m512i &sum) {
+    // __m256i temp_a = _mm256_loadu_epi8(pVect1);
+    // __m512i va = _mm512_cvtepi8_epi16(temp_a);
+    // pVect1 += 32;
+
+    // __m256i temp_b = _mm256_loadu_epi8(pVect2);
+    // __m512i vb = _mm512_cvtepi8_epi16(temp_b);
+    // pVect2 += 32;
+
+    // // _mm512_dpwssd_epi32(src, a, b)
+    // // Multiply groups of 2 adjacent pairs of signed 16-bit integers in `a` with corresponding
+    // // 16-bit integers in `b`, producing 2 intermediate signed 32-bit results. Sum these 2
+    // results
+    // // with the corresponding 32-bit integer in src, and store the packed 32-bit results in dst.
+    // sum = _mm512_dpwssd_epi32(sum, va, vb);
+}
+
+template <unsigned char residual> // 0..64
+static inline int UINT8_InnerProductImp(const void *pVect1v, const void *pVect2v,
+                                        size_t dimension) {
+    // uint8_t *pVect1 = (uint8_t *)pVect1v;
+    // uint8_t *pVect2 = (uint8_t *)pVect2v;
+
+    // const uint8_t *pEnd1 = pVect1 + dimension;
+
+    // __m512i sum = _mm512_setzero_epi32();
+
+    // // Deal with remainder first. `dim` is more than 32, so we have at least one 32-int_8 block,
+    // // so mask loading is guaranteed to be safe
+    // if constexpr (residual % 32) {
+    //     constexpr __mmask32 mask = (1LU << (residual % 32)) - 1;
+    //     __m256i temp_a = _mm256_maskz_loadu_epi8(mask, pVect1);
+    //     __m512i va = _mm512_cvtepi8_epi16(temp_a);
+    //     pVect1 += residual % 32;
+
+    //     __m256i temp_b = _mm256_maskz_loadu_epi8(mask, pVect2);
+    //     __m512i vb = _mm512_cvtepi8_epi16(temp_b);
+    //     pVect2 += residual % 32;
+
+    //     sum = _mm512_dpwssd_epi32(sum, va, vb);
+    // }
+
+    // if constexpr (residual >= 32) {
+    //     InnerProductStep(pVect1, pVect2, sum);
+    // }
+
+    // // We dealt with the residual part. We are left with some multiple of 64-int_8.
+    // while (pVect1 < pEnd1) {
+    //     InnerProductStep(pVect1, pVect2, sum);
+    //     InnerProductStep(pVect1, pVect2, sum);
+    // }
+
+    // return _mm512_reduce_add_epi32(sum);
+    return 0;
+}
+
+template <unsigned char residual> // 0..64
+float UINT8_InnerProductSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVect2v,
+                                                  size_t dimension) {
+
+    return 1 - UINT8_InnerProductImp<residual>(pVect1v, pVect2v, dimension);
+}
+template <unsigned char residual> // 0..64
+float UINT8_CosineSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVect2v,
+                                            size_t dimension) {
+    float ip = UINT8_InnerProductImp<residual>(pVect1v, pVect2v, dimension);
+    float norm_v1 =
+        *reinterpret_cast<const float *>(static_cast<const uint8_t *>(pVect1v) + dimension);
+    float norm_v2 =
+        *reinterpret_cast<const float *>(static_cast<const uint8_t *>(pVect2v) + dimension);
+    return 1.0f - ip / (norm_v1 * norm_v2);
+}

--- a/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
+++ b/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
@@ -13,13 +13,13 @@ static inline void InnerProductStep(uint8_t *&pVect1, uint8_t *&pVect2, __m512i 
     __m512i vb = _mm512_loadu_epi8(pVect2); // AVX512BW
     pVect2 += 64;
 
-    __m512i va_hi = _mm512_unpackhi_epi8(va, _mm512_setzero_si512()); // AVX512BW
-    __m512i vb_hi = _mm512_unpackhi_epi8(vb, _mm512_setzero_si512());
-    sum = _mm512_dpwssd_epi32(sum, va_hi, vb_hi);
-
     __m512i va_lo = _mm512_unpacklo_epi8(va, _mm512_setzero_si512()); // AVX512BW
     __m512i vb_lo = _mm512_unpacklo_epi8(vb, _mm512_setzero_si512());
     sum = _mm512_dpwssd_epi32(sum, va_lo, vb_lo);
+
+    __m512i va_hi = _mm512_unpackhi_epi8(va, _mm512_setzero_si512()); // AVX512BW
+    __m512i vb_hi = _mm512_unpackhi_epi8(vb, _mm512_setzero_si512());
+    sum = _mm512_dpwssd_epi32(sum, va_hi, vb_hi);
 
     // _mm512_dpwssd_epi32(src, a, b)
     // Multiply groups of 2 adjacent pairs of signed 16-bit integers in `a` with corresponding

--- a/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
+++ b/src/VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h
@@ -37,7 +37,7 @@ static inline int UINT8_InnerProductImp(const void *pVect1v, const void *pVect2v
 
     __m512i sum = _mm512_setzero_epi32();
 
-    // Deal with remainder first. `dim` is more than 32, so we have at least one 32-int_8 block,
+    // Deal with remainder first. `dim` is more than 32, so we have at least one 32-uint_8 block,
     // so mask loading is guaranteed to be safe
     if constexpr (residual % 32) {
         constexpr __mmask32 mask = (1LU << (residual % 32)) - 1;

--- a/src/VecSim/spaces/IP_space.cpp
+++ b/src/VecSim/spaces/IP_space.cpp
@@ -262,7 +262,7 @@ dist_func_t<float> IP_UINT8_GetDistFunc(size_t dim, unsigned char *alignment,
 
     dist_func_t<float> ret_dist_func = UINT8_InnerProduct;
     // Optimizations assume at least 32 uint8. If we have less, we use the naive implementation.
-    if (dim < 32) { // TODO: revalidate the optimization threshold
+    if (dim < 32) {
         return ret_dist_func;
     }
 #ifdef CPU_FEATURES_ARCH_X86_64
@@ -289,7 +289,7 @@ dist_func_t<float> Cosine_UINT8_GetDistFunc(size_t dim, unsigned char *alignment
 
     dist_func_t<float> ret_dist_func = UINT8_Cosine;
     // Optimizations assume at least 32 uint8. If we have less, we use the naive implementation.
-    if (dim < 32) { // TODO: revalidate the optimization threshold
+    if (dim < 32) {
         return ret_dist_func;
     }
 #ifdef CPU_FEATURES_ARCH_X86_64

--- a/src/VecSim/spaces/IP_space.cpp
+++ b/src/VecSim/spaces/IP_space.cpp
@@ -252,4 +252,61 @@ dist_func_t<float> Cosine_INT8_GetDistFunc(size_t dim, unsigned char *alignment,
 #endif // __x86_64__
     return ret_dist_func;
 }
+
+dist_func_t<float> IP_UINT8_GetDistFunc(size_t dim, unsigned char *alignment, const void *arch_opt) {
+    unsigned char dummy_alignment;
+    if (alignment == nullptr) {
+        alignment = &dummy_alignment;
+    }
+
+    dist_func_t<float> ret_dist_func = UINT8_InnerProduct;
+    // Optimizations assume at least 32 uint8. If we have less, we use the naive implementation.
+    if (dim < 32) { // TODO: revalidate the optimization threshold
+        return ret_dist_func;
+    }
+#ifdef CPU_FEATURES_ARCH_X86_64
+    auto features = (arch_opt == nullptr)
+                        ? cpu_features::GetX86Info().features
+                        : *static_cast<const cpu_features::X86Features *>(arch_opt);
+#ifdef OPT_AVX512_F_BW_VL_VNNI
+    if (features.avx512f && features.avx512bw && features.avx512vl && features.avx512vnni) {
+        if (dim % 32 == 0) // no point in aligning if we have an offsetting residual
+            *alignment = 32 * sizeof(uint8_t); // align to 256 bits.
+        return Choose_UINT8_IP_implementation_AVX512F_BW_VL_VNNI(dim);
+    }
+#endif
+#endif // __x86_64__
+    return ret_dist_func;
+}
+
+dist_func_t<float> Cosine_UINT8_GetDistFunc(size_t dim, unsigned char *alignment,
+                                           const void *arch_opt) {
+    unsigned char dummy_alignment;
+    if (alignment == nullptr) {
+        alignment = &dummy_alignment;
+    }
+
+    dist_func_t<float> ret_dist_func = UINT8_Cosine;
+    // Optimizations assume at least 32 uint8. If we have less, we use the naive implementation.
+    if (dim < 32) { // TODO: revalidate the optimization threshold
+        return ret_dist_func;
+    }
+#ifdef CPU_FEATURES_ARCH_X86_64
+    auto features = (arch_opt == nullptr)
+                        ? cpu_features::GetX86Info().features
+                        : *static_cast<const cpu_features::X86Features *>(arch_opt);
+#ifdef OPT_AVX512_F_BW_VL_VNNI
+    if (features.avx512f && features.avx512bw && features.avx512vl && features.avx512vnni) {
+        // For uint8 vectors with cosine distance, the extra float for the norm shifts alignment to
+        // `(dim + sizeof(float)) % 32`.
+        // Vectors satisfying this have a residual, causing offset loads during calculation.
+        // To avoid complexity, we skip alignment here, assuming the performance impact is
+        // negligible.
+        return Choose_UINT8_Cosine_implementation_AVX512F_BW_VL_VNNI(dim);
+    }
+#endif
+#endif // __x86_64__
+    return ret_dist_func;
+}
+
 } // namespace spaces

--- a/src/VecSim/spaces/IP_space.cpp
+++ b/src/VecSim/spaces/IP_space.cpp
@@ -253,7 +253,8 @@ dist_func_t<float> Cosine_INT8_GetDistFunc(size_t dim, unsigned char *alignment,
     return ret_dist_func;
 }
 
-dist_func_t<float> IP_UINT8_GetDistFunc(size_t dim, unsigned char *alignment, const void *arch_opt) {
+dist_func_t<float> IP_UINT8_GetDistFunc(size_t dim, unsigned char *alignment,
+                                        const void *arch_opt) {
     unsigned char dummy_alignment;
     if (alignment == nullptr) {
         alignment = &dummy_alignment;
@@ -280,7 +281,7 @@ dist_func_t<float> IP_UINT8_GetDistFunc(size_t dim, unsigned char *alignment, co
 }
 
 dist_func_t<float> Cosine_UINT8_GetDistFunc(size_t dim, unsigned char *alignment,
-                                           const void *arch_opt) {
+                                            const void *arch_opt) {
     unsigned char dummy_alignment;
     if (alignment == nullptr) {
         alignment = &dummy_alignment;

--- a/src/VecSim/spaces/IP_space.h
+++ b/src/VecSim/spaces/IP_space.h
@@ -20,4 +20,8 @@ dist_func_t<float> IP_INT8_GetDistFunc(size_t dim, unsigned char *alignment = nu
                                        const void *arch_opt = nullptr);
 dist_func_t<float> Cosine_INT8_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
                                            const void *arch_opt = nullptr);
+dist_func_t<float> IP_UINT8_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
+                                        const void *arch_opt = nullptr);
+dist_func_t<float> Cosine_UINT8_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
+                                            const void *arch_opt = nullptr);
 } // namespace spaces

--- a/src/VecSim/spaces/L2/L2.cpp
+++ b/src/VecSim/spaces/L2/L2.cpp
@@ -84,3 +84,17 @@ float INT8_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension) {
     }
     return float(res);
 }
+
+float UINT8_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    uint8_t *pVect1 = (uint8_t *)pVect1v;
+    uint8_t *pVect2 = (uint8_t *)pVect2v;
+
+    int res = 0;
+    for (size_t i = 0; i < dimension; i++) {
+        int16_t a = pVect1[i];
+        int16_t b = pVect2[i];
+        int16_t diff = a - b;
+        res += diff * diff;
+    }
+    return float(res);
+}

--- a/src/VecSim/spaces/L2/L2.cpp
+++ b/src/VecSim/spaces/L2/L2.cpp
@@ -71,30 +71,43 @@ float FP16_L2Sqr(const void *pVect1, const void *pVect2, size_t dimension) {
     return res;
 }
 
-float INT8_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension) {
-    int8_t *pVect1 = (int8_t *)pVect1v;
-    int8_t *pVect2 = (int8_t *)pVect2v;
+// Return type for the L2 functions.
+// The type should be able to hold `dimension * MAX_VAL(int_elem_t) * MAX_VAL(int_elem_t)`.
+// To support dimension up to 2^16, we need the difference between the type and int_elem_t to be at
+// least 2 bytes. We assert that in the implementation.
+template <typename int_elem_t>
+using ret_t = std::conditional_t<sizeof(int_elem_t) == 1, int, long long>;
 
-    int res = 0;
+// Difference type for the L2 functions.
+// The type should be able to hold `MIN_VAL(int_elem_t)-MAX_VAL(int_elem_t)`, and should be signed
+// to avoid unsigned arithmetic. This means that the difference type should be bigger than the
+// size of the element type. We assert that in the implementation.
+template <typename int_elem_t>
+using diff_t = std::conditional_t<sizeof(int_elem_t) == 1, int16_t, int>;
+
+template <typename int_elem_t>
+static inline ret_t<int_elem_t> INTEGER_L2Sqr(const int_elem_t *pVect1, const int_elem_t *pVect2,
+                                              size_t dimension) {
+    static_assert(sizeof(ret_t<int_elem_t>) - sizeof(int_elem_t) * 2 >= sizeof(uint16_t));
+    static_assert(std::is_signed_v<diff_t<int_elem_t>>);
+    static_assert(sizeof(diff_t<int_elem_t>) >= 2 * sizeof(int_elem_t));
+
+    ret_t<int_elem_t> res = 0;
     for (size_t i = 0; i < dimension; i++) {
-        int16_t a = pVect1[i];
-        int16_t b = pVect2[i];
-        int16_t diff = a - b;
+        diff_t<int_elem_t> diff = pVect1[i] - pVect2[i];
         res += diff * diff;
     }
-    return float(res);
+    return res;
+}
+
+float INT8_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    const auto *pVect1 = static_cast<const int8_t *>(pVect1v);
+    const auto *pVect2 = static_cast<const int8_t *>(pVect2v);
+    return float(INTEGER_L2Sqr(pVect1, pVect2, dimension));
 }
 
 float UINT8_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension) {
-    uint8_t *pVect1 = (uint8_t *)pVect1v;
-    uint8_t *pVect2 = (uint8_t *)pVect2v;
-
-    int res = 0;
-    for (size_t i = 0; i < dimension; i++) {
-        int16_t a = pVect1[i];
-        int16_t b = pVect2[i];
-        int16_t diff = a - b;
-        res += diff * diff;
-    }
-    return float(res);
+    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);
+    const auto *pVect2 = static_cast<const uint8_t *>(pVect2v);
+    return float(INTEGER_L2Sqr(pVect1, pVect2, dimension));
 }

--- a/src/VecSim/spaces/L2/L2.h
+++ b/src/VecSim/spaces/L2/L2.h
@@ -18,3 +18,5 @@ float BF16_L2Sqr_BigEndian(const void *pVect1v, const void *pVect2v, size_t dime
 float FP16_L2Sqr(const void *pVect1, const void *pVect2, size_t dimension);
 
 float INT8_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension);
+
+float UINT8_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension);

--- a/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_INT8.h
+++ b/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_INT8.h
@@ -23,7 +23,7 @@ static inline void L2SqrStep(int8_t *&pVect1, int8_t *&pVect2, __m512i &sum) {
     sum = _mm512_dpwssd_epi32(sum, diff, diff);
 }
 
-template <unsigned char residual> // 0..64
+template <unsigned char residual> // 0..63
 float INT8_L2SqrSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVect2v,
                                           size_t dimension) {
     int8_t *pVect1 = (int8_t *)pVect1v;

--- a/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_UINT8.h
+++ b/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_UINT8.h
@@ -39,39 +39,55 @@ float UINT8_L2SqrSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVec
 
     __m512i sum = _mm512_setzero_epi32();
 
-    // Deal with remainder first. `dim` is more than 32, so we have at least one 32-int_8 block,
-    // so mask loading is guaranteed to be safe
-    if constexpr (residual % 32) {
-        constexpr __mmask32 mask = (1LU << (residual % 32)) - 1;
-        __m256i temp_a = _mm256_loadu_epi8(pVect1);
-        __m512i va = _mm512_cvtepu8_epi16(temp_a);
-        pVect1 += residual % 32;
+    // Deal with remainder first.
+    if constexpr (residual) {
+        if constexpr (residual < 32) {
+            constexpr __mmask32 mask = (1LU << residual) - 1;
+            __m256i temp_a = _mm256_maskz_loadu_epi8(mask, pVect1);
+            __m512i va = _mm512_cvtepu8_epi16(temp_a);
 
-        __m256i temp_b = _mm256_loadu_epi8(pVect2);
-        __m512i vb = _mm512_cvtepu8_epi16(temp_b);
-        pVect2 += residual % 32;
+            __m256i temp_b = _mm256_maskz_loadu_epi8(mask, pVect2);
+            __m512i vb = _mm512_cvtepu8_epi16(temp_b);
 
-        __m512i diff = _mm512_maskz_sub_epi16(mask, va, vb);
-        sum = _mm512_dpwssd_epi32(sum, diff, diff);
-    }
+            __m512i diff = _mm512_sub_epi16(va, vb);
+            sum = _mm512_dpwssd_epi32(sum, diff, diff);
+        } else if constexpr (residual == 32) {
+            __m256i temp_a = _mm256_loadu_epi8(pVect1);
+            __m512i va = _mm512_cvtepu8_epi16(temp_a);
 
-    // TODO: unify this and the above steps for dim>64 with a single mask loading?
-    if constexpr (residual >= 32) {
-        __m256i temp_a = _mm256_loadu_epi8(pVect1);
-        __m512i va = _mm512_cvtepu8_epi16(temp_a);
-        pVect1 += 32;
+            __m256i temp_b = _mm256_loadu_epi8(pVect2);
+            __m512i vb = _mm512_cvtepu8_epi16(temp_b);
 
-        __m256i temp_b = _mm256_loadu_epi8(pVect2);
-        __m512i vb = _mm512_cvtepu8_epi16(temp_b);
-        pVect2 += 32;
+            __m512i diff = _mm512_sub_epi16(va, vb);
+            sum = _mm512_dpwssd_epi32(sum, diff, diff);
+        } else {
+            constexpr __mmask64 mask = (1LU << residual) - 1;
+            __m512i va = _mm512_maskz_loadu_epi8(mask, pVect1); // AVX512BW
+            __m512i vb = _mm512_maskz_loadu_epi8(mask, pVect2); // AVX512BW
 
-        __m512i diff = _mm512_sub_epi16(va, vb);
-        sum = _mm512_dpwssd_epi32(sum, diff, diff);
-    }
+            __m512i va_lo = _mm512_unpacklo_epi8(va, _mm512_setzero_si512()); // AVX512BW
+            __m512i vb_lo = _mm512_unpacklo_epi8(vb, _mm512_setzero_si512());
+            __m512i diff_lo = _mm512_sub_epi16(va_lo, vb_lo);
+            sum = _mm512_dpwssd_epi32(sum, diff_lo, diff_lo);
 
-    // We dealt with the residual part. We are left with some multiple of 64-int_8.
-    while (pVect1 < pEnd1) {
-        L2SqrStep(pVect1, pVect2, sum);
+            __m512i va_hi = _mm512_unpackhi_epi8(va, _mm512_setzero_si512()); // AVX512BW
+            __m512i vb_hi = _mm512_unpackhi_epi8(vb, _mm512_setzero_si512());
+            __m512i diff_hi = _mm512_sub_epi16(va_hi, vb_hi);
+            sum = _mm512_dpwssd_epi32(sum, diff_hi, diff_hi);
+        }
+        pVect1 += residual;
+        pVect2 += residual;
+
+        // We dealt with the residual part.
+        // We are left with some multiple of 64-uint_8 (might be 0).
+        while (pVect1 < pEnd1) {
+            L2SqrStep(pVect1, pVect2, sum);
+        }
+    } else {
+        // We have no residual, we have some non-zero multiple of 64-uint_8.
+        do {
+            L2SqrStep(pVect1, pVect2, sum);
+        } while (pVect1 < pEnd1);
     }
 
     return _mm512_reduce_add_epi32(sum);

--- a/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_UINT8.h
+++ b/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_UINT8.h
@@ -1,0 +1,65 @@
+/*
+ *Copyright Redis Ltd. 2021 - present
+ *Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ *the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "VecSim/spaces/space_includes.h"
+
+static inline void L2SqrStep(uint8_t *&pVect1, uint8_t *&pVect2, __m512i &sum) {
+    // __m256i temp_a = _mm256_loadu_epi8(pVect1);
+    // __m512i va = _mm512_cvtepi8_epi16(temp_a);
+    // pVect1 += 32;
+
+    // __m256i temp_b = _mm256_loadu_epi8(pVect2);
+    // __m512i vb = _mm512_cvtepi8_epi16(temp_b);
+    // pVect2 += 32;
+
+    // __m512i diff = _mm512_sub_epi16(va, vb);
+    // // _mm512_dpwssd_epi32(src, a, b)
+    // // Multiply groups of 2 adjacent pairs of signed 16-bit integers in `a` with corresponding
+    // // 16-bit integers in `b`, producing 2 intermediate signed 32-bit results. Sum these 2
+    // results
+    // // with the corresponding 32-bit integer in src, and store the packed 32-bit results in dst.
+    // sum = _mm512_dpwssd_epi32(sum, diff, diff);
+}
+
+template <unsigned char residual> // 0..64
+float UINT8_L2SqrSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVect2v,
+                                           size_t dimension) {
+    // uint8_t *pVect1 = (uint8_t *)pVect1v;
+    // uint8_t *pVect2 = (uint8_t *)pVect2v;
+
+    // const uint8_t *pEnd1 = pVect1 + dimension;
+
+    // __m512i sum = _mm512_setzero_epi32();
+
+    // // Deal with remainder first. `dim` is more than 32, so we have at least one 32-int_8 block,
+    // // so mask loading is guaranteed to be safe
+    // if constexpr (residual % 32) {
+    //     constexpr __mmask32 mask = (1LU << (residual % 32)) - 1;
+    //     __m256i temp_a = _mm256_loadu_epi8(pVect1);
+    //     __m512i va = _mm512_cvtepi8_epi16(temp_a);
+    //     pVect1 += residual % 32;
+
+    //     __m256i temp_b = _mm256_loadu_epi8(pVect2);
+    //     __m512i vb = _mm512_cvtepi8_epi16(temp_b);
+    //     pVect2 += residual % 32;
+
+    //     __m512i diff = _mm512_maskz_sub_epi16(mask, va, vb);
+    //     sum = _mm512_dpwssd_epi32(sum, diff, diff);
+    // }
+
+    // if constexpr (residual >= 32) {
+    //     L2SqrStep(pVect1, pVect2, sum);
+    // }
+
+    // // We dealt with the residual part. We are left with some multiple of 64-int_8.
+    // while (pVect1 < pEnd1) {
+    //     L2SqrStep(pVect1, pVect2, sum);
+    //     L2SqrStep(pVect1, pVect2, sum);
+    // }
+
+    // return _mm512_reduce_add_epi32(sum);
+    return 0;
+}

--- a/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_UINT8.h
+++ b/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_UINT8.h
@@ -13,15 +13,15 @@ static inline void L2SqrStep(uint8_t *&pVect1, uint8_t *&pVect2, __m512i &sum) {
     __m512i vb = _mm512_loadu_epi8(pVect2); // AVX512BW
     pVect2 += 64;
 
-    __m512i va_hi = _mm512_unpackhi_epi8(va, _mm512_setzero_si512()); // AVX512BW
-    __m512i vb_hi = _mm512_unpackhi_epi8(vb, _mm512_setzero_si512());
-    __m512i diff_hi = _mm512_sub_epi16(va_hi, vb_hi);
-    sum = _mm512_dpwssd_epi32(sum, diff_hi, diff_hi);
-
     __m512i va_lo = _mm512_unpacklo_epi8(va, _mm512_setzero_si512()); // AVX512BW
     __m512i vb_lo = _mm512_unpacklo_epi8(vb, _mm512_setzero_si512());
     __m512i diff_lo = _mm512_sub_epi16(va_lo, vb_lo);
     sum = _mm512_dpwssd_epi32(sum, diff_lo, diff_lo);
+
+    __m512i va_hi = _mm512_unpackhi_epi8(va, _mm512_setzero_si512()); // AVX512BW
+    __m512i vb_hi = _mm512_unpackhi_epi8(vb, _mm512_setzero_si512());
+    __m512i diff_hi = _mm512_sub_epi16(va_hi, vb_hi);
+    sum = _mm512_dpwssd_epi32(sum, diff_hi, diff_hi);
 
     // _mm512_dpwssd_epi32(src, a, b)
     // Multiply groups of 2 adjacent pairs of signed 16-bit integers in `a` with corresponding

--- a/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_UINT8.h
+++ b/src/VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_UINT8.h
@@ -7,59 +7,62 @@
 #include "VecSim/spaces/space_includes.h"
 
 static inline void L2SqrStep(uint8_t *&pVect1, uint8_t *&pVect2, __m512i &sum) {
-    // __m256i temp_a = _mm256_loadu_epi8(pVect1);
-    // __m512i va = _mm512_cvtepi8_epi16(temp_a);
-    // pVect1 += 32;
+    __m512i va = _mm512_loadu_epi8(pVect1); // AVX512BW
+    pVect1 += 64;
 
-    // __m256i temp_b = _mm256_loadu_epi8(pVect2);
-    // __m512i vb = _mm512_cvtepi8_epi16(temp_b);
-    // pVect2 += 32;
+    __m512i vb = _mm512_loadu_epi8(pVect2); // AVX512BW
+    pVect2 += 64;
 
-    // __m512i diff = _mm512_sub_epi16(va, vb);
-    // // _mm512_dpwssd_epi32(src, a, b)
-    // // Multiply groups of 2 adjacent pairs of signed 16-bit integers in `a` with corresponding
-    // // 16-bit integers in `b`, producing 2 intermediate signed 32-bit results. Sum these 2
-    // results
-    // // with the corresponding 32-bit integer in src, and store the packed 32-bit results in dst.
-    // sum = _mm512_dpwssd_epi32(sum, diff, diff);
+    __m512i va_hi = _mm512_unpackhi_epi8(va, _mm512_setzero_si512()); // AVX512BW
+    __m512i vb_hi = _mm512_unpackhi_epi8(vb, _mm512_setzero_si512());
+    __m512i diff_hi = _mm512_sub_epi16(va_hi, vb_hi);
+    sum = _mm512_dpwssd_epi32(sum, diff_hi, diff_hi);
+
+    __m512i va_lo = _mm512_unpacklo_epi8(va, _mm512_setzero_si512()); // AVX512BW
+    __m512i vb_lo = _mm512_unpacklo_epi8(vb, _mm512_setzero_si512());
+    __m512i diff_lo = _mm512_sub_epi16(va_lo, vb_lo);
+    sum = _mm512_dpwssd_epi32(sum, diff_lo, diff_lo);
+
+    // _mm512_dpwssd_epi32(src, a, b)
+    // Multiply groups of 2 adjacent pairs of signed 16-bit integers in `a` with corresponding
+    // 16-bit integers in `b`, producing 2 intermediate signed 32-bit results. Sum these 2 results
+    // with the corresponding 32-bit integer in src, and store the packed 32-bit results in dst.
 }
 
 template <unsigned char residual> // 0..64
 float UINT8_L2SqrSIMD64_AVX512F_BW_VL_VNNI(const void *pVect1v, const void *pVect2v,
                                            size_t dimension) {
-    // uint8_t *pVect1 = (uint8_t *)pVect1v;
-    // uint8_t *pVect2 = (uint8_t *)pVect2v;
+    uint8_t *pVect1 = (uint8_t *)pVect1v;
+    uint8_t *pVect2 = (uint8_t *)pVect2v;
 
-    // const uint8_t *pEnd1 = pVect1 + dimension;
+    const uint8_t *pEnd1 = pVect1 + dimension;
 
-    // __m512i sum = _mm512_setzero_epi32();
+    __m512i sum = _mm512_setzero_epi32();
 
-    // // Deal with remainder first. `dim` is more than 32, so we have at least one 32-int_8 block,
-    // // so mask loading is guaranteed to be safe
-    // if constexpr (residual % 32) {
-    //     constexpr __mmask32 mask = (1LU << (residual % 32)) - 1;
-    //     __m256i temp_a = _mm256_loadu_epi8(pVect1);
-    //     __m512i va = _mm512_cvtepi8_epi16(temp_a);
-    //     pVect1 += residual % 32;
+    // Deal with remainder first. `dim` is more than 32, so we have at least one 32-int_8 block,
+    // so mask loading is guaranteed to be safe
+    if constexpr (residual % 32) {
+        constexpr __mmask32 mask = (1LU << (residual % 32)) - 1;
+        __m256i temp_a = _mm256_loadu_epi8(pVect1);
+        __m512i va = _mm512_cvtepi8_epi16(temp_a);
+        pVect1 += residual % 32;
 
-    //     __m256i temp_b = _mm256_loadu_epi8(pVect2);
-    //     __m512i vb = _mm512_cvtepi8_epi16(temp_b);
-    //     pVect2 += residual % 32;
+        __m256i temp_b = _mm256_loadu_epi8(pVect2);
+        __m512i vb = _mm512_cvtepi8_epi16(temp_b);
+        pVect2 += residual % 32;
 
-    //     __m512i diff = _mm512_maskz_sub_epi16(mask, va, vb);
-    //     sum = _mm512_dpwssd_epi32(sum, diff, diff);
-    // }
+        __m512i diff = _mm512_maskz_sub_epi16(mask, va, vb);
+        sum = _mm512_dpwssd_epi32(sum, diff, diff);
+    }
 
-    // if constexpr (residual >= 32) {
-    //     L2SqrStep(pVect1, pVect2, sum);
-    // }
+    if constexpr (residual >= 32) {
+        L2SqrStep(pVect1, pVect2, sum);
+    }
 
-    // // We dealt with the residual part. We are left with some multiple of 64-int_8.
-    // while (pVect1 < pEnd1) {
-    //     L2SqrStep(pVect1, pVect2, sum);
-    //     L2SqrStep(pVect1, pVect2, sum);
-    // }
+    // We dealt with the residual part. We are left with some multiple of 64-int_8.
+    while (pVect1 < pEnd1) {
+        L2SqrStep(pVect1, pVect2, sum);
+    }
 
-    // return _mm512_reduce_add_epi32(sum);
-    return 0;
+    return _mm512_reduce_add_epi32(sum);
 }

--- a/src/VecSim/spaces/L2_space.cpp
+++ b/src/VecSim/spaces/L2_space.cpp
@@ -216,4 +216,30 @@ dist_func_t<float> L2_INT8_GetDistFunc(size_t dim, unsigned char *alignment, con
     return ret_dist_func;
 }
 
+dist_func_t<float> L2_UINT8_GetDistFunc(size_t dim, unsigned char *alignment, const void *arch_opt) {
+    unsigned char dummy_alignment;
+    if (alignment == nullptr) {
+        alignment = &dummy_alignment;
+    }
+
+    dist_func_t<float> ret_dist_func = UINT8_L2Sqr;
+    // Optimizations assume at least 32 uint8. If we have less, we use the naive implementation.
+    if (dim < 32) { // TODO: revalidate the optimization threshold
+        return ret_dist_func;
+    }
+#ifdef CPU_FEATURES_ARCH_X86_64
+    auto features = (arch_opt == nullptr)
+                        ? cpu_features::GetX86Info().features
+                        : *static_cast<const cpu_features::X86Features *>(arch_opt);
+#ifdef OPT_AVX512_F_BW_VL_VNNI
+    if (features.avx512f && features.avx512bw && features.avx512vl && features.avx512vnni) {
+        if (dim % 32 == 0) // no point in aligning if we have an offsetting residual
+            *alignment = 32 * sizeof(int8_t); // align to 256 bits.
+        return Choose_UINT8_L2_implementation_AVX512F_BW_VL_VNNI(dim);
+    }
+#endif
+#endif // __x86_64__
+    return ret_dist_func;
+}
+
 } // namespace spaces

--- a/src/VecSim/spaces/L2_space.cpp
+++ b/src/VecSim/spaces/L2_space.cpp
@@ -225,7 +225,7 @@ dist_func_t<float> L2_UINT8_GetDistFunc(size_t dim, unsigned char *alignment,
 
     dist_func_t<float> ret_dist_func = UINT8_L2Sqr;
     // Optimizations assume at least 32 uint8. If we have less, we use the naive implementation.
-    if (dim < 32) { // TODO: revalidate the optimization threshold
+    if (dim < 32) {
         return ret_dist_func;
     }
 #ifdef CPU_FEATURES_ARCH_X86_64

--- a/src/VecSim/spaces/L2_space.cpp
+++ b/src/VecSim/spaces/L2_space.cpp
@@ -216,7 +216,8 @@ dist_func_t<float> L2_INT8_GetDistFunc(size_t dim, unsigned char *alignment, con
     return ret_dist_func;
 }
 
-dist_func_t<float> L2_UINT8_GetDistFunc(size_t dim, unsigned char *alignment, const void *arch_opt) {
+dist_func_t<float> L2_UINT8_GetDistFunc(size_t dim, unsigned char *alignment,
+                                        const void *arch_opt) {
     unsigned char dummy_alignment;
     if (alignment == nullptr) {
         alignment = &dummy_alignment;

--- a/src/VecSim/spaces/L2_space.h
+++ b/src/VecSim/spaces/L2_space.h
@@ -18,4 +18,6 @@ dist_func_t<float> L2_FP16_GetDistFunc(size_t dim, unsigned char *alignment = nu
                                        const void *arch_opt = nullptr);
 dist_func_t<float> L2_INT8_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
                                        const void *arch_opt = nullptr);
+dist_func_t<float> L2_UINT8_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
+                                        const void *arch_opt = nullptr);
 } // namespace spaces

--- a/src/VecSim/spaces/functions/AVX512F_BW_VL_VNNI.cpp
+++ b/src/VecSim/spaces/functions/AVX512F_BW_VL_VNNI.cpp
@@ -4,10 +4,13 @@
  *the Server Side Public License v1 (SSPLv1).
  */
 
-#include "AVX512BW_VBMI2.h"
+#include "AVX512F_BW_VL_VNNI.h"
 
 #include "VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_INT8.h"
 #include "VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_INT8.h"
+
+#include "VecSim/spaces/L2/L2_AVX512F_BW_VL_VNNI_UINT8.h"
+#include "VecSim/spaces/IP/IP_AVX512F_BW_VL_VNNI_UINT8.h"
 
 namespace spaces {
 
@@ -28,6 +31,24 @@ dist_func_t<float> Choose_INT8_IP_implementation_AVX512F_BW_VL_VNNI(size_t dim) 
 dist_func_t<float> Choose_INT8_Cosine_implementation_AVX512F_BW_VL_VNNI(size_t dim) {
     dist_func_t<float> ret_dist_func;
     CHOOSE_IMPLEMENTATION(ret_dist_func, dim, 64, INT8_CosineSIMD64_AVX512F_BW_VL_VNNI);
+    return ret_dist_func;
+}
+
+dist_func_t<float> Choose_UINT8_L2_implementation_AVX512F_BW_VL_VNNI(size_t dim) {
+    dist_func_t<float> ret_dist_func;
+    CHOOSE_IMPLEMENTATION(ret_dist_func, dim, 64, UINT8_L2SqrSIMD64_AVX512F_BW_VL_VNNI);
+    return ret_dist_func;
+}
+
+dist_func_t<float> Choose_UINT8_IP_implementation_AVX512F_BW_VL_VNNI(size_t dim) {
+    dist_func_t<float> ret_dist_func;
+    CHOOSE_IMPLEMENTATION(ret_dist_func, dim, 64, UINT8_InnerProductSIMD64_AVX512F_BW_VL_VNNI);
+    return ret_dist_func;
+}
+
+dist_func_t<float> Choose_UINT8_Cosine_implementation_AVX512F_BW_VL_VNNI(size_t dim) {
+    dist_func_t<float> ret_dist_func;
+    CHOOSE_IMPLEMENTATION(ret_dist_func, dim, 64, UINT8_CosineSIMD64_AVX512F_BW_VL_VNNI);
     return ret_dist_func;
 }
 

--- a/src/VecSim/spaces/functions/AVX512F_BW_VL_VNNI.h
+++ b/src/VecSim/spaces/functions/AVX512F_BW_VL_VNNI.h
@@ -14,4 +14,8 @@ dist_func_t<float> Choose_INT8_L2_implementation_AVX512F_BW_VL_VNNI(size_t dim);
 dist_func_t<float> Choose_INT8_IP_implementation_AVX512F_BW_VL_VNNI(size_t dim);
 dist_func_t<float> Choose_INT8_Cosine_implementation_AVX512F_BW_VL_VNNI(size_t dim);
 
+dist_func_t<float> Choose_UINT8_L2_implementation_AVX512F_BW_VL_VNNI(size_t dim);
+dist_func_t<float> Choose_UINT8_IP_implementation_AVX512F_BW_VL_VNNI(size_t dim);
+dist_func_t<float> Choose_UINT8_Cosine_implementation_AVX512F_BW_VL_VNNI(size_t dim);
+
 } // namespace spaces

--- a/src/VecSim/spaces/functions/implementation_chooser.h
+++ b/src/VecSim/spaces/functions/implementation_chooser.h
@@ -21,23 +21,21 @@
         __ret_dist_func = func<(N)>;                                                               \
         break;
 
-// Macro for 4 cases. Used to collapse the switch statement. For a given N, expands to 4 X macros
-// of 4N, 4N+1, 4N+2, 4N+3.
-#define C4(X, func, N) X(4 * N, func) X(4 * N + 1, func) X(4 * N + 2, func) X(4 * N + 3, func)
+// Macros for folding cases of a switch statement, for easier readability.
+// Each macro expands into a sequence of cases, from 0 to N-1, doubling the previous macro.
+#define C2(X, func, N)  X(2 * (N), func) X(2 * (N) + 1, func)
+#define C4(X, func, N)  C2(X, func, 2 * (N)) C2(X, func, 2 * (N) + 1)
+#define C8(X, func, N)  C4(X, func, 2 * (N)) C4(X, func, 2 * (N) + 1)
+#define C16(X, func, N) C8(X, func, 2 * (N)) C8(X, func, 2 * (N) + 1)
+#define C32(X, func, N) C16(X, func, 2 * (N)) C16(X, func, 2 * (N) + 1)
+#define C64(X, func, N) C32(X, func, 2 * (N)) C32(X, func, 2 * (N) + 1)
 
-// Macros for 8, 16, 32 and 64 cases. Used to collapse the switch statement. Expands into 0-63,
-// 0-31, 0-15 or 0-7 cases.
-#define CASES32(X, func)                                                                           \
-    C4(X, func, 0)                                                                                 \
-    C4(X, func, 1)                                                                                 \
-    C4(X, func, 2) C4(X, func, 3) C4(X, func, 4) C4(X, func, 5) C4(X, func, 6) C4(X, func, 7)
-#define CASES16(X, func) C4(X, func, 0) C4(X, func, 1) C4(X, func, 2) C4(X, func, 3)
-#define CASES8(X, func)  C4(X, func, 0) C4(X, func, 1)
-#define CASES64(X, func)                                                                           \
-    CASES32(X, func)                                                                               \
-    C4(X, func, 8)                                                                                 \
-    C4(X, func, 9)                                                                                 \
-    C4(X, func, 10) C4(X, func, 11) C4(X, func, 12) C4(X, func, 13) C4(X, func, 14) C4(X, func, 15)
+// Macros for 8, 16, 32 and 64 cases. Used to collapse the switch statement.
+// Expands into 0-7, 0-15, 0-31 or 0-63 cases respectively.
+#define CASES8(X, func)  C8(X, func, 0)
+#define CASES16(X, func) C16(X, func, 0)
+#define CASES32(X, func) C32(X, func, 0)
+#define CASES64(X, func) C64(X, func, 0)
 
 // Main macro. Expands into a switch statement that chooses the implementation based on the
 // dimension's remainder.

--- a/src/VecSim/spaces/functions/implementation_chooser.h
+++ b/src/VecSim/spaces/functions/implementation_chooser.h
@@ -16,38 +16,38 @@
  */
 
 // Macro for a single case. Sets __ret_dist_func to the function with the given remainder.
-#define X(N, func)                                                                                 \
+#define C1(func, N)                                                                                \
     case (N):                                                                                      \
         __ret_dist_func = func<(N)>;                                                               \
         break;
 
 // Macros for folding cases of a switch statement, for easier readability.
 // Each macro expands into a sequence of cases, from 0 to N-1, doubling the previous macro.
-#define C2(X, func, N)  X(2 * (N), func) X(2 * (N) + 1, func)
-#define C4(X, func, N)  C2(X, func, 2 * (N)) C2(X, func, 2 * (N) + 1)
-#define C8(X, func, N)  C4(X, func, 2 * (N)) C4(X, func, 2 * (N) + 1)
-#define C16(X, func, N) C8(X, func, 2 * (N)) C8(X, func, 2 * (N) + 1)
-#define C32(X, func, N) C16(X, func, 2 * (N)) C16(X, func, 2 * (N) + 1)
-#define C64(X, func, N) C32(X, func, 2 * (N)) C32(X, func, 2 * (N) + 1)
+#define C2(func, N)  C1(func, 2 * (N)) C1(func, 2 * (N) + 1)
+#define C4(func, N)  C2(func, 2 * (N)) C2(func, 2 * (N) + 1)
+#define C8(func, N)  C4(func, 2 * (N)) C4(func, 2 * (N) + 1)
+#define C16(func, N) C8(func, 2 * (N)) C8(func, 2 * (N) + 1)
+#define C32(func, N) C16(func, 2 * (N)) C16(func, 2 * (N) + 1)
+#define C64(func, N) C32(func, 2 * (N)) C32(func, 2 * (N) + 1)
 
 // Macros for 8, 16, 32 and 64 cases. Used to collapse the switch statement.
 // Expands into 0-7, 0-15, 0-31 or 0-63 cases respectively.
-#define CASES8(X, func)  C8(X, func, 0)
-#define CASES16(X, func) C16(X, func, 0)
-#define CASES32(X, func) C32(X, func, 0)
-#define CASES64(X, func) C64(X, func, 0)
+#define CASES8(func)  C8(func, 0)
+#define CASES16(func) C16(func, 0)
+#define CASES32(func) C32(func, 0)
+#define CASES64(func) C64(func, 0)
 
 // Main macro. Expands into a switch statement that chooses the implementation based on the
 // dimension's remainder.
 // @params:
 // out:     The output variable that will be set to the chosen implementation.
 // dim:     The dimension.
-// chunk:   The chunk size. Can be 64, 32, 16 or 8. 64 for 8-bit elements, 32 for 16-bit elements,
-// 16 for 32-bit elements, 8 for 64-bit elements. func:    The templated function that we want to
-// choose the implementation for.
+// func:    The templated function that we want to choose the implementation for.
+// chunk:   The chunk size. Can be 64, 32, 16 or 8. Should be the number of elements of the expected
+//          type fitting in the expected register size.
 #define CHOOSE_IMPLEMENTATION(out, dim, chunk, func)                                               \
     do {                                                                                           \
         decltype(out) __ret_dist_func;                                                             \
-        switch ((dim) % (chunk)) { CASES##chunk(X, func) }                                         \
+        switch ((dim) % (chunk)) { CASES##chunk(func) }                                            \
         out = __ret_dist_func;                                                                     \
     } while (0)

--- a/src/VecSim/spaces/functions/implementation_chooser_cleanup.h
+++ b/src/VecSim/spaces/functions/implementation_chooser_cleanup.h
@@ -10,8 +10,7 @@
  * Include this file after done using the implementation chooser.
  */
 
-#undef X
-
+#undef C1
 #undef C2
 #undef C4
 #undef C8

--- a/src/VecSim/spaces/functions/implementation_chooser_cleanup.h
+++ b/src/VecSim/spaces/functions/implementation_chooser_cleanup.h
@@ -11,7 +11,17 @@
  */
 
 #undef X
+
+#undef C2
 #undef C4
+#undef C8
+#undef C16
+#undef C32
+#undef C64
+
 #undef CASES8
 #undef CASES16
+#undef CASES32
+#undef CASES64
+
 #undef CHOOSE_IMPLEMENTATION

--- a/src/VecSim/spaces/normalize/compute_norm.h
+++ b/src/VecSim/spaces/normalize/compute_norm.h
@@ -7,11 +7,14 @@
 #pragma once
 
 #include <cmath>
+#include <type_traits>
 
 namespace spaces {
 
 template <typename DataType>
 static inline float IntegralType_ComputeNorm(const DataType *vec, const size_t dim) {
+    static_assert(std::is_integral_v<DataType>, "DataType must be an integral type");
+
     int sum = 0;
 
     for (size_t i = 0; i < dim; i++) {

--- a/src/VecSim/spaces/normalize/normalize_naive.h
+++ b/src/VecSim/spaces/normalize/normalize_naive.h
@@ -75,7 +75,7 @@ static inline void float16_normalizeVector(void *vec, const size_t dim) {
 }
 
 template <typename DataType>
-static inline void int_normalizeVector(void *vec, const size_t dim) {
+static inline void integer_normalizeVector(void *vec, const size_t dim) {
     DataType *input_vector = static_cast<DataType *>(vec);
 
     float norm = IntegralType_ComputeNorm<DataType>(input_vector, dim);

--- a/src/VecSim/spaces/normalize/normalize_naive.h
+++ b/src/VecSim/spaces/normalize/normalize_naive.h
@@ -74,10 +74,11 @@ static inline void float16_normalizeVector(void *vec, const size_t dim) {
     }
 }
 
-static inline void int8_normalizeVector(void *vec, const size_t dim) {
-    int8_t *input_vector = static_cast<int8_t *>(vec);
+template <typename DataType>
+static inline void int_normalizeVector(void *vec, const size_t dim) {
+    DataType *input_vector = static_cast<DataType *>(vec);
 
-    float norm = IntegralType_ComputeNorm<int8_t>(input_vector, dim);
+    float norm = IntegralType_ComputeNorm<DataType>(input_vector, dim);
 
     // Store norm at the end of the vector.
     *reinterpret_cast<float *>(input_vector + dim) = norm;

--- a/src/VecSim/spaces/space_includes.h
+++ b/src/VecSim/spaces/space_includes.h
@@ -21,6 +21,7 @@
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95483
 #if (__GNUC__ < 11)
 #define _mm256_loadu_epi8(ptr) _mm256_maskz_loadu_epi8(~0, ptr)
+#define _mm512_loadu_epi8(ptr) _mm512_maskz_loadu_epi8(~0, ptr)
 #endif
 #elif defined(__clang__)
 #include <xmmintrin.h>

--- a/src/VecSim/spaces/spaces.cpp
+++ b/src/VecSim/spaces/spaces.cpp
@@ -85,6 +85,20 @@ dist_func_t<float> GetDistFunc<int8_t, float>(VecSimMetric metric, size_t dim,
 }
 
 template <>
+dist_func_t<float> GetDistFunc<uint8_t, float>(VecSimMetric metric, size_t dim,
+                                               unsigned char *alignment) {
+    switch (metric) {
+    case VecSimMetric_Cosine:
+        return Cosine_UINT8_GetDistFunc(dim, alignment);
+    case VecSimMetric_IP:
+        return IP_UINT8_GetDistFunc(dim, alignment);
+    case VecSimMetric_L2:
+        return L2_UINT8_GetDistFunc(dim, alignment);
+    }
+    throw std::invalid_argument("Invalid metric");
+}
+
+template <>
 normalizeVector_f<float> GetNormalizeFunc<float>(void) {
     return normalizeVector_imp<float>;
 }
@@ -111,7 +125,11 @@ normalizeVector_f<vecsim_types::float16> GetNormalizeFunc<vecsim_types::float16>
 /** The returned function computes the norm and stores it at the end of the given vector */
 template <>
 normalizeVector_f<int8_t> GetNormalizeFunc<int8_t>(void) {
-    return int8_normalizeVector;
+    return int_normalizeVector<int8_t>;
+}
+template <>
+normalizeVector_f<uint8_t> GetNormalizeFunc<uint8_t>(void) {
+    return int_normalizeVector<uint8_t>;
 }
 
 } // namespace spaces

--- a/src/VecSim/spaces/spaces.cpp
+++ b/src/VecSim/spaces/spaces.cpp
@@ -125,11 +125,11 @@ normalizeVector_f<vecsim_types::float16> GetNormalizeFunc<vecsim_types::float16>
 /** The returned function computes the norm and stores it at the end of the given vector */
 template <>
 normalizeVector_f<int8_t> GetNormalizeFunc<int8_t>(void) {
-    return int_normalizeVector<int8_t>;
+    return integer_normalizeVector<int8_t>;
 }
 template <>
 normalizeVector_f<uint8_t> GetNormalizeFunc<uint8_t>(void) {
-    return int_normalizeVector<uint8_t>;
+    return integer_normalizeVector<uint8_t>;
 }
 
 } // namespace spaces

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -28,6 +28,7 @@ const char *VecSimCommonStrings::FLOAT64_STRING = "FLOAT64";
 const char *VecSimCommonStrings::BFLOAT16_STRING = "BFLOAT16";
 const char *VecSimCommonStrings::FLOAT16_STRING = "FLOAT16";
 const char *VecSimCommonStrings::INT8_STRING = "INT8";
+const char *VecSimCommonStrings::UINT8_STRING = "UINT8";
 const char *VecSimCommonStrings::INT32_STRING = "INT32";
 const char *VecSimCommonStrings::INT64_STRING = "INT64";
 
@@ -150,6 +151,8 @@ const char *VecSimType_ToString(VecSimType vecsimType) {
         return VecSimCommonStrings::FLOAT16_STRING;
     case VecSimType_INT8:
         return VecSimCommonStrings::INT8_STRING;
+    case VecSimType_UINT8:
+        return VecSimCommonStrings::UINT8_STRING;
     case VecSimType_INT32:
         return VecSimCommonStrings::INT32_STRING;
     case VecSimType_INT64:
@@ -200,6 +203,8 @@ size_t VecSimType_sizeof(VecSimType type) {
         return sizeof(float16);
     case VecSimType_INT8:
         return sizeof(int8_t);
+    case VecSimType_UINT8:
+        return sizeof(uint8_t);
     case VecSimType_INT32:
         return sizeof(int32_t);
     case VecSimType_INT64:
@@ -210,7 +215,7 @@ size_t VecSimType_sizeof(VecSimType type) {
 
 size_t VecSimParams_GetDataSize(VecSimType type, size_t dim, VecSimMetric metric) {
     size_t dataSize = VecSimType_sizeof(type) * dim;
-    if (type == VecSimType_INT8 && metric == VecSimMetric_Cosine) {
+    if (metric == VecSimMetric_Cosine && (type == VecSimType_INT8 || type == VecSimType_UINT8)) {
         dataSize += sizeof(float); // For the norm
     }
     return dataSize;

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -28,6 +28,7 @@ public:
     static const char *BFLOAT16_STRING;
     static const char *FLOAT16_STRING;
     static const char *INT8_STRING;
+    static const char *UINT8_STRING;
     static const char *INT32_STRING;
     static const char *INT64_STRING;
 

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -141,6 +141,9 @@ extern "C" void VecSim_Normalize(void *blob, size_t dim, VecSimType type) {
     } else if (type == VecSimType_INT8) {
         // assuming blob is large enough to store the norm at the end of the vector
         spaces::GetNormalizeFunc<int8_t>()(blob, dim);
+    } else if (type == VecSimType_UINT8) {
+        // assuming blob is large enough to store the norm at the end of the vector
+        spaces::GetNormalizeFunc<uint8_t>()(blob, dim);
     }
 }
 

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -37,6 +37,7 @@ typedef enum {
     VecSimType_BFLOAT16,
     VecSimType_FLOAT16,
     VecSimType_INT8,
+    VecSimType_UINT8,
     VecSimType_INT32,
     VecSimType_INT64
 } VecSimType;

--- a/src/VecSim/vec_sim_debug.cpp
+++ b/src/VecSim/vec_sim_debug.cpp
@@ -35,6 +35,9 @@ extern "C" int VecSimDebug_GetElementNeighborsInHNSWGraph(VecSimIndex *index, si
         } else if (info.type == VecSimType_INT8) {
             return dynamic_cast<HNSWIndex<int8_t, float> *>(index)->getHNSWElementNeighbors(
                 label, neighborsData);
+        } else if (info.type == VecSimType_UINT8) {
+            return dynamic_cast<HNSWIndex<uint8_t, float> *>(index)->getHNSWElementNeighbors(
+                label, neighborsData);
         } else {
             assert(false && "Invalid data type");
         }
@@ -53,6 +56,9 @@ extern "C" int VecSimDebug_GetElementNeighborsInHNSWGraph(VecSimIndex *index, si
                 ->getHNSWElementNeighbors(label, neighborsData);
         } else if (info.type == VecSimType_INT8) {
             return dynamic_cast<TieredHNSWIndex<int8_t, float> *>(index)->getHNSWElementNeighbors(
+                label, neighborsData);
+        } else if (info.type == VecSimType_UINT8) {
+            return dynamic_cast<TieredHNSWIndex<uint8_t, float> *>(index)->getHNSWElementNeighbors(
                 label, neighborsData);
         } else {
             assert(false && "Invalid data type");

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -303,6 +303,9 @@ public:
         } else if (type == VecSimType_INT8) {
             auto *hnsw = dynamic_cast<HNSWIndex<int8_t, float> *>(index.get());
             hnsw->saveIndex(location);
+        } else if (type == VecSimType_UINT8) {
+            auto *hnsw = dynamic_cast<HNSWIndex<uint8_t, float> *>(index.get());
+            hnsw->saveIndex(location);
         } else {
             throw std::runtime_error("Invalid index data type");
         }
@@ -439,6 +442,10 @@ public:
             return dynamic_cast<HNSWIndex<int8_t, float> *>(this->index.get())
                 ->checkIntegrity()
                 .valid_state;
+        } else if (type == VecSimType_UINT8) {
+            return dynamic_cast<HNSWIndex<uint8_t, float> *>(this->index.get())
+                ->checkIntegrity()
+                .valid_state;
         } else {
             throw std::runtime_error("Invalid index data type");
         }
@@ -542,6 +549,7 @@ PYBIND11_MODULE(VecSim, m) {
         .value("VecSimType_BFLOAT16", VecSimType_BFLOAT16)
         .value("VecSimType_FLOAT16", VecSimType_FLOAT16)
         .value("VecSimType_INT8", VecSimType_INT8)
+        .value("VecSimType_UINT8", VecSimType_UINT8)
         .value("VecSimType_INT32", VecSimType_INT32)
         .value("VecSimType_INT64", VecSimType_INT64)
         .export_values();

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -31,7 +31,7 @@ endforeach()
 
 include(${root}/cmake/x86_64InstructionFlags.cmake)
 
-set(DATA_TYPE fp32 fp64 bf16 fp16 int8)
+set(DATA_TYPE fp32 fp64 bf16 fp16 int8 uint8)
 foreach(data_type IN LISTS DATA_TYPE)
 	add_executable(bm_spaces_${data_type} spaces_benchmarks/bm_spaces_${data_type}.cpp)
 	target_link_libraries(bm_spaces_${data_type} VectorSimilarity benchmark::benchmark)

--- a/tests/benchmark/benchmarks.sh
+++ b/tests/benchmark/benchmarks.sh
@@ -17,6 +17,7 @@ if [ -z "$BM_TYPE"  ] || [ "$BM_TYPE" = "benchmarks-all" ]; then
     echo spaces_fp16
     echo spaces_int8
     echo spaces_uint8
+
 elif [ "$BM_TYPE" = "benchmarks-default" ]; then
     echo basics_single_fp32
     echo basics_multi_fp32
@@ -26,6 +27,7 @@ elif [ "$BM_TYPE" = "benchmarks-default" ]; then
     echo spaces_fp16
     echo spaces_int8
     echo spaces_uint8
+
 # Basic benchmarks
 elif [ "$BM_TYPE" = "bm-basics-fp32-single" ] ; then
     echo basics_single_fp32
@@ -78,6 +80,7 @@ elif [ "$BM_TYPE" = "bm-spaces" ] ; then
     echo spaces_bf16
     echo spaces_int8
     echo spaces_uint8
+
 elif [ "$BM_TYPE" = "bm-spaces-fp32" ] ; then
     echo spaces_fp32
 elif [ "$BM_TYPE" = "bm-spaces-fp64" ] ; then

--- a/tests/benchmark/benchmarks.sh
+++ b/tests/benchmark/benchmarks.sh
@@ -14,6 +14,7 @@ if [ -z "$BM_TYPE"  ] || [ "$BM_TYPE" = "benchmarks-all" ]; then
     echo spaces_bf16
     echo spaces_fp16
     echo spaces_int8
+    echo spaces_uint8
 elif [ "$BM_TYPE" = "benchmarks-default" ]; then
     echo basics_single_fp32
     echo basics_multi_fp32
@@ -22,6 +23,7 @@ elif [ "$BM_TYPE" = "benchmarks-default" ]; then
     echo spaces_bf16
     echo spaces_fp16
     echo spaces_int8
+    echo spaces_uint8
 # Basic benchmarks
 elif [ "$BM_TYPE" = "bm-basics-fp32-single" ] ; then
     echo basics_single_fp32
@@ -69,6 +71,7 @@ elif [ "$BM_TYPE" = "bm-spaces" ] ; then
     echo spaces_fp64
     echo spaces_bf16
     echo spaces_int8
+    echo spaces_uint8
 elif [ "$BM_TYPE" = "bm-spaces-fp32" ] ; then
     echo spaces_fp32
 elif [ "$BM_TYPE" = "bm-spaces-fp64" ] ; then
@@ -79,4 +82,6 @@ elif [ "$BM_TYPE" = "bm-spaces-fp16" ] ; then
     echo spaces_fp16
 elif [ "$BM_TYPE" = "bm-spaces-int8" ] ; then
     echo spaces_int8
+elif [ "$BM_TYPE" = "bm-spaces-uint8" ] ; then
+    echo spaces_uint8
 fi

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_int8.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_int8.cpp
@@ -52,5 +52,6 @@ INITIALIZE_BENCHMARKS_SET_Cosine(BM_VecSimSpaces_Integers_INT8, INT8, AVX512F_BW
 #endif // x86_64
 
 INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_INT8, INT8, InnerProduct, 32);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_INT8, INT8, Cosine, 32);
 INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_INT8, INT8, L2Sqr, 32);
 BENCHMARK_MAIN();

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_int8.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_int8.cpp
@@ -46,11 +46,11 @@ bool avx512_f_bw_vl_vnni_supported = opt.avx512f && opt.avx512bw && opt.avx512vl
 INITIALIZE_BENCHMARKS_SET_L2_IP(BM_VecSimSpaces_Integers_INT8, INT8, AVX512F_BW_VL_VNNI, 32,
                                 avx512_f_bw_vl_vnni_supported);
 INITIALIZE_BENCHMARKS_SET_Cosine(BM_VecSimSpaces_Integers_INT8, INT8, AVX512F_BW_VL_VNNI, 32,
-                                 avx512_f_bw_vl_vnni_supported)
+                                 avx512_f_bw_vl_vnni_supported);
 #endif // AVX512_F_BW_VL_VNNI
 
 #endif // x86_64
 
-    INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_INT8, INT8, InnerProduct, 32);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_INT8, INT8, InnerProduct, 32);
 INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_INT8, INT8, L2Sqr, 32);
 BENCHMARK_MAIN();

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_uint8.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_uint8.cpp
@@ -46,11 +46,11 @@ bool avx512_f_bw_vl_vnni_supported = opt.avx512f && opt.avx512bw && opt.avx512vl
 INITIALIZE_BENCHMARKS_SET_L2_IP(BM_VecSimSpaces_Integers_UINT8, UINT8, AVX512F_BW_VL_VNNI, 32,
                                 avx512_f_bw_vl_vnni_supported);
 INITIALIZE_BENCHMARKS_SET_Cosine(BM_VecSimSpaces_Integers_UINT8, UINT8, AVX512F_BW_VL_VNNI, 32,
-                                 avx512_f_bw_vl_vnni_supported)
+                                 avx512_f_bw_vl_vnni_supported);
 #endif // AVX512_F_BW_VL_VNNI
 
 #endif // x86_64
 
-    INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_UINT8, UINT8, InnerProduct, 32);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_UINT8, UINT8, InnerProduct, 32);
 INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_UINT8, UINT8, L2Sqr, 32);
 BENCHMARK_MAIN();

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_uint8.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_uint8.cpp
@@ -1,0 +1,56 @@
+/*
+ *Copyright Redis Ltd. 2021 - present
+ *Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ *the Server Side Public License v1 (SSPLv1).
+ */
+#include <benchmark/benchmark.h>
+#include <random>
+#include <cstring>
+#include "utils/tests_utils.h"
+#include "bm_spaces.h"
+
+class BM_VecSimSpaces_Integers_UINT8 : public benchmark::Fixture {
+protected:
+    std::mt19937 rng;
+    size_t dim;
+    uint8_t *v1, *v2;
+
+public:
+    BM_VecSimSpaces_Integers_UINT8() { rng.seed(47); }
+    ~BM_VecSimSpaces_Integers_UINT8() = default;
+
+    void SetUp(const ::benchmark::State &state) {
+        dim = state.range(0);
+        // Allocate vector with extra space for cosine calculations
+        v1 = new uint8_t[dim + sizeof(float)];
+        v2 = new uint8_t[dim + sizeof(float)];
+        test_utils::populate_uint8_vec(v1, dim, 123);
+        test_utils::populate_uint8_vec(v2, dim, 1234);
+
+        // Store the norm in the extra space for cosine calculations
+        *(float *)(v1 + dim) = test_utils::integral_compute_norm(v1, dim);
+        *(float *)(v2 + dim) = test_utils::integral_compute_norm(v2, dim);
+    }
+    void TearDown(const ::benchmark::State &state) {
+        delete v1;
+        delete v2;
+    }
+};
+
+#ifdef CPU_FEATURES_ARCH_X86_64
+cpu_features::X86Features opt = cpu_features::GetX86Info().features;
+
+// AVX512_F_BW_VL_VNNI functions
+#ifdef OPT_AVX512_F_BW_VL_VNNI
+bool avx512_f_bw_vl_vnni_supported = opt.avx512f && opt.avx512bw && opt.avx512vl && opt.avx512vnni;
+INITIALIZE_BENCHMARKS_SET_L2_IP(BM_VecSimSpaces_Integers_UINT8, UINT8, AVX512F_BW_VL_VNNI, 32,
+                                avx512_f_bw_vl_vnni_supported);
+INITIALIZE_BENCHMARKS_SET_Cosine(BM_VecSimSpaces_Integers_UINT8, UINT8, AVX512F_BW_VL_VNNI, 32,
+                                 avx512_f_bw_vl_vnni_supported)
+#endif // AVX512_F_BW_VL_VNNI
+
+#endif // x86_64
+
+    INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_UINT8, UINT8, InnerProduct, 32);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_UINT8, UINT8, L2Sqr, 32);
+BENCHMARK_MAIN();

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_uint8.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_uint8.cpp
@@ -52,5 +52,6 @@ INITIALIZE_BENCHMARKS_SET_Cosine(BM_VecSimSpaces_Integers_UINT8, UINT8, AVX512F_
 #endif // x86_64
 
 INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_UINT8, UINT8, InnerProduct, 32);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_UINT8, UINT8, Cosine, 32);
 INITIALIZE_NAIVE_BM(BM_VecSimSpaces_Integers_UINT8, UINT8, L2Sqr, 32);
 BENCHMARK_MAIN();

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -83,6 +83,10 @@ def create_int8_vectors(shape, rng: np.random.Generator = None):
     rng = np.random.default_rng(seed=42) if rng is None else rng
     return rng.integers(low=-128, high=127, size=shape, dtype=np.int8)
 
+def create_uint8_vectors(shape, rng: np.random.Generator = None):
+    rng = np.random.default_rng(seed=42) if rng is None else rng
+    return rng.integers(low=0, high=255, size=shape, dtype=np.uint8)
+
 def get_ground_truth_results(dist_func, query, vectors, k):
     results = [{"dist": dist_func(query, vec), "label": key} for key, vec in vectors]
     results = sorted(results, key=lambda x: x["dist"])

--- a/tests/flow/test_bruteforce.py
+++ b/tests/flow/test_bruteforce.py
@@ -734,3 +734,26 @@ class TestINT8(GeneralTest):
 
     def test_multi_value(self):
         self.multi_value(create_int8_vectors)
+
+class TestUINT8(GeneralTest):
+
+    GeneralTest.data_type = VecSimType_UINT8
+
+    #### Create vectors
+    GeneralTest.vectors_data = create_uint8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
+
+    #### Create queries
+    GeneralTest.query_data = create_uint8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
+
+    def test_Cosine(self):
+
+        index = self.create_index(VecSimMetric_Cosine)
+        label_to_vec_list = self.create_add_vectors(index)
+
+        self.knn(index, label_to_vec_list, fp32_expand_and_calc_cosine_dist)
+
+    def test_range_query(self):
+        self.range_query(fp32_expand_and_calc_cosine_dist)
+
+    def test_multi_value(self):
+        self.multi_value(create_uint8_vectors)

--- a/tests/flow/test_bruteforce.py
+++ b/tests/flow/test_bruteforce.py
@@ -652,7 +652,7 @@ class GeneralTest():
     def range_query(self, dist_func):
         bfindex = self.create_index(VecSimMetric_Cosine)
         label_to_vec_list = self.create_add_vectors(bfindex)
-        radius = 0.7
+        radius = bfindex.knn_query(self.query_data[0], k=100)[1][0][-1] # get the distance of the 100th closest vector as the radius
 
         start = time.time()
         bf_labels, bf_distances = bfindex.range_query(self.query_data[0], radius=radius)
@@ -663,8 +663,8 @@ class GeneralTest():
         # Verify that we got exactly all vectors within the range
         results, keys = get_ground_truth_results(dist_func, self.query_data[0], label_to_vec_list, res_num)
 
-        assert_allclose(max(bf_distances[0]), results[res_num-1]["dist"], rtol=1e-05)
-        assert np.array_equal(np.array(bf_labels[0]), np.array(keys))
+        assert_allclose(bf_distances[0], [results[i]["dist"] for i in range(res_num)], rtol=1e-05)
+        assert self.compute_correct(bf_labels[0], bf_distances[0], keys, results) == res_num
         assert max(bf_distances[0]) <= radius
         # Verify that the next closest vector that hasn't returned is not within the range
         assert results[res_num]["dist"] > radius
@@ -680,13 +680,13 @@ class GeneralTest():
         num_labels = self.num_elements // num_per_label
         k = 10
 
-        data = create_data_func((num_labels, self.dim), self.rng)
+        data = create_data_func((num_labels, num_per_label, self.dim), self.rng)
 
         index = self.create_index(is_multi=True)
 
         vectors = []
-        for i, vector in enumerate(data):
-            for _ in range(num_per_label):
+        for i, cur_vectors in enumerate(data):
+            for vector in cur_vectors:
                 index.add_vector(vector, i)
                 vectors.append((i, vector))
 
@@ -704,23 +704,23 @@ class GeneralTest():
         dists = [dist for _, dist in dists[:k]]
 
         start = time.time()
-        bf_labels, bf_distances = index.knn_query(self.query_data[0], k=10)
+        bf_labels, bf_distances = index.knn_query(self.query_data[0], k=k)
         end = time.time()
 
         print(f'\nlookup time for {self.num_elements} vectors ({num_labels} labels and {num_per_label} vectors per label) with dim={self.dim} took {end - start} seconds')
 
-        assert_allclose(bf_labels, [keys],  rtol=1e-5, atol=0)
-        assert_allclose(bf_distances, [dists],  rtol=1e-5, atol=0)
+        assert_allclose(bf_labels, [keys],  rtol=1e-5)
+        assert_allclose(bf_distances, [dists],  rtol=1e-5)
 
 class TestINT8(GeneralTest):
 
-    GeneralTest.data_type = VecSimType_INT8
+    data_type = VecSimType_INT8
 
     #### Create vectors
-    GeneralTest.vectors_data = create_int8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
+    vectors_data = create_int8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
 
     #### Create queries
-    GeneralTest.query_data = create_int8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
+    query_data = create_int8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
 
     def test_Cosine(self):
 
@@ -737,13 +737,13 @@ class TestINT8(GeneralTest):
 
 class TestUINT8(GeneralTest):
 
-    GeneralTest.data_type = VecSimType_UINT8
+    data_type = VecSimType_UINT8
 
     #### Create vectors
-    GeneralTest.vectors_data = create_uint8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
+    vectors_data = create_uint8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
 
     #### Create queries
-    GeneralTest.query_data = create_uint8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
+    query_data = create_uint8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
 
     def test_Cosine(self):
 

--- a/tests/flow/test_hnsw.py
+++ b/tests/flow/test_hnsw.py
@@ -1028,7 +1028,7 @@ class GeneralTest():
     def range_query(self, dist_func):
         hnsw_index = self.create_index(VecSimMetric_Cosine)
         label_to_vec_list = self.create_add_vectors(hnsw_index)
-        radius = 0.7
+        radius = hnsw_index.knn_query(self.query_data[0], k=100)[1][0][-1] # get the distance of the 100th closest vector as the radius
         recalls = {}
 
         for epsilon_rt in [0.001, 0.01, 0.1]:
@@ -1066,13 +1066,13 @@ class GeneralTest():
         num_labels = self.num_elements // num_per_label
         k = 10
 
-        data = create_data_func((num_labels, self.dim), self.rng)
+        data = create_data_func((num_labels, num_per_label, self.dim), self.rng)
 
         hnsw_index = self.create_index(is_multi=True)
 
         vectors = []
-        for i, vector in enumerate(data):
-            for _ in range(num_per_label):
+        for i, cur_vectors in enumerate(data):
+            for vector in cur_vectors:
                 hnsw_index.add_vector(vector, i)
                 vectors.append((i, vector))
 
@@ -1108,13 +1108,13 @@ class GeneralTest():
 
 class TestINT8(GeneralTest):
 
-    GeneralTest.data_type = VecSimType_INT8
+    data_type = VecSimType_INT8
 
     #### Create vectors
-    GeneralTest.data = create_int8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
+    data = create_int8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
 
     #### Create queries
-    GeneralTest.query_data = create_int8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
+    query_data = create_int8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
 
     def test_Cosine(self):
         hnsw_index = self.create_index(VecSimMetric_Cosine)
@@ -1130,13 +1130,13 @@ class TestINT8(GeneralTest):
 
 class TestUINT8(GeneralTest):
 
-    GeneralTest.data_type = VecSimType_UINT8
+    data_type = VecSimType_UINT8
 
     #### Create vectors
-    GeneralTest.data = create_uint8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
+    data = create_uint8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
 
     #### Create queries
-    GeneralTest.query_data = create_uint8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
+    query_data = create_uint8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
 
     def test_Cosine(self):
         hnsw_index = self.create_index(VecSimMetric_Cosine)

--- a/tests/flow/test_hnsw.py
+++ b/tests/flow/test_hnsw.py
@@ -1127,3 +1127,25 @@ class TestINT8(GeneralTest):
 
     def test_multi_value(self):
         self.multi_value(create_int8_vectors)
+
+class TestUINT8(GeneralTest):
+
+    GeneralTest.data_type = VecSimType_UINT8
+
+    #### Create vectors
+    GeneralTest.data = create_uint8_vectors((GeneralTest.num_elements, GeneralTest.dim), GeneralTest.rng)
+
+    #### Create queries
+    GeneralTest.query_data = create_uint8_vectors((GeneralTest.num_queries, GeneralTest.dim), GeneralTest.rng)
+
+    def test_Cosine(self):
+        hnsw_index = self.create_index(VecSimMetric_Cosine)
+        label_to_vec_list = self.create_add_vectors(hnsw_index)
+
+        self.knn(hnsw_index, label_to_vec_list, fp32_expand_and_calc_cosine_dist)
+
+    def test_range_query(self):
+        self.range_query(fp32_expand_and_calc_cosine_dist)
+
+    def test_multi_value(self):
+        self.multi_value(create_uint8_vectors)

--- a/tests/flow/test_hnsw_tiered.py
+++ b/tests/flow/test_hnsw_tiered.py
@@ -23,7 +23,8 @@ class IndexCtx:
         VecSimType_FLOAT64: np.float64,
         VecSimType_BFLOAT16: bfloat16,
         VecSimType_FLOAT16: np.float16,
-        VecSimType_INT8: np.int8
+        VecSimType_INT8: np.int8,
+        VecSimType_UINT8: np.uint8,
     }
 
     def __init__(self, data_size=10000,
@@ -132,7 +133,8 @@ class IndexCtx:
             VecSimType_FLOAT64: 8,
             VecSimType_BFLOAT16: 2,
             VecSimType_FLOAT16: 2,
-            VecSimType_INT8: 1
+            VecSimType_INT8: 1,
+            VecSimType_UINT8: 1,
         }
         return bytes_to_mega(self.num_vectors * self.dim * memory_size[self.data_type])
 
@@ -261,6 +263,10 @@ def test_create_int8():
     print("Test create INT8 tiered hnsw index")
     create_tiered_index(is_multi=False, data_type=VecSimType_INT8, create_data_func=create_int8_vectors)
 
+def test_create_uint8():
+    print("Test create UINT8 tiered hnsw index")
+    create_tiered_index(is_multi=False, data_type=VecSimType_UINT8, create_data_func=create_uint8_vectors)
+
 def test_search_insert():
     print(f"\nStart insert & search test")
     search_insert(is_multi=False)
@@ -276,6 +282,10 @@ def test_search_insert_fp16():
 def test_search_insert_int8():
     print(f"\nStart insert & search test")
     search_insert(is_multi=False, data_type=VecSimType_INT8, create_data_func=create_int8_vectors)
+
+def test_search_insert_uint8():
+    print(f"\nStart insert & search test")
+    search_insert(is_multi=False, data_type=VecSimType_UINT8, create_data_func=create_uint8_vectors)
 
 def test_search_insert_multi_index():
     print(f"\nStart insert & search test for multi index")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(test_components test_components.cpp ../utils/mock_thread_pool.cpp
 add_executable(test_bf16 ../utils/mock_thread_pool.cpp test_bf16.cpp unit_test_utils.cpp)
 add_executable(test_fp16 ../utils/mock_thread_pool.cpp test_fp16.cpp unit_test_utils.cpp)
 add_executable(test_int8 ../utils/mock_thread_pool.cpp test_int8.cpp unit_test_utils.cpp)
+add_executable(test_uint8 ../utils/mock_thread_pool.cpp test_uint8.cpp unit_test_utils.cpp)
 
 target_link_libraries(test_hnsw PUBLIC gtest_main VectorSimilarity)
 target_link_libraries(test_hnsw_parallel PUBLIC gtest_main VectorSimilarity)
@@ -53,6 +54,7 @@ target_link_libraries(test_types PUBLIC gtest_main VectorSimilarity)
 target_link_libraries(test_bf16 PUBLIC gtest_main VectorSimilarity)
 target_link_libraries(test_fp16 PUBLIC gtest_main VectorSimilarity)
 target_link_libraries(test_int8 PUBLIC gtest_main VectorSimilarity)
+target_link_libraries(test_uint8 PUBLIC gtest_main VectorSimilarity)
 
 include(GoogleTest)
 
@@ -67,3 +69,4 @@ gtest_discover_tests(test_types)
 gtest_discover_tests(test_bf16 TEST_PREFIX BF16UNIT_)
 gtest_discover_tests(test_fp16 TEST_PREFIX FP16UNIT_)
 gtest_discover_tests(test_int8 TEST_PREFIX INT8UNIT_)
+gtest_discover_tests(test_uint8 TEST_PREFIX UINT8UNIT_)

--- a/tests/unit/test_common.cpp
+++ b/tests/unit/test_common.cpp
@@ -735,7 +735,8 @@ TEST_P(CommonTypeMetricTieredTests, TestDataSizeTieredHNSW) {
         auto hnsw_index = tiered_index->getHNSWIndex();
         auto bf_index = tiered_index->getFlatBufferIndex();
         size_t expected = dim * VecSimType_sizeof(type);
-        if (metric == VecSimMetric_Cosine && (type == VecSimType_INT8 || type == VecSimType_UINT8)) {
+        if (metric == VecSimMetric_Cosine &&
+            (type == VecSimType_INT8 || type == VecSimType_UINT8)) {
             expected += sizeof(float);
         }
         size_t actual_hnsw = hnsw_index->getDataSize();
@@ -798,9 +799,9 @@ TEST_P(CommonTypeMetricTieredTests, TestInitialSizeEstimationTieredHNSW) {
     ASSERT_EQ(estimation, actual);
 }
 
-constexpr VecSimType vecsim_datatypes[] = {VecSimType_FLOAT32, VecSimType_FLOAT64,
+constexpr VecSimType vecsim_datatypes[] = {VecSimType_FLOAT32,  VecSimType_FLOAT64,
                                            VecSimType_BFLOAT16, VecSimType_FLOAT16,
-                                           VecSimType_INT8, VecSimType_UINT8};
+                                           VecSimType_INT8,     VecSimType_UINT8};
 
 /** Run all CommonTypeMetricTests tests for each {VecSimType, VecSimMetric} combination */
 INSTANTIATE_TEST_SUITE_P(CommonTest, CommonTypeMetricTests,

--- a/tests/unit/test_common.cpp
+++ b/tests/unit/test_common.cpp
@@ -498,6 +498,7 @@ TEST_F(SerializerTest, HNSWSerialzer) {
     Serializer::writeBinaryPOD(output, size_t(128));
 
     Serializer::writeBinaryPOD(output, 42);
+    Serializer::writeBinaryPOD(output, VecSimMetric_Cosine);
     output.flush();
 
     ASSERT_EXCEPTION_MESSAGE(HNSWFactory::NewIndex(this->file_name), std::runtime_error,

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -117,6 +117,19 @@ TEST_F(SpacesTest, int8_l2_no_optimization_func_test) {
     ASSERT_EQ(dist, 5.0);
 }
 
+TEST_F(SpacesTest, uint8_l2_no_optimization_func_test) {
+    size_t dim = 5;
+
+    uint8_t a[dim], b[dim];
+    for (size_t i = 0; i < dim; i++) {
+        a[i] = (i + 1);
+        b[i] = (i + 2);
+    }
+
+    float dist = UINT8_L2Sqr((const void *)a, (const void *)b, dim);
+    ASSERT_EQ(dist, 5.0);
+}
+
 /* ======================== IP NO OPT ======================== */
 
 TEST_F(SpacesTest, float_ip_no_optimization_func_test) {
@@ -237,6 +250,15 @@ TEST_F(SpacesTest, int8_ip_no_optimization_func_test) {
     ASSERT_EQ(dist, 0.0);
 }
 
+TEST_F(SpacesTest, uint8_ip_no_optimization_func_test) {
+    size_t dim = 4;
+    uint8_t a[] = {1, 0, 0, 0};
+    uint8_t b[] = {1, 0, 0, 0};
+
+    float dist = UINT8_InnerProduct((const void *)a, (const void *)b, dim);
+    ASSERT_EQ(dist, 0.0);
+}
+
 /* ======================== Cosine NO OPT ======================== */
 
 TEST_F(SpacesTest, int8_Cosine_no_optimization_func_test) {
@@ -253,6 +275,23 @@ TEST_F(SpacesTest, int8_Cosine_no_optimization_func_test) {
     *(float *)(v2 + dim) = test_utils::integral_compute_norm(v2, dim);
 
     float dist = INT8_Cosine((const void *)v1, (const void *)v2, dim);
+    ASSERT_NEAR(dist, 0.0, 0.000001);
+}
+
+TEST_F(SpacesTest, uint8_Cosine_no_optimization_func_test) {
+    size_t dim = 4;
+    // create a vector with extra space for the norm
+    uint8_t v1[dim + sizeof(float)];
+    uint8_t v2[dim + sizeof(float)];
+
+    test_utils::populate_uint8_vec(v1, dim, 123);
+    test_utils::populate_uint8_vec(v2, dim, 123);
+
+    // write the norm at the end of the vector
+    *(float *)(v1 + dim) = test_utils::integral_compute_norm(v1, dim);
+    *(float *)(v2 + dim) = test_utils::integral_compute_norm(v2, dim);
+
+    float dist = UINT8_Cosine((const void *)v1, (const void *)v2, dim);
     ASSERT_NEAR(dist, 0.0, 0.000001);
 }
 
@@ -283,6 +322,11 @@ TEST_F(SpacesTest, GetDistFuncInvalidMetricINT8) {
         (spaces::GetDistFunc<int8_t, float>((VecSimMetric)(VecSimMetric_Cosine + 1), 10, nullptr)),
         std::invalid_argument);
 }
+TEST_F(SpacesTest, GetDistFuncInvalidMetricUINT8) {
+    EXPECT_THROW(
+        (spaces::GetDistFunc<uint8_t, float>((VecSimMetric)(VecSimMetric_Cosine + 1), 10, nullptr)),
+        std::invalid_argument);
+}
 
 using namespace spaces;
 
@@ -294,32 +338,41 @@ TEST_F(SpacesTest, smallDimChooser) {
         ASSERT_EQ(L2_BF16_GetDistFunc(dim), BF16_L2Sqr_LittleEndian);
         ASSERT_EQ(L2_FP16_GetDistFunc(dim), FP16_L2Sqr);
         ASSERT_EQ(L2_INT8_GetDistFunc(dim), INT8_L2Sqr);
+        ASSERT_EQ(L2_UINT8_GetDistFunc(dim), UINT8_L2Sqr);
         ASSERT_EQ(IP_FP32_GetDistFunc(dim), FP32_InnerProduct);
         ASSERT_EQ(IP_FP64_GetDistFunc(dim), FP64_InnerProduct);
         ASSERT_EQ(IP_BF16_GetDistFunc(dim), BF16_InnerProduct_LittleEndian);
         ASSERT_EQ(IP_FP16_GetDistFunc(dim), FP16_InnerProduct);
         ASSERT_EQ(IP_INT8_GetDistFunc(dim), INT8_InnerProduct);
+        ASSERT_EQ(IP_UINT8_GetDistFunc(dim), UINT8_InnerProduct);
         ASSERT_EQ(Cosine_INT8_GetDistFunc(dim), INT8_Cosine);
+        ASSERT_EQ(Cosine_UINT8_GetDistFunc(dim), UINT8_Cosine);
     }
     for (size_t dim = 8; dim < 16; dim++) {
         ASSERT_EQ(L2_FP32_GetDistFunc(dim), FP32_L2Sqr);
         ASSERT_EQ(L2_BF16_GetDistFunc(dim), BF16_L2Sqr_LittleEndian);
         ASSERT_EQ(L2_FP16_GetDistFunc(dim), FP16_L2Sqr);
         ASSERT_EQ(L2_INT8_GetDistFunc(dim), INT8_L2Sqr);
+        ASSERT_EQ(L2_UINT8_GetDistFunc(dim), UINT8_L2Sqr);
         ASSERT_EQ(IP_FP32_GetDistFunc(dim), FP32_InnerProduct);
         ASSERT_EQ(IP_BF16_GetDistFunc(dim), BF16_InnerProduct_LittleEndian);
         ASSERT_EQ(IP_FP16_GetDistFunc(dim), FP16_InnerProduct);
         ASSERT_EQ(IP_INT8_GetDistFunc(dim), INT8_InnerProduct);
+        ASSERT_EQ(IP_UINT8_GetDistFunc(dim), UINT8_InnerProduct);
         ASSERT_EQ(Cosine_INT8_GetDistFunc(dim), INT8_Cosine);
+        ASSERT_EQ(Cosine_UINT8_GetDistFunc(dim), UINT8_Cosine);
     }
     for (size_t dim = 16; dim < 32; dim++) {
         ASSERT_EQ(L2_BF16_GetDistFunc(dim), BF16_L2Sqr_LittleEndian);
         ASSERT_EQ(L2_FP16_GetDistFunc(dim), FP16_L2Sqr);
         ASSERT_EQ(L2_INT8_GetDistFunc(dim), INT8_L2Sqr);
+        ASSERT_EQ(L2_UINT8_GetDistFunc(dim), UINT8_L2Sqr);
         ASSERT_EQ(IP_BF16_GetDistFunc(dim), BF16_InnerProduct_LittleEndian);
         ASSERT_EQ(IP_FP16_GetDistFunc(dim), FP16_InnerProduct);
         ASSERT_EQ(IP_INT8_GetDistFunc(dim), INT8_InnerProduct);
+        ASSERT_EQ(IP_UINT8_GetDistFunc(dim), UINT8_InnerProduct);
         ASSERT_EQ(Cosine_INT8_GetDistFunc(dim), INT8_Cosine);
+        ASSERT_EQ(Cosine_UINT8_GetDistFunc(dim), UINT8_Cosine);
     }
 }
 
@@ -1024,6 +1077,120 @@ TEST_P(INT8SpacesOptimizationTest, INT8CosineTest) {
 }
 
 INSTANTIATE_TEST_SUITE_P(INT8OptFuncs, INT8SpacesOptimizationTest,
+                         testing::Range(32UL, 32 * 2UL + 1));
+
+class UINT8SpacesOptimizationTest : public testing::TestWithParam<size_t> {};
+
+TEST_P(UINT8SpacesOptimizationTest, UINT8L2SqrTest) {
+    auto optimization = cpu_features::GetX86Info().features;
+    size_t dim = GetParam();
+    uint8_t v1[dim];
+    uint8_t v2[dim];
+    test_utils::populate_uint8_vec(v1, dim, 123);
+    test_utils::populate_uint8_vec(v2, dim, 1234);
+
+    auto expected_alignment = [](size_t reg_bit_size, size_t dim) {
+        size_t elements_in_reg = reg_bit_size / sizeof(uint8_t) / 8;
+        return (dim % elements_in_reg == 0) ? elements_in_reg * sizeof(uint8_t) : 0;
+    };
+
+    dist_func_t<float> arch_opt_func;
+    float baseline = UINT8_L2Sqr(v1, v2, dim);
+#ifdef OPT_AVX512_F_BW_VL_VNNI
+    if (optimization.avx512f && optimization.avx512bw && optimization.avx512vl &&
+        optimization.avx512vnni) {
+        unsigned char alignment = 0;
+        arch_opt_func = L2_UINT8_GetDistFunc(dim, &alignment, &optimization);
+        ASSERT_EQ(arch_opt_func, Choose_UINT8_L2_implementation_AVX512F_BW_VL_VNNI(dim))
+            << "Unexpected distance function chosen for dim " << dim;
+        ASSERT_EQ(baseline, arch_opt_func(v1, v2, dim)) << "AVX512 with dim " << dim;
+        ASSERT_EQ(alignment, expected_alignment(256, dim)) << "AVX512 with dim " << dim;
+        // Unset optimizations flag, so we'll choose the next optimization.
+        optimization.avx512f = optimization.avx512bw = optimization.avx512vl =
+            optimization.avx512vnni = 0;
+    }
+#endif
+    unsigned char alignment = 0;
+    arch_opt_func = L2_UINT8_GetDistFunc(dim, &alignment, &optimization);
+    ASSERT_EQ(arch_opt_func, UINT8_L2Sqr) << "Unexpected distance function chosen for dim " << dim;
+    ASSERT_EQ(baseline, arch_opt_func(v1, v2, dim)) << "No optimization with dim " << dim;
+    ASSERT_EQ(alignment, 0) << "No optimization with dim " << dim;
+}
+
+TEST_P(UINT8SpacesOptimizationTest, UINT8InnerProductTest) {
+    auto optimization = cpu_features::GetX86Info().features;
+    size_t dim = GetParam();
+    uint8_t v1[dim];
+    uint8_t v2[dim];
+    test_utils::populate_uint8_vec(v1, dim, 123);
+    test_utils::populate_uint8_vec(v2, dim, 1234);
+
+    auto expected_alignment = [](size_t reg_bit_size, size_t dim) {
+        size_t elements_in_reg = reg_bit_size / sizeof(uint8_t) / 8;
+        return (dim % elements_in_reg == 0) ? elements_in_reg * sizeof(uint8_t) : 0;
+    };
+
+    dist_func_t<float> arch_opt_func;
+    float baseline = UINT8_InnerProduct(v1, v2, dim);
+#ifdef OPT_AVX512_F_BW_VL_VNNI
+    if (optimization.avx512f && optimization.avx512bw && optimization.avx512vl &&
+        optimization.avx512vnni) {
+        unsigned char alignment = 0;
+        arch_opt_func = IP_UINT8_GetDistFunc(dim, &alignment, &optimization);
+        ASSERT_EQ(arch_opt_func, Choose_UINT8_IP_implementation_AVX512F_BW_VL_VNNI(dim))
+            << "Unexpected distance function chosen for dim " << dim;
+        ASSERT_EQ(baseline, arch_opt_func(v1, v2, dim)) << "AVX512 with dim " << dim;
+        ASSERT_EQ(alignment, expected_alignment(256, dim)) << "AVX512 with dim " << dim;
+        // Unset optimizations flag, so we'll choose the next optimization.
+        optimization.avx512f = optimization.avx512bw = optimization.avx512vl =
+            optimization.avx512vnni = 0;
+    }
+#endif
+    unsigned char alignment = 0;
+    arch_opt_func = IP_UINT8_GetDistFunc(dim, &alignment, &optimization);
+    ASSERT_EQ(arch_opt_func, UINT8_InnerProduct)
+        << "Unexpected distance function chosen for dim " << dim;
+    ASSERT_EQ(baseline, arch_opt_func(v1, v2, dim)) << "No optimization with dim " << dim;
+    ASSERT_EQ(alignment, 0) << "No optimization with dim " << dim;
+}
+
+TEST_P(UINT8SpacesOptimizationTest, UINT8CosineTest) {
+    auto optimization = cpu_features::GetX86Info().features;
+    size_t dim = GetParam();
+    uint8_t v1[dim + sizeof(float)];
+    uint8_t v2[dim + sizeof(float)];
+    test_utils::populate_uint8_vec(v1, dim, 123);
+    test_utils::populate_uint8_vec(v2, dim, 1234);
+
+    // write the norm at the end of the vector
+    *(float *)(v1 + dim) = test_utils::integral_compute_norm(v1, dim);
+    *(float *)(v2 + dim) = test_utils::integral_compute_norm(v2, dim);
+
+    dist_func_t<float> arch_opt_func;
+    float baseline = UINT8_Cosine(v1, v2, dim);
+#ifdef OPT_AVX512_F_BW_VL_VNNI
+    if (optimization.avx512f && optimization.avx512bw && optimization.avx512vl &&
+        optimization.avx512vnni) {
+        unsigned char alignment = 0;
+        arch_opt_func = Cosine_UINT8_GetDistFunc(dim, &alignment, &optimization);
+        ASSERT_EQ(arch_opt_func, Choose_UINT8_Cosine_implementation_AVX512F_BW_VL_VNNI(dim))
+            << "Unexpected distance function chosen for dim " << dim;
+        ASSERT_EQ(baseline, arch_opt_func(v1, v2, dim)) << "AVX512 with dim " << dim;
+        // We don't align uint8 vectors with cosine distance
+        ASSERT_EQ(alignment, 0) << "AVX512 with dim " << dim;
+        // Unset optimizations flag, so we'll choose the next optimization.
+        optimization.avx512f = optimization.avx512bw = optimization.avx512vl =
+            optimization.avx512vnni = 0;
+    }
+#endif
+    unsigned char alignment = 0;
+    arch_opt_func = Cosine_UINT8_GetDistFunc(dim, &alignment, &optimization);
+    ASSERT_EQ(arch_opt_func, UINT8_Cosine) << "Unexpected distance function chosen for dim " << dim;
+    ASSERT_EQ(baseline, arch_opt_func(v1, v2, dim)) << "No optimization with dim " << dim;
+    ASSERT_EQ(alignment, 0) << "No optimization with dim " << dim;
+}
+
+INSTANTIATE_TEST_SUITE_P(UINT8OptFuncs, UINT8SpacesOptimizationTest,
                          testing::Range(32UL, 32 * 2UL + 1));
 
 #endif // CPU_FEATURES_ARCH_X86_64

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -1191,6 +1191,6 @@ TEST_P(UINT8SpacesOptimizationTest, UINT8CosineTest) {
 }
 
 INSTANTIATE_TEST_SUITE_P(UINT8OptFuncs, UINT8SpacesOptimizationTest,
-                         testing::Range(32UL, 32 * 2UL + 1));
+                         testing::Range(32UL, 64 * 2UL + 1));
 
 #endif // CPU_FEATURES_ARCH_X86_64

--- a/tests/unit/test_uint8.cpp
+++ b/tests/unit/test_uint8.cpp
@@ -386,7 +386,7 @@ void UINT8Test::metrics_test(params_t index_params) {
     double expected_score = 0;
 
     auto verify_res = [&](size_t id, double score, size_t index) {
-        ASSERT_FLOAT_EQ(score, expected_score) << "failed at vector id:" << id;
+        ASSERT_NEAR(score, expected_score, 1e-6);
     };
 
     for (size_t i = 0; i < n; i++) {

--- a/tests/unit/test_uint8.cpp
+++ b/tests/unit/test_uint8.cpp
@@ -1,0 +1,995 @@
+#include "gtest/gtest.h"
+#include "VecSim/vec_sim.h"
+#include "VecSim/algorithms/hnsw/hnsw_single.h"
+#include "tests_utils.h"
+#include "unit_test_utils.h"
+#include "mock_thread_pool.h"
+#include "VecSim/vec_sim_debug.h"
+#include "VecSim/spaces/L2/L2.h"
+#include "VecSim/spaces/IP/IP.h"
+
+class UINT8Test : public ::testing::Test {
+protected:
+    virtual void SetUp(HNSWParams &params) {
+        FAIL() << "UINT8Test::SetUp(HNSWParams) this method should be overriden";
+    }
+
+    virtual void SetUp(BFParams &params) {
+        FAIL() << "UINT8Test::SetUp(BFParams) this method should be overriden";
+    }
+
+    virtual void SetUp(TieredIndexParams &tiered_params) {
+        FAIL() << "UINT8Test::SetUp(TieredIndexParams) this method should be overriden";
+    }
+
+    virtual void TearDown() { VecSimIndex_Free(index); }
+
+    virtual const void *GetDataByInternalId(idType id) = 0;
+
+    template <typename algo_t>
+    algo_t *CastIndex() {
+        return dynamic_cast<algo_t *>(index);
+    }
+
+    template <typename algo_t>
+    algo_t *CastIndex(VecSimIndex *vecsim_index) {
+        return dynamic_cast<algo_t *>(vecsim_index);
+    }
+
+    virtual HNSWIndex<uint8_t, float> *CastToHNSW() { return CastIndex<HNSWIndex<uint8_t, float>>(); }
+
+    void PopulateRandomVector(uint8_t *out_vec) { test_utils::populate_uint8_vec(out_vec, dim); }
+    int PopulateRandomAndAddVector(size_t id, uint8_t *out_vec) {
+        PopulateRandomVector(out_vec);
+        return VecSimIndex_AddVector(index, out_vec, id);
+    }
+
+    virtual int GenerateAndAddVector(size_t id, uint8_t value = 1) {
+        // use unit_test_utils.h
+        return ::GenerateAndAddVector<uint8_t>(index, dim, id, value);
+    }
+
+    void GenerateVector(uint8_t *out_vec, uint8_t value) {
+        // use unit_test_utils.h
+        return ::GenerateVector<uint8_t>(out_vec, this->dim, value);
+    }
+
+    virtual int GenerateRandomAndAddVector(size_t id) {
+        uint8_t v[dim];
+        PopulateRandomVector(v);
+        return VecSimIndex_AddVector(index, v, id);
+    }
+
+    size_t GetValidVectorsCount() {
+        VecSimIndexInfo info = VecSimIndex_Info(index);
+        return info.commonInfo.indexLabelCount;
+    }
+
+    template <typename params_t>
+    void create_index_test(params_t index_params);
+    template <typename params_t>
+    void element_size_test(params_t index_params);
+    template <typename params_t>
+    void search_by_id_test(params_t index_params);
+    template <typename params_t>
+    void search_by_score_test(params_t index_params);
+    template <typename params_t>
+    void metrics_test(params_t index_params);
+    template <typename params_t>
+    void search_empty_index_test(params_t index_params);
+    template <typename params_t>
+    void test_override(params_t index_params);
+    template <typename params_t>
+    void test_range_query(params_t index_params);
+    template <typename params_t>
+    void test_batch_iterator_basic(params_t index_params);
+    template <typename params_t>
+    VecSimIndexInfo test_info(params_t index_params);
+    template <typename params_t>
+    void test_info_iterator(VecSimMetric metric);
+    template <typename params_t>
+    void get_element_neighbors(params_t index_params);
+
+    VecSimIndex *index;
+    size_t dim;
+};
+
+class UINT8HNSWTest : public UINT8Test {
+protected:
+    virtual void SetUp(HNSWParams &params) override {
+        params.type = VecSimType_UINT8;
+        VecSimParams vecsim_params = CreateParams(params);
+        index = VecSimIndex_New(&vecsim_params);
+        dim = params.dim;
+    }
+
+    virtual const void *GetDataByInternalId(idType id) override {
+        return CastIndex<HNSWIndex_Single<uint8_t, float>>()->getDataByInternalId(id);
+    }
+
+    virtual HNSWIndex<uint8_t, float> *CastToHNSW() override {
+        return CastIndex<HNSWIndex<uint8_t, float>>(index);
+    }
+
+    HNSWIndex<uint8_t, float> *CastToHNSW(VecSimIndex *new_index) {
+        return CastIndex<HNSWIndex<uint8_t, float>>(new_index);
+    }
+
+    void test_info(bool is_multi);
+    void test_serialization(bool is_multi);
+};
+
+class UINT8BruteForceTest : public UINT8Test {
+protected:
+    virtual void SetUp(BFParams &params) override {
+        params.type = VecSimType_UINT8;
+        VecSimParams vecsim_params = CreateParams(params);
+        index = VecSimIndex_New(&vecsim_params);
+        dim = params.dim;
+    }
+
+    virtual const void *GetDataByInternalId(idType id) override {
+        return CastIndex<BruteForceIndex_Single<uint8_t, float>>()->getDataByInternalId(id);
+    }
+
+    virtual HNSWIndex<uint8_t, float> *CastToHNSW() override {
+        ADD_FAILURE() << "UINT8BruteForceTest::CastToHNSW() this method should not be called";
+        return nullptr;
+    }
+
+    void test_info(bool is_multi);
+};
+
+class UINT8TieredTest : public UINT8Test {
+protected:
+    TieredIndexParams generate_tiered_params(HNSWParams &hnsw_params, size_t swap_job_threshold = 1,
+                                             size_t flat_buffer_limit = SIZE_MAX) {
+        hnsw_params.type = VecSimType_UINT8;
+        vecsim_hnsw_params = CreateParams(hnsw_params);
+        TieredIndexParams tiered_params = {
+            .jobQueue = &mock_thread_pool.jobQ,
+            .jobQueueCtx = mock_thread_pool.ctx,
+            .submitCb = tieredIndexMock::submit_callback,
+            .flatBufferLimit = flat_buffer_limit,
+            .primaryIndexParams = &vecsim_hnsw_params,
+            .specificParams = {TieredHNSWParams{.swapJobThreshold = swap_job_threshold}}};
+        return tiered_params;
+    }
+
+    virtual void SetUp(TieredIndexParams &tiered_params) override {
+        VecSimParams params = CreateParams(tiered_params);
+        index = VecSimIndex_New(&params);
+        dim = tiered_params.primaryIndexParams->algoParams.hnswParams.dim;
+
+        // Set the created tiered index in the index external context.
+        mock_thread_pool.ctx->index_strong_ref.reset(index);
+    }
+
+    virtual void SetUp(HNSWParams &hnsw_params) override {
+        TieredIndexParams tiered_params = generate_tiered_params(hnsw_params);
+        SetUp(tiered_params);
+    }
+
+    virtual void TearDown() override {}
+
+    virtual const void *GetDataByInternalId(idType id) override {
+        return CastIndex<BruteForceIndex<uint8_t, float>>(CastToBruteForce())
+            ->getDataByInternalId(id);
+    }
+
+    virtual HNSWIndex<uint8_t, float> *CastToHNSW() override {
+        auto tiered_index = dynamic_cast<TieredHNSWIndex<uint8_t, float> *>(index);
+        return tiered_index->getHNSWIndex();
+    }
+
+    virtual HNSWIndex_Single<uint8_t, float> *CastToHNSWSingle() {
+        return CastIndex<HNSWIndex_Single<uint8_t, float>>(CastToHNSW());
+    }
+
+    VecSimIndexAbstract<uint8_t, float> *CastToBruteForce() {
+        auto tiered_index = dynamic_cast<TieredHNSWIndex<uint8_t, float> *>(index);
+        return tiered_index->getFlatBufferIndex();
+    }
+
+    int GenerateRandomAndAddVector(size_t id) override {
+        uint8_t v[dim];
+        PopulateRandomVector(v);
+        int ret = VecSimIndex_AddVector(index, v, id);
+        mock_thread_pool.thread_iteration();
+        return ret;
+    }
+
+    int GenerateAndAddVector(size_t id, uint8_t value) override {
+        // use unit_test_utils.h
+        int ret = UINT8Test::GenerateAndAddVector(id, value);
+        mock_thread_pool.thread_iteration();
+        return ret;
+    }
+
+    void test_info(bool is_multi);
+    void test_info_iterator(VecSimMetric metric);
+
+    VecSimParams vecsim_hnsw_params;
+    tieredIndexMock mock_thread_pool;
+};
+
+/* ---------------------------- Create index tests ---------------------------- */
+
+template <typename params_t>
+void UINT8Test::create_index_test(params_t index_params) {
+    SetUp(index_params);
+
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    uint8_t vector[dim];
+    this->PopulateRandomVector(vector);
+    VecSimIndex_AddVector(index, vector, 0);
+
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 1);
+    ASSERT_EQ(index->getDistanceFrom_Unsafe(0, vector), 0);
+
+    ASSERT_NO_FATAL_FAILURE(
+        CompareVectors(static_cast<const uint8_t *>(this->GetDataByInternalId(0)), vector, dim));
+}
+
+TEST_F(UINT8HNSWTest, createIndex) {
+    HNSWParams params = {.dim = 40, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(create_index_test(params));
+    ASSERT_EQ(index->basicInfo().type, VecSimType_UINT8);
+    ASSERT_EQ(index->basicInfo().algo, VecSimAlgo_HNSWLIB);
+}
+
+TEST_F(UINT8BruteForceTest, createIndex) {
+    BFParams params = {.dim = 40};
+    EXPECT_NO_FATAL_FAILURE(create_index_test(params));
+    ASSERT_EQ(index->basicInfo().type, VecSimType_UINT8);
+    ASSERT_EQ(index->basicInfo().algo, VecSimAlgo_BF);
+}
+
+TEST_F(UINT8TieredTest, createIndex) {
+    HNSWParams params = {.dim = 40, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(create_index_test(params));
+    ASSERT_EQ(index->basicInfo().type, VecSimType_UINT8);
+    ASSERT_EQ(index->basicInfo().isTiered, true);
+}
+
+/* ---------------------------- Size Estimation tests ---------------------------- */
+
+template <typename params_t>
+void UINT8Test::element_size_test(params_t index_params) {
+    SetUp(index_params);
+
+    // Estimate the memory delta of adding a single vector that requires a full new block.
+    size_t estimation = EstimateElementSize(index_params) * DEFAULT_BLOCK_SIZE;
+    size_t before = index->getAllocationSize();
+    ASSERT_EQ(this->GenerateRandomAndAddVector(0), 1);
+    size_t actual = index->getAllocationSize() - before;
+
+    // We check that the actual size is within 1% of the estimation.
+    ASSERT_GE(estimation, actual * 0.99);
+    ASSERT_LE(estimation, actual * 1.01);
+}
+
+TEST_F(UINT8HNSWTest, elementSizeEstimation) {
+    size_t M = 64;
+
+    HNSWParams params = {.dim = 4, .M = M};
+    EXPECT_NO_FATAL_FAILURE(element_size_test(params));
+}
+
+TEST_F(UINT8BruteForceTest, elementSizeEstimation) {
+    BFParams params = {.dim = 4};
+    EXPECT_NO_FATAL_FAILURE(element_size_test(params));
+}
+
+TEST_F(UINT8TieredTest, elementSizeEstimation) {
+    size_t M = 64;
+    HNSWParams hnsw_params = {.dim = 4, .M = M};
+    VecSimParams vecsim_hnsw_params = CreateParams(hnsw_params);
+    TieredIndexParams tiered_params =
+        test_utils::CreateTieredParams(vecsim_hnsw_params, this->mock_thread_pool);
+    EXPECT_NO_FATAL_FAILURE(element_size_test(tiered_params));
+}
+
+/* ---------------------------- Functionality tests ---------------------------- */
+
+template <typename params_t>
+void UINT8Test::search_by_id_test(params_t index_params) {
+    SetUp(index_params);
+
+    size_t k = 11;
+    uint8_t n = 100;
+
+    for (uint8_t i = 0; i < n; i++) {
+        this->GenerateAndAddVector(i, i); // {i, i, i, i}
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    uint8_t query[dim];
+    this->GenerateVector(query, 50); // {50, 50, 50, 50}
+
+    // Vectors values are equal to the id, so the 11 closest vectors are 45, 46...50
+    // (closest), 51...55
+    static size_t expected_res_order[] = {45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55};
+    auto verify_res = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(id, expected_res_order[index]);    // results are sorted by ID
+        ASSERT_EQ(score, 4 * (50 - id) * (50 - id)); // L2 distance
+    };
+
+    runTopKSearchTest(index, query, k, verify_res, nullptr, BY_ID);
+}
+
+TEST_F(UINT8HNSWTest, searchByID) {
+    HNSWParams params = {.dim = 4, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(search_by_id_test(params));
+}
+
+TEST_F(UINT8BruteForceTest, searchByID) {
+    BFParams params = {.dim = 4};
+    EXPECT_NO_FATAL_FAILURE(search_by_id_test(params));
+}
+
+TEST_F(UINT8TieredTest, searchByID) {
+    HNSWParams params = {.dim = 4, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(search_by_id_test(params));
+}
+
+template <typename params_t>
+void UINT8Test::search_by_score_test(params_t index_params) {
+    SetUp(index_params);
+
+    size_t k = 11;
+    size_t n = 100;
+
+    for (size_t i = 0; i < n; i++) {
+        this->GenerateAndAddVector(i, i); // {i, i, i, i}
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    uint8_t query[dim];
+    this->GenerateVector(query, 50); // {50, 50, 50, 50}
+
+    // Vectors values are equal to the id, so the 11 closest vectors are
+    // 45, 46...50 (closest), 51...55
+    static size_t expected_res_order[] = {50, 49, 51, 48, 52, 47, 53, 46, 54, 45, 55};
+    auto verify_res = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(id, expected_res_order[index]);
+        ASSERT_EQ(score, 4 * (50 - id) * (50 - id)); // L2 distance
+    };
+
+    // Search by score
+    runTopKSearchTest(index, query, k, verify_res);
+}
+
+TEST_F(UINT8HNSWTest, searchByScore) {
+    HNSWParams params = {.dim = 4, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(search_by_score_test(params));
+}
+
+TEST_F(UINT8BruteForceTest, searchByScore) {
+    BFParams params = {.dim = 4};
+    EXPECT_NO_FATAL_FAILURE(search_by_score_test(params));
+}
+
+TEST_F(UINT8TieredTest, searchByScore) {
+    HNSWParams params = {.dim = 4, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(search_by_score_test(params));
+}
+
+template <typename params_t>
+void UINT8Test::metrics_test(params_t index_params) {
+    SetUp(index_params);
+    size_t n = 10;
+    VecSimMetric metric = index_params.metric;
+    double expected_score = 0;
+
+    auto verify_res = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(score, expected_score) << "failed at vector id:" << id;
+    };
+
+    for (size_t i = 0; i < n; i++) {
+        uint8_t vector[dim];
+        this->PopulateRandomAndAddVector(i, vector);
+
+        if (metric == VecSimMetric_Cosine) {
+            // compare with the norm stored in the index vector
+            const uint8_t *index_vector = static_cast<const uint8_t *>(this->GetDataByInternalId(i));
+            float index_vector_norm = *(reinterpret_cast<const float *>(index_vector + dim));
+            float vector_norm = spaces::IntegralType_ComputeNorm<uint8_t>(vector, dim);
+            ASSERT_EQ(index_vector_norm, vector_norm) << "wrong vector norm for vector id:" << i;
+        } else if (metric == VecSimMetric_IP) {
+            expected_score = UINT8_InnerProduct(vector, vector, dim);
+        }
+
+        // query index with k = 1 expect to get the vector
+        runTopKSearchTest(index, vector, 1, verify_res);
+        ASSERT_EQ(VecSimIndex_IndexSize(index), i + 1);
+    }
+}
+
+TEST_F(UINT8HNSWTest, CosineTest) {
+    HNSWParams params = {.dim = 40, .metric = VecSimMetric_Cosine, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(metrics_test(params));
+}
+TEST_F(UINT8HNSWTest, IPTest) {
+    HNSWParams params = {.dim = 40, .metric = VecSimMetric_IP, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE((metrics_test)(params));
+}
+TEST_F(UINT8HNSWTest, L2Test) {
+    HNSWParams params = {.dim = 40, .metric = VecSimMetric_L2, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(metrics_test(params));
+}
+
+TEST_F(UINT8BruteForceTest, CosineTest) {
+    BFParams params = {.dim = 40, .metric = VecSimMetric_Cosine};
+    EXPECT_NO_FATAL_FAILURE(metrics_test(params));
+}
+TEST_F(UINT8BruteForceTest, IPTest) {
+    BFParams params = {.dim = 40, .metric = VecSimMetric_IP};
+    EXPECT_NO_FATAL_FAILURE((metrics_test)(params));
+}
+TEST_F(UINT8BruteForceTest, L2Test) {
+    BFParams params = {.dim = 40, .metric = VecSimMetric_L2};
+    EXPECT_NO_FATAL_FAILURE(metrics_test(params));
+}
+
+TEST_F(UINT8TieredTest, CosineTest) {
+    HNSWParams params = {.dim = 40, .metric = VecSimMetric_Cosine, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(metrics_test(params));
+}
+TEST_F(UINT8TieredTest, IPTest) {
+    HNSWParams params = {.dim = 40, .metric = VecSimMetric_IP, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE((metrics_test)(params));
+}
+TEST_F(UINT8TieredTest, L2Test) {
+    HNSWParams params = {.dim = 40, .metric = VecSimMetric_L2, .M = 16, .efConstruction = 200};
+    EXPECT_NO_FATAL_FAILURE(metrics_test(params));
+}
+
+template <typename params_t>
+void UINT8Test::search_empty_index_test(params_t params) {
+    size_t n = 100;
+    size_t k = 11;
+
+    SetUp(params);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0);
+
+    uint8_t query[dim];
+    this->GenerateVector(query, 50); // {50, 50, 50, 50}
+
+    // We do not expect any results.
+    VecSimQueryReply *res = VecSimIndex_TopKQuery(index, query, k, NULL, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(res), 0);
+    VecSimQueryReply_Iterator *it = VecSimQueryReply_GetIterator(res);
+    ASSERT_EQ(VecSimQueryReply_IteratorNext(it), nullptr);
+    VecSimQueryReply_IteratorFree(it);
+    VecSimQueryReply_Free(res);
+
+    res = VecSimIndex_RangeQuery(index, query, 1.0, NULL, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(res), 0);
+    VecSimQueryReply_Free(res);
+
+    // Add some vectors and remove them all from index, so it will be empty again.
+    for (size_t i = 0; i < n; i++) {
+        this->GenerateAndAddVector(i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+    for (size_t i = 0; i < n; i++) {
+        VecSimIndex_DeleteVector(index, i);
+    }
+    // vectors marked as deleted will be included in VecSimIndex_IndexSize
+    ASSERT_EQ(GetValidVectorsCount(), 0);
+
+    // Again - we do not expect any results.
+    res = VecSimIndex_TopKQuery(index, query, k, NULL, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(res), 0);
+    it = VecSimQueryReply_GetIterator(res);
+    ASSERT_EQ(VecSimQueryReply_IteratorNext(it), nullptr);
+    VecSimQueryReply_IteratorFree(it);
+    VecSimQueryReply_Free(res);
+
+    res = VecSimIndex_RangeQuery(index, query, 1.0, NULL, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(res), 0);
+    VecSimQueryReply_Free(res);
+}
+
+TEST_F(UINT8HNSWTest, SearchEmptyIndex) {
+    HNSWParams params = {.dim = 4, .initialCapacity = 0};
+    EXPECT_NO_FATAL_FAILURE(search_empty_index_test(params));
+}
+
+TEST_F(UINT8BruteForceTest, SearchEmptyIndex) {
+    BFParams params = {.dim = 4, .initialCapacity = 0};
+    EXPECT_NO_FATAL_FAILURE(search_empty_index_test(params));
+}
+
+TEST_F(UINT8TieredTest, SearchEmptyIndex) {
+    HNSWParams params = {.dim = 4, .initialCapacity = 0};
+    EXPECT_NO_FATAL_FAILURE(search_empty_index_test(params));
+}
+
+template <typename params_t>
+void UINT8Test::test_override(params_t params) {
+    size_t n = 50;
+    size_t new_n = 120;
+    SetUp(params);
+
+    // Insert n vectors.
+    for (size_t i = 0; i < n; i++) {
+        ASSERT_EQ(GenerateAndAddVector(i, i), 1);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    // Override n vectors, the first 100 will be overwritten (deleted first).
+    for (size_t i = 0; i < n; i++) {
+        ASSERT_EQ(this->GenerateAndAddVector(i, i), 0);
+    }
+
+    // Add up to new_n vectors.
+    for (size_t i = n; i < new_n; i++) {
+        ASSERT_EQ(this->GenerateAndAddVector(i, i), 1);
+    }
+
+    uint8_t query[dim];
+    this->GenerateVector(query, new_n);
+
+    // Vectors values equals their id, so we expect the larger the id the closest it will be to the
+    // query.
+    auto verify_res = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(id, new_n - 1 - index) << "id: " << id << " score: " << score;
+        float diff = new_n - id;
+        float exp_score = 4 * diff * diff;
+        ASSERT_EQ(score, exp_score) << "id: " << id << " score: " << score;
+    };
+    runTopKSearchTest(index, query, 300, verify_res);
+}
+
+TEST_F(UINT8HNSWTest, Override) {
+    HNSWParams params = {
+        .dim = 4, .initialCapacity = 100, .M = 8, .efConstruction = 20, .efRuntime = 250};
+    EXPECT_NO_FATAL_FAILURE(test_override(params));
+}
+
+TEST_F(UINT8BruteForceTest, Override) {
+    BFParams params = {.dim = 4, .initialCapacity = 100};
+    EXPECT_NO_FATAL_FAILURE(test_override(params));
+}
+
+TEST_F(UINT8TieredTest, Override) {
+    HNSWParams params = {
+        .dim = 4, .initialCapacity = 100, .M = 8, .efConstruction = 20, .efRuntime = 250};
+    EXPECT_NO_FATAL_FAILURE(test_override(params));
+}
+
+template <typename params_t>
+void UINT8Test::test_range_query(params_t params) {
+    size_t n = 100;
+    SetUp(params);
+
+    uint8_t pivot_value = 1;
+    uint8_t pivot_vec[dim];
+    this->GenerateVector(pivot_vec, pivot_value);
+
+    uint8_t radius = 20;
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int16_t> dis(pivot_value - radius, pivot_value + radius);
+
+    // insert 20 vectors near a pivot vector.
+    size_t n_close = 20;
+    for (size_t i = 0; i < n_close; i++) {
+        uint8_t random_number = static_cast<uint8_t>(dis(gen));
+        this->GenerateAndAddVector(i, random_number);
+    }
+
+    uint8_t max_vec[dim];
+    GenerateVector(max_vec, pivot_value + radius);
+    float max_dist = UINT8_L2Sqr(pivot_vec, max_vec, dim);
+
+    // Add more vectors far from the pivot vector
+    for (size_t i = n_close; i < n; i++) {
+        uint8_t random_number = static_cast<uint8_t>(dis(gen));
+        GenerateAndAddVector(i, 50 + random_number);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    auto verify_res_by_score = [&](size_t id, double score, size_t index) {
+        ASSERT_LE(id, n_close - 1) << "score: " << score;
+        ASSERT_LE(score, max_dist);
+    };
+    size_t expected_num_results = n_close;
+
+    runRangeQueryTest(index, pivot_vec, max_dist, verify_res_by_score, expected_num_results,
+                      BY_SCORE);
+}
+
+TEST_F(UINT8HNSWTest, rangeQuery) {
+    HNSWParams params = {.dim = 4};
+    EXPECT_NO_FATAL_FAILURE(test_range_query(params));
+}
+
+TEST_F(UINT8BruteForceTest, rangeQuery) {
+    BFParams params = {.dim = 4};
+    EXPECT_NO_FATAL_FAILURE(test_range_query(params));
+}
+
+TEST_F(UINT8TieredTest, rangeQuery) {
+    HNSWParams params = {.dim = 4};
+    EXPECT_NO_FATAL_FAILURE(test_range_query(params));
+}
+
+/* ---------------------------- Batch iterator tests ---------------------------- */
+
+template <typename params_t>
+void UINT8Test::test_batch_iterator_basic(params_t params) {
+    SetUp(params);
+    size_t n = 100;
+
+    // For every i, add the vector (i,i,i,i) under the label i.
+    for (size_t i = 0; i < n; i++) {
+        ASSERT_EQ(this->GenerateAndAddVector(i, i), 1);
+    }
+
+    ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+    // Query for (n,n,n,n) vector (recall that n-1 is the largest id in te index).
+    uint8_t query[dim];
+    GenerateVector(query, n);
+
+    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(index, query, nullptr);
+    size_t iteration_num = 0;
+
+    // Get the 5 vectors whose ids are the maximal among those that hasn't been returned yet
+    // in every iteration. The results order should be sorted by their score (distance from the
+    // query vector), which means sorted from the largest id to the lowest.
+    size_t n_res = 5;
+    while (VecSimBatchIterator_HasNext(batchIterator)) {
+        std::vector<size_t> expected_ids(n_res);
+        for (size_t i = 0; i < n_res; i++) {
+            expected_ids[i] = (n - iteration_num * n_res - i - 1);
+        }
+        auto verify_res = [&](size_t id, double score, size_t index) {
+            ASSERT_EQ(expected_ids[index], id)
+                << "iteration_num: " << iteration_num << " index: " << index << " score: " << score;
+        };
+        runBatchIteratorSearchTest(batchIterator, n_res, verify_res);
+        iteration_num++;
+    }
+    ASSERT_EQ(iteration_num, n / n_res);
+    VecSimBatchIterator_Free(batchIterator);
+}
+
+TEST_F(UINT8HNSWTest, BatchIteratorBasic) {
+    HNSWParams params = {.dim = 4, .M = 8, .efConstruction = 20, .efRuntime = 100};
+    EXPECT_NO_FATAL_FAILURE(test_batch_iterator_basic(params));
+}
+
+TEST_F(UINT8BruteForceTest, BatchIteratorBasic) {
+    BFParams params = {.dim = 4};
+    EXPECT_NO_FATAL_FAILURE(test_batch_iterator_basic(params));
+}
+
+TEST_F(UINT8TieredTest, BatchIteratorBasic) {
+    HNSWParams params = {.dim = 4, .M = 8, .efConstruction = 20, .efRuntime = 100};
+    EXPECT_NO_FATAL_FAILURE(test_batch_iterator_basic(params));
+}
+
+/* ---------------------------- Info tests ---------------------------- */
+
+template <typename params_t>
+VecSimIndexInfo UINT8Test::test_info(params_t params) {
+    SetUp(params);
+    VecSimIndexInfo info = VecSimIndex_Info(index);
+    EXPECT_EQ(info.commonInfo.basicInfo.dim, params.dim);
+    EXPECT_EQ(info.commonInfo.basicInfo.isMulti, params.multi);
+    EXPECT_EQ(info.commonInfo.basicInfo.type, VecSimType_UINT8);
+    EXPECT_EQ(info.commonInfo.basicInfo.blockSize, DEFAULT_BLOCK_SIZE);
+    EXPECT_EQ(info.commonInfo.indexSize, 0);
+    EXPECT_EQ(info.commonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.commonInfo.memory, index->getAllocationSize());
+    EXPECT_EQ(info.commonInfo.basicInfo.metric, VecSimMetric_L2);
+
+    // Validate that basic info returns the right restricted info as well.
+    VecSimIndexBasicInfo s_info = VecSimIndex_BasicInfo(index);
+    EXPECT_EQ(info.commonInfo.basicInfo.algo, s_info.algo);
+    EXPECT_EQ(info.commonInfo.basicInfo.dim, s_info.dim);
+    EXPECT_EQ(info.commonInfo.basicInfo.blockSize, s_info.blockSize);
+    EXPECT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    EXPECT_EQ(info.commonInfo.basicInfo.isMulti, s_info.isMulti);
+    EXPECT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    EXPECT_EQ(info.commonInfo.basicInfo.isTiered, s_info.isTiered);
+
+    return info;
+}
+
+void UINT8HNSWTest::test_info(bool is_multi) {
+    HNSWParams params = {.dim = 128, .multi = is_multi};
+    VecSimIndexInfo info = UINT8Test::test_info(params);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
+
+    ASSERT_EQ(info.hnswInfo.M, HNSW_DEFAULT_M);
+    ASSERT_EQ(info.hnswInfo.efConstruction, HNSW_DEFAULT_EF_C);
+    ASSERT_EQ(info.hnswInfo.efRuntime, HNSW_DEFAULT_EF_RT);
+    ASSERT_DOUBLE_EQ(info.hnswInfo.epsilon, HNSW_DEFAULT_EPSILON);
+}
+TEST_F(UINT8HNSWTest, testInfoSingle) { test_info(false); }
+TEST_F(UINT8HNSWTest, testInfoMulti) { test_info(true); }
+
+void UINT8BruteForceTest::test_info(bool is_multi) {
+    BFParams params = {.dim = 128, .multi = is_multi};
+    VecSimIndexInfo info = UINT8Test::test_info(params);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_BF);
+}
+
+TEST_F(UINT8BruteForceTest, testInfoSingle) { test_info(false); }
+TEST_F(UINT8BruteForceTest, testInfoMulti) { test_info(true); }
+
+void UINT8TieredTest::test_info(bool is_multi) {
+    size_t bufferLimit = SIZE_MAX;
+    HNSWParams hnsw_params = {.dim = 128, .multi = is_multi};
+
+    VecSimIndexInfo info = UINT8Test::test_info(hnsw_params);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
+    VecSimIndexInfo frontendIndexInfo = CastToBruteForce()->info();
+    VecSimIndexInfo backendIndexInfo = CastToHNSW()->info();
+
+    compareCommonInfo(info.tieredInfo.frontendCommonInfo, frontendIndexInfo.commonInfo);
+    compareFlatInfo(info.tieredInfo.bfInfo, frontendIndexInfo.bfInfo);
+    compareCommonInfo(info.tieredInfo.backendCommonInfo, backendIndexInfo.commonInfo);
+    compareHNSWInfo(info.tieredInfo.backendInfo.hnswInfo, backendIndexInfo.hnswInfo);
+
+    EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                          backendIndexInfo.commonInfo.memory +
+                                          frontendIndexInfo.commonInfo.memory);
+    EXPECT_EQ(info.tieredInfo.backgroundIndexing, false);
+    EXPECT_EQ(info.tieredInfo.bufferLimit, bufferLimit);
+    EXPECT_EQ(info.tieredInfo.specificTieredBackendInfo.hnswTieredInfo.pendingSwapJobsThreshold, 1);
+
+    UINT8Test::GenerateAndAddVector(1, 1);
+    info = index->info();
+
+    EXPECT_EQ(info.commonInfo.indexSize, 1);
+    EXPECT_EQ(info.commonInfo.indexLabelCount, 1);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexSize, 0);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexSize, 1);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexLabelCount, 1);
+    EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                          info.tieredInfo.backendCommonInfo.memory +
+                                          info.tieredInfo.frontendCommonInfo.memory);
+    EXPECT_EQ(info.tieredInfo.backgroundIndexing, true);
+
+    mock_thread_pool.thread_iteration();
+    info = index->info();
+
+    EXPECT_EQ(info.commonInfo.indexSize, 1);
+    EXPECT_EQ(info.commonInfo.indexLabelCount, 1);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexSize, 1);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexLabelCount, 1);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexSize, 0);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                          info.tieredInfo.backendCommonInfo.memory +
+                                          info.tieredInfo.frontendCommonInfo.memory);
+    EXPECT_EQ(info.tieredInfo.backgroundIndexing, false);
+
+    if (is_multi) {
+        UINT8Test::GenerateAndAddVector(1, 1);
+        info = index->info();
+
+        EXPECT_EQ(info.commonInfo.indexSize, 2);
+        EXPECT_EQ(info.commonInfo.indexLabelCount, 1);
+        EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexSize, 1);
+        EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexLabelCount, 1);
+        EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexSize, 1);
+        EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexLabelCount, 1);
+        EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                              info.tieredInfo.backendCommonInfo.memory +
+                                              info.tieredInfo.frontendCommonInfo.memory);
+        EXPECT_EQ(info.tieredInfo.backgroundIndexing, true);
+    }
+
+    VecSimIndex_DeleteVector(index, 1);
+    info = index->info();
+
+    EXPECT_EQ(info.commonInfo.indexSize, 0);
+    EXPECT_EQ(info.commonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexSize, 0);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexSize, 0);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                          info.tieredInfo.backendCommonInfo.memory +
+                                          info.tieredInfo.frontendCommonInfo.memory);
+    EXPECT_EQ(info.tieredInfo.backgroundIndexing, false);
+}
+
+TEST_F(UINT8TieredTest, testInfoSingle) { test_info(false); }
+TEST_F(UINT8TieredTest, testInfoMulti) { test_info(true); }
+
+template <typename params_t>
+void UINT8Test::test_info_iterator(VecSimMetric metric) {
+    params_t params = {.dim = 128, .metric = metric};
+    SetUp(params);
+    VecSimIndexInfo info = VecSimIndex_Info(index);
+    VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(index);
+    VecSimAlgo algo = info.commonInfo.basicInfo.algo;
+    if (algo == VecSimAlgo_HNSWLIB) {
+        compareHNSWIndexInfoToIterator(info, infoIter);
+    } else if (algo == VecSimAlgo_BF) {
+        compareFlatIndexInfoToIterator(info, infoIter);
+    }
+    VecSimInfoIterator_Free(infoIter);
+}
+
+TEST_F(UINT8BruteForceTest, InfoIteratorCosine) {
+    test_info_iterator<BFParams>(VecSimMetric_Cosine);
+}
+TEST_F(UINT8BruteForceTest, InfoIteratorIP) { test_info_iterator<BFParams>(VecSimMetric_IP); }
+TEST_F(UINT8BruteForceTest, InfoIteratorL2) { test_info_iterator<BFParams>(VecSimMetric_L2); }
+TEST_F(UINT8HNSWTest, InfoIteratorCosine) { test_info_iterator<HNSWParams>(VecSimMetric_Cosine); }
+TEST_F(UINT8HNSWTest, InfoIteratorIP) { test_info_iterator<HNSWParams>(VecSimMetric_IP); }
+TEST_F(UINT8HNSWTest, InfoIteratorL2) { test_info_iterator<HNSWParams>(VecSimMetric_L2); }
+
+void UINT8TieredTest::test_info_iterator(VecSimMetric metric) {
+    size_t n = 100;
+    size_t d = 128;
+    HNSWParams params = {.dim = d, .metric = metric, .initialCapacity = n};
+    SetUp(params);
+    VecSimIndexInfo info = VecSimIndex_Info(index);
+    VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(index);
+    VecSimIndexInfo frontendIndexInfo = CastToBruteForce()->info();
+    VecSimIndexInfo backendIndexInfo = CastToHNSW()->info();
+    VecSimInfoIterator_Free(infoIter);
+}
+
+TEST_F(UINT8TieredTest, InfoIteratorCosine) { test_info_iterator(VecSimMetric_Cosine); }
+TEST_F(UINT8TieredTest, InfoIteratorIP) { test_info_iterator(VecSimMetric_IP); }
+TEST_F(UINT8TieredTest, InfoIteratorL2) { test_info_iterator(VecSimMetric_L2); }
+
+/* ---------------------------- HNSW specific tests ---------------------------- */
+
+void UINT8HNSWTest::test_serialization(bool is_multi) {
+    size_t dim = 4;
+    size_t n = 1001;
+    size_t n_labels[] = {n, 100};
+    size_t M = 8;
+    size_t ef = 10;
+    double epsilon = 0.004;
+    size_t blockSize = 20;
+    std::string multiToString[] = {"single", "multi_100labels_"};
+
+    HNSWParams params{.type = VecSimType_UINT8,
+                      .dim = dim,
+                      .metric = VecSimMetric_Cosine,
+                      .multi = is_multi,
+                      .initialCapacity = n,
+                      .blockSize = blockSize,
+                      .M = M,
+                      .efConstruction = ef,
+                      .efRuntime = ef,
+                      .epsilon = epsilon};
+    SetUp(params);
+
+    auto *hnsw_index = this->CastToHNSW();
+
+    uint8_t data[n * dim];
+
+    for (size_t i = 0; i < n * dim; i += dim) {
+        test_utils::populate_uint8_vec(data + i, dim, i);
+    }
+
+    for (size_t j = 0; j < n; ++j) {
+        VecSimIndex_AddVector(index, data + dim * j, j % n_labels[is_multi]);
+    }
+
+    auto file_name = std::string(getenv("ROOT")) + "/tests/unit/1k-d4-L2-M8-ef_c10_" +
+                     VecSimType_ToString(VecSimType_UINT8) + "_" + multiToString[is_multi] +
+                     ".hnsw_current_version";
+
+    // Save the index with the default version (V3).
+    hnsw_index->saveIndex(file_name);
+
+    // Fetch info after saving, as memory size change during saving.
+    VecSimIndexInfo info = VecSimIndex_Info(index);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(info.hnswInfo.M, M);
+    ASSERT_EQ(info.hnswInfo.efConstruction, ef);
+    ASSERT_EQ(info.hnswInfo.efRuntime, ef);
+    ASSERT_EQ(info.commonInfo.indexSize, n);
+    ASSERT_EQ(info.commonInfo.basicInfo.metric, VecSimMetric_Cosine);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, VecSimType_UINT8);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, dim);
+    ASSERT_EQ(info.commonInfo.indexLabelCount, n_labels[is_multi]);
+
+    // Load the index from the file.
+    VecSimIndex *serialized_index = HNSWFactory::NewIndex(file_name);
+    auto *serialized_hnsw_index = this->CastToHNSW(serialized_index);
+
+    // Verify that the index was loaded as expected.
+    ASSERT_TRUE(serialized_hnsw_index->checkIntegrity().valid_state);
+
+    VecSimIndexInfo info2 = VecSimIndex_Info(serialized_index);
+    ASSERT_EQ(info2.commonInfo.basicInfo.algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(info2.hnswInfo.M, M);
+    ASSERT_EQ(info2.commonInfo.basicInfo.isMulti, is_multi);
+    ASSERT_EQ(info2.commonInfo.basicInfo.blockSize, blockSize);
+    ASSERT_EQ(info2.hnswInfo.efConstruction, ef);
+    ASSERT_EQ(info2.hnswInfo.efRuntime, ef);
+    ASSERT_EQ(info2.commonInfo.indexSize, n);
+    ASSERT_EQ(info2.commonInfo.basicInfo.metric, VecSimMetric_Cosine);
+    ASSERT_EQ(info2.commonInfo.basicInfo.type, VecSimType_UINT8);
+    ASSERT_EQ(info2.commonInfo.basicInfo.dim, dim);
+    ASSERT_EQ(info2.commonInfo.indexLabelCount, n_labels[is_multi]);
+    ASSERT_EQ(info2.hnswInfo.epsilon, epsilon);
+
+    // Check the functionality of the loaded index.
+
+    uint8_t new_vec[dim];
+    this->PopulateRandomVector(new_vec);
+    VecSimIndex_AddVector(serialized_index, new_vec, n);
+    auto verify_res = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(id, n) << "score: " << score;
+        ASSERT_NEAR(score, 0.0, 1e-7);
+    };
+    runTopKSearchTest(serialized_index, new_vec, 1, verify_res);
+    VecSimIndex_DeleteVector(serialized_index, 1);
+
+    size_t n_per_label = n / n_labels[is_multi];
+    ASSERT_TRUE(serialized_hnsw_index->checkIntegrity().valid_state);
+    ASSERT_EQ(VecSimIndex_IndexSize(serialized_index), n + 1 - n_per_label);
+
+    // Clean up.
+    remove(file_name.c_str());
+    VecSimIndex_Free(serialized_index);
+}
+
+TEST_F(UINT8HNSWTest, SerializationCurrentVersion) { test_serialization(false); }
+
+TEST_F(UINT8HNSWTest, SerializationCurrentVersionMulti) { test_serialization(true); }
+
+template <typename params_t>
+void UINT8Test::get_element_neighbors(params_t params) {
+    size_t n = 0;
+
+    SetUp(params);
+    auto *hnsw_index = CastToHNSW();
+
+    // Add vectors until we have at least 2 vectors at level 1.
+    size_t vectors_in_higher_levels = 0;
+    while (vectors_in_higher_levels < 2) {
+        GenerateAndAddVector(n, n);
+        if (hnsw_index->getGraphDataByInternalId(n)->toplevel > 0) {
+            vectors_in_higher_levels++;
+        }
+        n++;
+    }
+    ASSERT_GE(n, 1) << "n: " << n;
+
+    // Go over all vectors and validate that the getElementNeighbors debug command returns the
+    // neighbors properly.
+    for (size_t id = 0; id < n; id++) {
+        ElementLevelData &cur = hnsw_index->getElementLevelData(id, 0);
+        int **neighbors_output;
+        VecSimDebug_GetElementNeighborsInHNSWGraph(index, id, &neighbors_output);
+        auto graph_data = hnsw_index->getGraphDataByInternalId(id);
+        for (size_t l = 0; l <= graph_data->toplevel; l++) {
+            auto &level_data = hnsw_index->getElementLevelData(graph_data, l);
+            auto &neighbours = neighbors_output[l];
+            ASSERT_EQ(neighbours[0], level_data.numLinks);
+            for (size_t j = 1; j <= neighbours[0]; j++) {
+                ASSERT_EQ(neighbours[j], level_data.links[j - 1]);
+            }
+        }
+        VecSimDebug_ReleaseElementNeighborsInHNSWGraph(neighbors_output);
+    }
+}
+
+TEST_F(UINT8HNSWTest, getElementNeighbors) {
+    HNSWParams params = {.dim = 4, .M = 20};
+    get_element_neighbors(params);
+}
+
+TEST_F(UINT8TieredTest, getElementNeighbors) {
+    HNSWParams params = {.dim = 4, .M = 20};
+    get_element_neighbors(params);
+}

--- a/tests/unit/test_uint8.cpp
+++ b/tests/unit/test_uint8.cpp
@@ -566,13 +566,13 @@ void UINT8Test::test_range_query(params_t params) {
     size_t n = 100;
     SetUp(params);
 
-    uint8_t pivot_value = 1;
+    uint8_t pivot_value = 46;
     uint8_t pivot_vec[dim];
     this->GenerateVector(pivot_vec, pivot_value);
 
     uint8_t radius = 20;
     std::mt19937 gen(42);
-    std::uniform_int_distribution<int16_t> dis(pivot_value - radius, pivot_value + radius);
+    std::uniform_int_distribution<uint16_t> dis(pivot_value - radius, pivot_value + radius);
 
     // insert 20 vectors near a pivot vector.
     size_t n_close = 20;
@@ -588,7 +588,7 @@ void UINT8Test::test_range_query(params_t params) {
     // Add more vectors far from the pivot vector
     for (size_t i = n_close; i < n; i++) {
         uint8_t random_number = static_cast<uint8_t>(dis(gen));
-        GenerateAndAddVector(i, 50 + random_number);
+        GenerateAndAddVector(i, pivot_value + (2 * radius) + random_number);
     }
     ASSERT_EQ(VecSimIndex_IndexSize(index), n);
 

--- a/tests/unit/test_uint8.cpp
+++ b/tests/unit/test_uint8.cpp
@@ -228,7 +228,7 @@ void UINT8Test::create_index_test(params_t index_params) {
     VecSimIndex_AddVector(index, vector, 0);
 
     ASSERT_EQ(VecSimIndex_IndexSize(index), 1);
-    ASSERT_EQ(index->getDistanceFrom_Unsafe(0, vector), 0);
+    ASSERT_FLOAT_EQ(index->getDistanceFrom_Unsafe(0, vector), 0);
 
     ASSERT_NO_FATAL_FAILURE(
         CompareVectors(static_cast<const uint8_t *>(this->GetDataByInternalId(0)), vector, dim));
@@ -314,8 +314,8 @@ void UINT8Test::search_by_id_test(params_t index_params) {
     // (closest), 51...55
     static size_t expected_res_order[] = {45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55};
     auto verify_res = [&](size_t id, double score, size_t index) {
-        ASSERT_EQ(id, expected_res_order[index]);    // results are sorted by ID
-        ASSERT_EQ(score, 4 * (50 - id) * (50 - id)); // L2 distance
+        ASSERT_EQ(id, expected_res_order[index]);          // results are sorted by ID
+        ASSERT_FLOAT_EQ(score, 4 * (50 - id) * (50 - id)); // L2 distance
     };
 
     runTopKSearchTest(index, query, k, verify_res, nullptr, BY_ID);
@@ -356,7 +356,7 @@ void UINT8Test::search_by_score_test(params_t index_params) {
     static size_t expected_res_order[] = {50, 49, 51, 48, 52, 47, 53, 46, 54, 45, 55};
     auto verify_res = [&](size_t id, double score, size_t index) {
         ASSERT_EQ(id, expected_res_order[index]);
-        ASSERT_EQ(score, 4 * (50 - id) * (50 - id)); // L2 distance
+        ASSERT_FLOAT_EQ(score, 4 * (50 - id) * (50 - id)); // L2 distance
     };
 
     // Search by score
@@ -386,7 +386,7 @@ void UINT8Test::metrics_test(params_t index_params) {
     double expected_score = 0;
 
     auto verify_res = [&](size_t id, double score, size_t index) {
-        ASSERT_EQ(score, expected_score) << "failed at vector id:" << id;
+        ASSERT_DOUBLE_EQ(score, expected_score) << "failed at vector id:" << id;
     };
 
     for (size_t i = 0; i < n; i++) {
@@ -398,7 +398,7 @@ void UINT8Test::metrics_test(params_t index_params) {
             auto *index_vector = static_cast<const uint8_t *>(this->GetDataByInternalId(i));
             float index_vector_norm = *(reinterpret_cast<const float *>(index_vector + dim));
             float vector_norm = spaces::IntegralType_ComputeNorm<uint8_t>(vector, dim);
-            ASSERT_EQ(index_vector_norm, vector_norm) << "wrong vector norm for vector id:" << i;
+            ASSERT_FLOAT_EQ(index_vector_norm, vector_norm) << "wrong norm for vector id:" << i;
         } else if (metric == VecSimMetric_IP) {
             expected_score = UINT8_InnerProduct(vector, vector, dim);
         }
@@ -541,7 +541,7 @@ void UINT8Test::test_override(params_t params) {
         ASSERT_EQ(id, new_n - 1 - index) << "id: " << id << " score: " << score;
         float diff = new_n - id;
         float exp_score = 4 * diff * diff;
-        ASSERT_EQ(score, exp_score) << "id: " << id << " score: " << score;
+        ASSERT_FLOAT_EQ(score, exp_score) << "id: " << id << " score: " << score;
     };
     runTopKSearchTest(index, query, 300, verify_res);
 }

--- a/tests/unit/test_uint8.cpp
+++ b/tests/unit/test_uint8.cpp
@@ -36,7 +36,9 @@ protected:
         return dynamic_cast<algo_t *>(vecsim_index);
     }
 
-    virtual HNSWIndex<uint8_t, float> *CastToHNSW() { return CastIndex<HNSWIndex<uint8_t, float>>(); }
+    virtual HNSWIndex<uint8_t, float> *CastToHNSW() {
+        return CastIndex<HNSWIndex<uint8_t, float>>();
+    }
 
     void PopulateRandomVector(uint8_t *out_vec) { test_utils::populate_uint8_vec(out_vec, dim); }
     int PopulateRandomAndAddVector(size_t id, uint8_t *out_vec) {
@@ -393,7 +395,7 @@ void UINT8Test::metrics_test(params_t index_params) {
 
         if (metric == VecSimMetric_Cosine) {
             // compare with the norm stored in the index vector
-            const uint8_t *index_vector = static_cast<const uint8_t *>(this->GetDataByInternalId(i));
+            auto *index_vector = static_cast<const uint8_t *>(this->GetDataByInternalId(i));
             float index_vector_norm = *(reinterpret_cast<const float *>(index_vector + dim));
             float vector_norm = spaces::IntegralType_ComputeNorm<uint8_t>(vector, dim);
             ASSERT_EQ(index_vector_norm, vector_norm) << "wrong vector norm for vector id:" << i;

--- a/tests/unit/test_uint8.cpp
+++ b/tests/unit/test_uint8.cpp
@@ -386,7 +386,7 @@ void UINT8Test::metrics_test(params_t index_params) {
     double expected_score = 0;
 
     auto verify_res = [&](size_t id, double score, size_t index) {
-        ASSERT_DOUBLE_EQ(score, expected_score) << "failed at vector id:" << id;
+        ASSERT_FLOAT_EQ(score, expected_score) << "failed at vector id:" << id;
     };
 
     for (size_t i = 0; i < n; i++) {

--- a/tests/unit/unit_test_utils.cpp
+++ b/tests/unit/unit_test_utils.cpp
@@ -9,7 +9,12 @@
 #include "VecSim/utils/vec_utils.h"
 #include "VecSim/memory/vecsim_malloc.h"
 #include "VecSim/utils/vecsim_stl.h"
+#include "VecSim/types/bfloat16.h"
+#include "VecSim/types/float16.h"
 #include "VecSim/algorithms/hnsw/hnsw_tiered.h"
+
+using bfloat16 = vecsim_types::bfloat16;
+using float16 = vecsim_types::float16;
 
 VecsimQueryType test_utils::query_types[4] = {QUERY_TYPE_NONE, QUERY_TYPE_KNN, QUERY_TYPE_HYBRID,
                                               QUERY_TYPE_RANGE};
@@ -46,6 +51,9 @@ VecSimQueryParams CreateQueryParams(const HNSWRuntimeParams &RuntimeParams) {
 
 static bool is_async_index(VecSimIndex *index) {
     return dynamic_cast<VecSimTieredIndex<float, float> *>(index) != nullptr ||
+           dynamic_cast<VecSimTieredIndex<bfloat16, float> *>(index) != nullptr ||
+           dynamic_cast<VecSimTieredIndex<float16, float> *>(index) != nullptr ||
+           dynamic_cast<VecSimTieredIndex<uint8_t, float> *>(index) != nullptr ||
            dynamic_cast<VecSimTieredIndex<int8_t, float> *>(index) != nullptr ||
            dynamic_cast<VecSimTieredIndex<double, double> *>(index) != nullptr;
 }
@@ -413,6 +421,13 @@ size_t CalcVectorDataSize(VecSimIndex *index, VecSimType data_type) {
             dynamic_cast<VecSimIndexAbstract<int8_t, float> *>(index);
         assert(abs_index &&
                "dynamic_cast failed: can't convert index to VecSimIndexAbstract<int8_t, float>");
+        return abs_index->getDataSize();
+    }
+    case VecSimType_UINT8: {
+        VecSimIndexAbstract<uint8_t, float> *abs_index =
+            dynamic_cast<VecSimIndexAbstract<uint8_t, float> *>(index);
+        assert(abs_index &&
+               "dynamic_cast failed: can't convert index to VecSimIndexAbstract<uint8_t, float>");
         return abs_index->getDataSize();
     }
     default:

--- a/tests/utils/tests_utils.h
+++ b/tests/utils/tests_utils.h
@@ -13,10 +13,22 @@ static void populate_int8_vec(int8_t *v, size_t dim, int seed = 1234) {
 
     // uniform_int_distribution doesn't support int8,
     // Define a distribution range for int8_t
-    std::uniform_int_distribution<int16_t> dis(-128, 127);
+    std::uniform_int_distribution<int16_t> dis(INT8_MIN, INT8_MAX);
 
     for (size_t i = 0; i < dim; i++) {
         v[i] = static_cast<int8_t>(dis(gen));
+    }
+}
+static void populate_uint8_vec(uint8_t *v, size_t dim, int seed = 1234) {
+
+    std::mt19937 gen(seed); // Mersenne Twister engine initialized with the fixed seed
+
+    // uniform_int_distribution doesn't support uint8,
+    // Define a distribution range for uint8_t
+    std::uniform_int_distribution<uint16_t> dis(0, UINT8_MAX);
+
+    for (size_t i = 0; i < dim; i++) {
+        v[i] = static_cast<uint8_t>(dis(gen));
     }
 }
 


### PR DESCRIPTION
## Implement support for new type `UINT8`

This PR follows the implementation of the `INT8` type and implements all the functionality required for the `UINT8` type.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
