### PR TITLE
fix artifact naming

### DIFF
--- a/.github/workflows/task-unit-test.yml
+++ b/.github/workflows/task-unit-test.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test:
-    name: Test ${{ inputs.container || inputs.env }}${{ inputs.container && format(' (on {0})', inputs.env) || '' }}
+    name: Test ${{ inputs.container && format('{0} (on {1})', inputs.container, inputs.env) || inputs.env }}
     runs-on: ${{ inputs.env }}
     container: ${{ inputs.container || null }}
     defaults:

--- a/.github/workflows/task-unit-test.yml
+++ b/.github/workflows/task-unit-test.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test:
-    name: Test ${{ inputs.container || inputs.env }}
+    name: Test ${{ inputs.container || inputs.env }}${{ inputs.container && format(' (on {0})', inputs.env) || '' }}
     runs-on: ${{ inputs.env }}
     container: ${{ inputs.container || null }}
     defaults:
@@ -31,51 +31,29 @@ jobs:
         if: ${{ inputs.pre-checkout-script }}
         shell: sh -l -eo pipefail {0}
         run: ${{ inputs.pre-checkout-script }}
-      - name: Check for node20 support
-        id: node20 # TODO: Remove this when node20 is supported on all platforms, or when we drop support for theses platforms
-        run: |
-          for os in amazonlinux:2 ubuntu:bionic; do
-              if [ "${{ inputs.container }}" = "$os" ]; then
-                  # https://github.com/actions/checkout/issues/1809
-                  # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
-                  echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
-                  echo "supported=false" >> $GITHUB_OUTPUT
-                  exit 0
-              fi
-          done
-          echo "supported=true" >> $GITHUB_OUTPUT
       - name: checkout
-        if: steps.node20.outputs.supported == 'true'
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || github.head_ref }}
-      - name: checkout (fallback)
-        if: steps.node20.outputs.supported == 'false'
-        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || github.head_ref }}
       - name: install dependencies
         run: .install/install_script.sh ${{ !inputs.container && 'sudo' || '' }}
+      - name: Set Artifact Name
+        # Artifact names have to be unique, so we base them on the environment.
+        # We also remove invalid characters from the name.
+        id: artifact-name
+        run: | # Invalid characters include: Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?
+          NAME="${{ inputs.container && format('{0} (on {1})', inputs.container, inputs.env) || inputs.env }} ${{ runner.arch }}"
+          NAME="$(echo $NAME | sed -e 's/[":\/\\<>\|*?]/_/g')" # Replace invalid characters with underscores
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+
       - name: unit tests
         run: make unit_test
       - name: valgrind
         if: ${{ inputs.run-valgrind }}
         run: make valgrind
-      - name: Set Artifact Names
-        # Artifact names have to be unique, so we base them on the environment.
-        # We also remove invalid characters from the name.
-        id: artifact-names
-        run: | # Invalid characters include: Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?
-          echo "name=$(echo "${{ inputs.container || inputs.env }} ${{ runner.arch }}" | sed -e 's/[":\/\\<>\|*?]/_/g')" >> $GITHUB_OUTPUT
       - name: Archive valgrind tests reports
-        if: ${{ inputs.run-valgrind && failure() && steps.node20.outputs.supported == 'true' }}
+        if: ${{ inputs.run-valgrind && failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: valgrind tests reports ${{ steps.artifact-names.outputs.name }}
-          path: bin/Linux-x86_64-debug/unit_tests/Testing/Temporary/
-      - name: Archive valgrind tests reports (fallback)
-        if: ${{ inputs.run-valgrind && failure() && steps.node20.outputs.supported == 'false' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: valgrind tests reports ${{ steps.artifact-names.outputs.name }}
+          name: valgrind tests reports on ${{ steps.artifact-name.outputs.name }}
           path: bin/Linux-x86_64-debug/unit_tests/Testing/Temporary/


### PR DESCRIPTION
## Changes in the pull request

1. Remove node16 workaround (not valid anymore)
2. Move artifact name generation to before running any test (so we don't skip running it)
3. Improve job and artifact names

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
