### PR TITLE
[MOD-8438] Micro-benchmarks for multi - int8 + benchmark ranges generalization 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,7 @@ on:
           - bm-basics-fp16-single
           - bm-basics-fp16-multi
           - bm-basics-int8-single
+          - bm-basics-int8-multi
           - bm-batch-iter-fp32-single
           - bm-batch-iter-fp32-multi
           - bm-batch-iter-fp64-single
@@ -29,6 +30,7 @@ on:
           - bm-batch-iter-fp16-single
           - bm-batch-iter-fp16-multi
           - bm-batch-iter-int8-single
+          - bm-batch-iter-int8-multi
           - bm-updated-fp32-single
           - bm-spaces
         description: 'Benchmarks set to run'

--- a/tests/benchmark/benchmarks.sh
+++ b/tests/benchmark/benchmarks.sh
@@ -3,13 +3,11 @@ BM_TYPE=$1;
 if [ -z "$BM_TYPE"  ] || [ "$BM_TYPE" = "benchmarks-all" ]; then
     for bm_class in basics batch_iterator; do
         for type in single multi; do
-            for data_type in fp32 fp64 bf16 fp16; do
+            for data_type in fp32 fp64 bf16 fp16 int8; do
                 echo ${bm_class}_${type}_${data_type};
             done
         done
     done
-    echo basics_single_int8
-    echo batch_iterator_single_int8
     echo updated_index_single_fp32
     echo spaces_fp32
     echo spaces_fp64
@@ -47,6 +45,8 @@ elif [ "$BM_TYPE" = "bm-basics-fp16-multi" ] ; then
     echo basics_multi_fp16
 elif [ "$BM_TYPE" = "bm-basics-int8-single" ] ; then
     echo basics_single_int8
+elif [ "$BM_TYPE" = "bm-basics-int8-multi" ] ; then
+    echo basics_multi_int8
 
 # Batch iterator benchmarks
 elif [ "$BM_TYPE" = "bm-batch-iter-fp32-single" ] ; then
@@ -67,6 +67,8 @@ elif [ "$BM_TYPE" = "bm-batch-iter-fp16-multi" ] ; then
     echo batch_iterator_multi_fp16
 elif [ "$BM_TYPE" = "bm-batch-iter-int8-single" ] ; then
     echo batch_iterator_single_int8
+elif [ "$BM_TYPE" = "bm-batch-iter-int8-multi" ] ; then
+    echo batch_iterator_multi_int8
 
 # Updated index benchmarks
 elif [ "$BM_TYPE" = "bm-updated-fp32-single" ] ; then

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -27,7 +27,9 @@ elif [ "$BM_TYPE" = "bm-basics-fp16-single" ] \
 then
     file_name="basic_fp16"
 elif [ "$BM_TYPE" = "bm-basics-int8-single" ] \
-|| [ "$BM_TYPE" = "bm-batch-iter-int8-single" ] 
+|| [ "$BM_TYPE" = "bm-basics-int8-multi" ] \
+|| [ "$BM_TYPE" = "bm-batch-iter-int8-single" ] \
+|| [ "$BM_TYPE" = "bm-batch-iter-int8-multi" ]
 then
     file_name="basic_int8"
 elif [ "$BM_TYPE" = "bm-updated-fp32-single" ]; then

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), bf16_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII, bf16_index_t);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF), bf16_index_t);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), bf16_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS,bf16_index_t);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), bf16_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), bf16_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF));
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), bf16_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW));
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), bf16_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII, bf16_index_t);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), bf16_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS,bf16_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), fp16_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII, fp16_index_t);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF), fp16_index_t);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp16_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS, fp16_index_t);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), fp16_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), fp16_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII, fp16_index_t);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp16_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS, fp16_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), fp16_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF));
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp16_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW));
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), fp32_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF));
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp32_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW));
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), fp32_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII, fp32_index_t);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF), fp32_index_t);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp32_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS, fp32_index_t);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), fp32_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), fp32_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII, fp32_index_t);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp32_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS, fp32_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), fp64_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII, fp64_index_t);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF), fp64_index_t);
 
 // Range HSNW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp64_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS, fp64_index_t);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), fp64_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), fp64_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII, fp64_index_t);
 
 // Range HSNW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp64_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS, fp64_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), fp64_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF));
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),DEFAULT_RANGE_RADII);
 
 // Range HSNW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp64_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW));
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),DEFAULT_RANGE_RADII,DEFAULT_RANGE_EPSILONS);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
@@ -5,6 +5,11 @@
 the file.
 ***************************************/
 
+// Larger Range query values are required for wikipedia dataset.
+// Current values in bm_vecsim_basics.h gives 0 results
+#define INT8_RANGE_RADII {50,65,80}
+#define INT8_RANGE_EPSILON {1,10,100}
+
 // Memory BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT), int8_index_t)
 (benchmark::State &st) { Memory_FLAT(st); }
@@ -48,12 +53,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), int8_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_INT8_BF(BM_FUNC_NAME(Range, BF));
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),INT8_RANGE_RADII);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), int8_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_INT8_HNSW(BM_FUNC_NAME(Range, HNSW));
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),INT8_RANGE_RADII,INT8_RANGE_EPSILON);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
@@ -48,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), int8_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),INT8_RANGE_RADII, int8_index_t);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF), int8_index_t);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), int8_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),INT8_RANGE_RADII,INT8_RANGE_EPSILON, int8_index_t);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), int8_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
@@ -5,11 +5,6 @@
 the file.
 ***************************************/
 
-// Larger Range query values are required for wikipedia dataset.
-// Current values in bm_vecsim_basics.h gives 0 results
-#define INT8_RANGE_RADII {50,65,80}
-#define INT8_RANGE_EPSILON {1,10,100}
-
 // Memory BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT), int8_index_t)
 (benchmark::State &st) { Memory_FLAT(st); }
@@ -53,12 +48,12 @@ REGISTER_TopK_Tiered(BM_VecSimCommon, BM_FUNC_NAME(TopK, Tiered));
 // Range BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, BF), int8_index_t)
 (benchmark::State &st) { Range_BF(st); }
-REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),INT8_RANGE_RADII);
+REGISTER_Range_BF(BM_FUNC_NAME(Range, BF),INT8_RANGE_RADII, int8_index_t);
 
 // Range HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), int8_index_t)
 (benchmark::State &st) { Range_HNSW(st); }
-REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),INT8_RANGE_RADII,INT8_RANGE_EPSILON);
+REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW),INT8_RANGE_RADII,INT8_RANGE_EPSILON, int8_index_t);
 
 // Tiered HNSW add/delete benchmarks
 REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);

--- a/tests/benchmark/bm_vecsim_basics.h
+++ b/tests/benchmark/bm_vecsim_basics.h
@@ -291,11 +291,11 @@ void BM_VecSimBasics<index_type_t>::Range_HNSW(benchmark::State &st) {
 
 // These macros are used to make sure the expansion of other macros happens when needed
 #define MACRO_EXPAND_AND_CONCATENATE(a, b) a##b
-#define MACRO_CONCATENATE(a, b) MACRO_EXPAND_AND_CONCATENATE(a, b)
+#define MACRO_CONCATENATE(a, b)            MACRO_EXPAND_AND_CONCATENATE(a, b)
 
 // The actual radius will be the given arg divided by 100, since arg must be an integer.
 #define REGISTER_Range_BF(BM_FUNC, TYPENAME)                                                       \
-    static void MACRO_CONCATENATE(BM_FUNC, _Args)(benchmark::internal::Benchmark* b) {             \
+    static void MACRO_CONCATENATE(BM_FUNC, _Args)(benchmark::internal::Benchmark * b) {            \
         for (int radius : benchmark_range<TYPENAME>::get_radii()) {                                \
             b->Args({radius});                                                                     \
         }                                                                                          \
@@ -310,9 +310,9 @@ void BM_VecSimBasics<index_type_t>::Range_HNSW(benchmark::State &st) {
 // The actual radius will be the given arg divided by 100, and the actual epsilon values
 // will be the given arg divided by 1000.
 #define REGISTER_Range_HNSW(BM_FUNC, TYPENAME)                                                     \
-    static void MACRO_CONCATENATE(BM_FUNC, _Args)(benchmark::internal::Benchmark* b) {             \
-        for (int radius : benchmark_range<TYPENAME>::get_radii() ) {                               \
-            for (int epsilon : benchmark_range<TYPENAME>::get_epsilons() ) {                       \
+    static void MACRO_CONCATENATE(BM_FUNC, _Args)(benchmark::internal::Benchmark * b) {            \
+        for (int radius : benchmark_range<TYPENAME>::get_radii()) {                                \
+            for (int epsilon : benchmark_range<TYPENAME>::get_epsilons()) {                        \
                 b->Args({radius, epsilon});                                                        \
             }                                                                                      \
         }                                                                                          \

--- a/tests/benchmark/bm_vecsim_basics.h
+++ b/tests/benchmark/bm_vecsim_basics.h
@@ -294,9 +294,9 @@ void BM_VecSimBasics<index_type_t>::Range_HNSW(benchmark::State &st) {
 #define MACRO_CONCATENATE(a, b) MACRO_EXPAND_AND_CONCATENATE(a, b)
 
 // The actual radius will be the given arg divided by 100, since arg must be an integer.
-#define REGISTER_Range_BF(BM_FUNC, RADII, TYPENAME)                                                          \
+#define REGISTER_Range_BF(BM_FUNC, TYPENAME)                                                       \
     static void MACRO_CONCATENATE(BM_FUNC, _Args)(benchmark::internal::Benchmark* b) {             \
-        for (int radius : benchmark_range<TYPENAME>::get_radii()) {                                                                 \
+        for (int radius : benchmark_range<TYPENAME>::get_radii()) {                                \
             b->Args({radius});                                                                     \
         }                                                                                          \
     }                                                                                              \
@@ -309,10 +309,10 @@ void BM_VecSimBasics<index_type_t>::Range_HNSW(benchmark::State &st) {
 // {radius*100, epsilon*1000}
 // The actual radius will be the given arg divided by 100, and the actual epsilon values
 // will be the given arg divided by 1000.
-#define REGISTER_Range_HNSW(BM_FUNC, RADII, EPSILONS, TYPENAME)                                              \
+#define REGISTER_Range_HNSW(BM_FUNC, TYPENAME)                                                     \
     static void MACRO_CONCATENATE(BM_FUNC, _Args)(benchmark::internal::Benchmark* b) {             \
-        for (int radius : benchmark_range<TYPENAME>::get_radii() ) {                                                                 \
-            for (int epsilon : benchmark_range<TYPENAME>::get_epsilons() ) {                                                         \
+        for (int radius : benchmark_range<TYPENAME>::get_radii() ) {                               \
+            for (int epsilon : benchmark_range<TYPENAME>::get_epsilons() ) {                       \
                 b->Args({radius, epsilon});                                                        \
             }                                                                                      \
         }                                                                                          \

--- a/tests/benchmark/bm_vecsim_basics.h
+++ b/tests/benchmark/bm_vecsim_basics.h
@@ -2,6 +2,7 @@
 #include <atomic>
 #include "bm_common.h"
 #include <chrono>
+#include "types_ranges.h"
 
 using namespace std::chrono;
 
@@ -292,13 +293,10 @@ void BM_VecSimBasics<index_type_t>::Range_HNSW(benchmark::State &st) {
 #define MACRO_EXPAND_AND_CONCATENATE(a, b) a##b
 #define MACRO_CONCATENATE(a, b) MACRO_EXPAND_AND_CONCATENATE(a, b)
 
-#define DEFAULT_RANGE_RADII {20,35,50}
-#define DEFAULT_RANGE_EPSILONS {1,10,11}
-
 // The actual radius will be the given arg divided by 100, since arg must be an integer.
-#define REGISTER_Range_BF(BM_FUNC, RADII)                                                          \
+#define REGISTER_Range_BF(BM_FUNC, RADII, TYPENAME)                                                          \
     static void MACRO_CONCATENATE(BM_FUNC, _Args)(benchmark::internal::Benchmark* b) {             \
-        for (int radius : RADII) {                                                                 \
+        for (int radius : benchmark_range<TYPENAME>::get_radii()) {                                                                 \
             b->Args({radius});                                                                     \
         }                                                                                          \
     }                                                                                              \
@@ -311,10 +309,10 @@ void BM_VecSimBasics<index_type_t>::Range_HNSW(benchmark::State &st) {
 // {radius*100, epsilon*1000}
 // The actual radius will be the given arg divided by 100, and the actual epsilon values
 // will be the given arg divided by 1000.
-#define REGISTER_Range_HNSW(BM_FUNC, RADII, EPSILONS)                                              \
+#define REGISTER_Range_HNSW(BM_FUNC, RADII, EPSILONS, TYPENAME)                                              \
     static void MACRO_CONCATENATE(BM_FUNC, _Args)(benchmark::internal::Benchmark* b) {             \
-        for (int radius : RADII) {                                                                 \
-            for (int epsilon : EPSILONS) {                                                         \
+        for (int radius : benchmark_range<TYPENAME>::get_radii() ) {                                                                 \
+            for (int epsilon : benchmark_range<TYPENAME>::get_epsilons() ) {                                                         \
                 b->Args({radius, epsilon});                                                        \
             }                                                                                      \
         }                                                                                          \

--- a/tests/benchmark/data/hnsw_indices/hnsw_indices_all.txt
+++ b/tests/benchmark/data/hnsw_indices/hnsw_indices_all.txt
@@ -25,5 +25,8 @@ https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/dbpedia-cosine-dim768-fp
 https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/fashion_images_multi_value-cosine-dim512-M64-efc512-fp16.hnsw_v3
 https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/fashion_images_multi_value-cosine-dim512-fp16-test_vectors.raw
 
-https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_single-cosine-dim1024-M64-efc512-int8.hnsw_v3 
+https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_single-cosine-dim1024-M64-efc512-int8.hnsw_v3
 https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_single-cosine-dim1024-int8-test_vectors.raw
+
+https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_multi-cosine-dim1024-M64-efc512-int8.hnsw_v3
+https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_multi-cosine-dim1024-int8-test_vectors.raw

--- a/tests/benchmark/data/hnsw_indices/hnsw_indices_basic_int8.txt
+++ b/tests/benchmark/data/hnsw_indices/hnsw_indices_basic_int8.txt
@@ -1,2 +1,5 @@
-https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_single-cosine-dim1024-M64-efc512-int8.hnsw_v3 
+https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_single-cosine-dim1024-M64-efc512-int8.hnsw_v3
 https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_single-cosine-dim1024-int8-test_vectors.raw
+
+https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_multi-cosine-dim1024-M64-efc512-int8.hnsw_v3
+https://dev.cto.redis.s3.amazonaws.com/VectorSimilarity/wipedia_multi-cosine-dim1024-int8-test_vectors.raw

--- a/tests/benchmark/data/scripts/single_to_multi.py
+++ b/tests/benchmark/data/scripts/single_to_multi.py
@@ -1,6 +1,6 @@
 # This file is a template file for generating multi datasets from single
 # Using HNSW-knn for labeling
-# In this version, it create a multi dataset from the "wipedia_single" dataset used for int8
+# In this version, it creates a multi dataset from the "wipedia_single" dataset used for int8
 # Refrain from pushing changes unless necessary
 import h5py
 import numpy as np
@@ -63,17 +63,17 @@ for vct,lbl in groups.items():
 
 for i in range(n_vectors):
     if i not in groups:
-        print("Error: Some vectors appear are missing!")
+        print("Error: Some vectors appear to be missing!")
         sys.exit(1)
 for i in range(n_labels):
     if i not in inverse_groups:
-        print("Error: Some labels appear are missing!")
+        print("Error: Some labels appear to be missing!")
         sys.exit(1)
     if len(inverse_groups[i]) <label_size:
         print("Error: Not all labels are full")
         sys.exit(1)
     if len(inverse_groups[i]) > label_size:
-        print(f"Error: some labels bigger then {label_size}")
+        print(f"Error: Some labels are bigger then {label_size}")
         sys.exit(1)
 
 

--- a/tests/benchmark/data/scripts/single_to_multi.py
+++ b/tests/benchmark/data/scripts/single_to_multi.py
@@ -1,0 +1,88 @@
+# This file is a template file for generating multi datasets from single
+# Using HNSW-knn for labeling
+# In this version, it create a multi dataset from the "wipedia_single" dataset used for int8
+# Refrain from pushing changes unless necessary
+import h5py
+import numpy as np
+import sys
+from tqdm import tqdm
+import hnswlib
+import os
+
+DATASET = 'wikipedia-1024_eng_v3_single'
+label_size = 10
+select_from_closest = label_size - 1  # Ensures label groups have `label_size` elements
+
+hdf5_output_file_name = f"{DATASET}.hdf5"
+
+# Load dataset
+with h5py.File(hdf5_output_file_name, "r") as f:
+    dataset = np.array(f['train'])  # Load into memory
+
+n_vectors, vector_dim = dataset.shape
+n_labels = n_vectors // label_size
+
+p = hnswlib.Index(space='cosine', dim=1024)
+p.init_index(max_elements=n_vectors, ef_construction=100, M=16)
+# Controlling the recall by setting ef:
+# higher ef leads to better accuracy, but slower search
+p.set_ef(64)
+
+# Set number of threads used during batch search/construction
+# By default using all available cores
+p.set_num_threads(4)
+
+p.add_items(dataset)
+
+
+available = np.ones(n_vectors, dtype=bool)
+result_arr = np.zeros((n_labels, label_size, vector_dim), dtype=np.float32)  # Store actual vectors
+
+groups = {}
+count = 0
+for i in tqdm(range(n_vectors)):
+    if i in groups:
+        continue
+    labels, distances = p.knn_query(dataset[i], k=label_size)
+    labels = labels[0]
+    if i not in labels:
+        labels[-1] = i
+    for lbl in labels:
+        groups[lbl] = count
+        p.mark_deleted(lbl)
+    result_arr[count] = dataset[labels]
+    count+=1
+    if count== n_labels:
+        break
+
+inverse_groups = {}
+for vct,lbl in groups.items():
+    if lbl not in inverse_groups:
+        inverse_groups[lbl] = []
+    inverse_groups[lbl].append(vct)
+
+for i in range(n_vectors):
+    if i not in groups:
+        print("Error: Some vectors appear are missing!")
+        sys.exit(1)
+for i in range(n_labels):
+    if i not in inverse_groups:
+        print("Error: Some labels appear are missing!")
+        sys.exit(1)
+    if len(inverse_groups[i]) <label_size:
+        print("Error: Not all labels are full")
+        sys.exit(1)
+    if len(inverse_groups[i]) > label_size:
+        print(f"Error: some labels bigger then {label_size}")
+        sys.exit(1)
+
+
+# Save to HDF5, replacing the single with multi
+output_file = DATASET.replace("_single", "_multi") + ".hdf5"
+with h5py.File(output_file, "w") as f:
+    f.create_dataset('train', data=result_arr)
+
+    # Copy 'test' dataset
+    with h5py.File(hdf5_output_file_name, "r") as f_in:
+        test_data = f_in['test'][:]
+    f.create_dataset('test', data=test_data)

--- a/tests/benchmark/run_files/bm_basics_multi_int8.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_int8.cpp
@@ -25,32 +25,6 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_ADD_LABEL_ASYNC          AddLabel_Async_Multi
 #define BM_DELETE_LABEL_ASYNC       DeleteLabel_Async_Multi
 
-// Larger Range query values are required for wikipedia dataset.
-// Current values in bm_vecsim_basics.h gives 0 results
-#define REGISTER_Range_INT8_HNSW(BM_FUNC)                                                          \
-    BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_FUNC)                                                 \
-        ->Args({50, 1})                                                                            \
-        ->Args({50, 10})                                                                           \
-        ->Args({50, 100})                                                                          \
-        ->Args({65, 1})                                                                            \
-        ->Args({65, 10})                                                                           \
-        ->Args({65, 100})                                                                          \
-        ->Args({80, 1})                                                                            \
-        ->Args({80, 10})                                                                           \
-        ->Args({80, 100})                                                                          \
-        ->ArgNames({"radiusX100", "epsilonX1000"})                                                 \
-        ->Iterations(10)                                                                           \
-        ->Unit(benchmark::kMillisecond)
-
-#define REGISTER_Range_INT8_BF(BM_FUNC)                                                            \
-    BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_FUNC)                                                 \
-        ->Arg(50)                                                                                  \
-        ->Arg(65)                                                                                  \
-        ->Arg(80)                                                                                  \
-        ->ArgName("radiusX100")                                                                    \
-        ->Iterations(10)                                                                           \
-        ->Unit(benchmark::kMillisecond)
-
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), int8_index_t, BruteForceIndex_Multi, int8_t,
                     float, VecSimAlgo_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), int8_index_t, HNSWIndex_Multi, int8_t, float,

--- a/tests/benchmark/run_files/bm_basics_multi_int8.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_int8.cpp
@@ -1,0 +1,62 @@
+#include "benchmark/bm_vecsim_basics.h"
+#include "VecSim/algorithms/brute_force/brute_force_multi.h"
+#include "VecSim/algorithms/hnsw/hnsw_multi.h"
+
+/**************************************
+  Basic tests for multi value index with int8 data type.
+***************************************/
+
+bool BM_VecSimGeneral::is_multi = true;
+
+size_t BM_VecSimGeneral::n_queries = 10000;
+size_t BM_VecSimGeneral::n_vectors = 1000000;
+size_t BM_VecSimGeneral::dim = 1024;
+size_t BM_VecSimGeneral::M = 64;
+size_t BM_VecSimGeneral::EF_C = 512;
+tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
+
+const char *BM_VecSimGeneral::hnsw_index_file =
+    "tests/benchmark/data/wipedia_multi-cosine-dim1024-M64-efc512-int8.hnsw_v3";
+const char *BM_VecSimGeneral::test_queries_file =
+    "tests/benchmark/data/wipedia_multi-cosine-dim1024-int8-test_vectors.raw";
+
+#define BM_FUNC_NAME(bm_func, algo) bm_func##_##algo##_Multi
+#define BM_ADD_LABEL                AddLabel_Multi
+#define BM_ADD_LABEL_ASYNC          AddLabel_Async_Multi
+#define BM_DELETE_LABEL_ASYNC       DeleteLabel_Async_Multi
+
+// Larger Range query values are required for wikipedia dataset.
+// Current values in bm_vecsim_basics.h gives 0 results
+#define REGISTER_Range_INT8_HNSW(BM_FUNC)                                                          \
+    BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_FUNC)                                                 \
+        ->Args({50, 1})                                                                            \
+        ->Args({50, 10})                                                                           \
+        ->Args({50, 100})                                                                          \
+        ->Args({65, 1})                                                                            \
+        ->Args({65, 10})                                                                           \
+        ->Args({65, 100})                                                                          \
+        ->Args({80, 1})                                                                            \
+        ->Args({80, 10})                                                                           \
+        ->Args({80, 100})                                                                          \
+        ->ArgNames({"radiusX100", "epsilonX1000"})                                                 \
+        ->Iterations(10)                                                                           \
+        ->Unit(benchmark::kMillisecond)
+
+#define REGISTER_Range_INT8_BF(BM_FUNC)                                                            \
+    BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_FUNC)                                                 \
+        ->Arg(50)                                                                                  \
+        ->Arg(65)                                                                                  \
+        ->Arg(80)                                                                                  \
+        ->ArgName("radiusX100")                                                                    \
+        ->Iterations(10)                                                                           \
+        ->Unit(benchmark::kMillisecond)
+
+DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), int8_index_t, BruteForceIndex_Multi, int8_t,
+                    float, VecSimAlgo_BF)
+DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), int8_index_t, HNSWIndex_Multi, int8_t, float,
+                    VecSimAlgo_HNSWLIB)
+DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), int8_index_t, TieredHNSWIndex, int8_t, float,
+                    VecSimAlgo_TIERED)
+#include "benchmark/bm_initialization/bm_basics_initialize_int8.h"
+
+BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_single_int8.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_int8.cpp
@@ -25,32 +25,6 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_ADD_LABEL_ASYNC          AddLabel_Async_Single
 #define BM_DELETE_LABEL_ASYNC       DeleteLabel_Async_Single
 
-// Larger Range query values are required for wikipedia dataset.
-// Current values in bm_vecsim_basics.h gives 0 results
-#define REGISTER_Range_INT8_HNSW(BM_FUNC)                                                          \
-    BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_FUNC)                                                 \
-        ->Args({50, 1})                                                                            \
-        ->Args({50, 10})                                                                           \
-        ->Args({50, 100})                                                                          \
-        ->Args({65, 1})                                                                            \
-        ->Args({65, 10})                                                                           \
-        ->Args({65, 100})                                                                          \
-        ->Args({80, 1})                                                                            \
-        ->Args({80, 10})                                                                           \
-        ->Args({80, 100})                                                                          \
-        ->ArgNames({"radiusX100", "epsilonX1000"})                                                 \
-        ->Iterations(10)                                                                           \
-        ->Unit(benchmark::kMillisecond)
-
-#define REGISTER_Range_INT8_BF(BM_FUNC)                                                            \
-    BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_FUNC)                                                 \
-        ->Arg(50)                                                                                  \
-        ->Arg(65)                                                                                  \
-        ->Arg(80)                                                                                  \
-        ->ArgName("radiusX100")                                                                    \
-        ->Iterations(10)                                                                           \
-        ->Unit(benchmark::kMillisecond)
-
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), int8_index_t, BruteForceIndex_Single, int8_t,
                     float, VecSimAlgo_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), int8_index_t, HNSWIndex_Single, int8_t, float,

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_int8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_int8.cpp
@@ -1,0 +1,22 @@
+#include "benchmark/bm_batch_iterator.h"
+
+bool BM_VecSimGeneral::is_multi = true;
+
+size_t BM_VecSimGeneral::n_queries = 10000;
+size_t BM_VecSimGeneral::n_vectors = 1000000;
+size_t BM_VecSimGeneral::dim = 1024;
+size_t BM_VecSimGeneral::M = 64;
+size_t BM_VecSimGeneral::EF_C = 512;
+size_t BM_VecSimGeneral::block_size = 1024;
+tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
+
+const char *BM_VecSimGeneral::hnsw_index_file =
+    "tests/benchmark/data/wipedia_multi-cosine-dim1024-M64-efc512-int8.hnsw_v3";
+const char *BM_VecSimGeneral::test_queries_file =
+    "tests/benchmark/data/wipedia_multi-cosine-dim1024-int8-test_vectors.raw";
+
+#define BM_FUNC_NAME(bm_func, algo) algo##_##bm_func##_Multi
+
+#include "benchmark/bm_initialization/bm_batch_initialize_int8.h"
+
+BENCHMARK_MAIN();

--- a/tests/benchmark/types_ranges.h
+++ b/tests/benchmark/types_ranges.h
@@ -2,9 +2,9 @@
 #include <array>
 #include "bm_definitions.h"
 
-#define DEFAULT_RANGE_RADII                                                                        
+#define DEFAULT_RANGE_RADII                                                                        \
     { 20, 35, 50 }
-#define DEFAULT_RANGE_EPSILONS                                                                     
+#define DEFAULT_RANGE_EPSILONS                                                                     \
     { 1, 10, 11 }
 
 // This template struct methods returns the default values for radii and epsilons
@@ -17,7 +17,7 @@ struct benchmark_range {
 
 // Larger Range query values are required for int8 wikipedia dataset.
 // Default values gives 0 results
-#define INT8_RANGE_RADII                                                                           
+#define INT8_RANGE_RADII                                                                           \
     { 50, 65, 80 }
 
 template <>

--- a/tests/benchmark/types_ranges.h
+++ b/tests/benchmark/types_ranges.h
@@ -1,9 +1,12 @@
+#pragma once
 #include <array>
 #include "bm_definitions.h"
 
 #define DEFAULT_RANGE_RADII {20,35,50}
 #define DEFAULT_RANGE_EPSILONS {1,10,11}
 
+// This template struct methods returns the default values for radii and epsilons
+// To specify different values for a certain type, use template specialization
 template<typename t>
 struct benchmark_range {
     static std::array<unsigned int,3> get_radii() {
@@ -14,8 +17,8 @@ struct benchmark_range {
     }
 };
 
-// Larger Range query values are required for wikipedia dataset.
-// Current values in bm_vecsim_basics.h gives 0 results
+// Larger Range query values are required for int8 wikipedia dataset.
+// Default values gives 0 results
 #define INT8_RANGE_RADII {50,65,80}
 
 template<>

--- a/tests/benchmark/types_ranges.h
+++ b/tests/benchmark/types_ranges.h
@@ -2,31 +2,26 @@
 #include <array>
 #include "bm_definitions.h"
 
-#define DEFAULT_RANGE_RADII {20,35,50}
-#define DEFAULT_RANGE_EPSILONS {1,10,11}
+#define DEFAULT_RANGE_RADII                                                                        \
+    { 20, 35, 50 }
+#define DEFAULT_RANGE_EPSILONS                                                                     \
+    { 1, 10, 11 }
 
 // This template struct methods returns the default values for radii and epsilons
 // To specify different values for a certain type, use template specialization
-template<typename t>
+template <typename t>
 struct benchmark_range {
-    static std::array<unsigned int,3> get_radii() {
-        return DEFAULT_RANGE_RADII;
-    }
-    static std::array<unsigned int,3> get_epsilons() {
-        return DEFAULT_RANGE_EPSILONS;
-    }
+    static std::array<unsigned int, 3> get_radii() { return DEFAULT_RANGE_RADII; }
+    static std::array<unsigned int, 3> get_epsilons() { return DEFAULT_RANGE_EPSILONS; }
 };
 
 // Larger Range query values are required for int8 wikipedia dataset.
 // Default values gives 0 results
-#define INT8_RANGE_RADII {50,65,80}
+#define INT8_RANGE_RADII                                                                           \
+    { 50, 65, 80 }
 
-template<>
+template <>
 struct benchmark_range<int8_index_t> {
-    static std::array<unsigned int,3> get_radii() {
-        return INT8_RANGE_RADII;
-    }
-    static std::array<unsigned int,3> get_epsilons() {
-        return DEFAULT_RANGE_EPSILONS;
-    }
+    static std::array<unsigned int, 3> get_radii() { return INT8_RANGE_RADII; }
+    static std::array<unsigned int, 3> get_epsilons() { return DEFAULT_RANGE_EPSILONS; }
 };

--- a/tests/benchmark/types_ranges.h
+++ b/tests/benchmark/types_ranges.h
@@ -2,9 +2,9 @@
 #include <array>
 #include "bm_definitions.h"
 
-#define DEFAULT_RANGE_RADII                                                                        \
+#define DEFAULT_RANGE_RADII                                                                        
     { 20, 35, 50 }
-#define DEFAULT_RANGE_EPSILONS                                                                     \
+#define DEFAULT_RANGE_EPSILONS                                                                     
     { 1, 10, 11 }
 
 // This template struct methods returns the default values for radii and epsilons
@@ -17,7 +17,7 @@ struct benchmark_range {
 
 // Larger Range query values are required for int8 wikipedia dataset.
 // Default values gives 0 results
-#define INT8_RANGE_RADII                                                                           \
+#define INT8_RANGE_RADII                                                                           
     { 50, 65, 80 }
 
 template <>

--- a/tests/benchmark/types_ranges.h
+++ b/tests/benchmark/types_ranges.h
@@ -1,0 +1,29 @@
+#include <array>
+#include "bm_definitions.h"
+
+#define DEFAULT_RANGE_RADII {20,35,50}
+#define DEFAULT_RANGE_EPSILONS {1,10,11}
+
+template<typename t>
+struct benchmark_range {
+    static std::array<unsigned int,3> get_radii() {
+        return DEFAULT_RANGE_RADII;
+    }
+    static std::array<unsigned int,3> get_epsilons() {
+        return DEFAULT_RANGE_EPSILONS;
+    }
+};
+
+// Larger Range query values are required for wikipedia dataset.
+// Current values in bm_vecsim_basics.h gives 0 results
+#define INT8_RANGE_RADII {50,65,80}
+
+template<>
+struct benchmark_range<int8_index_t> {
+    static std::array<unsigned int,3> get_radii() {
+        return INT8_RANGE_RADII;
+    }
+    static std::array<unsigned int,3> get_epsilons() {
+        return DEFAULT_RANGE_EPSILONS;
+    }
+};

--- a/tests/benchmark/types_ranges.h
+++ b/tests/benchmark/types_ranges.h
@@ -16,7 +16,7 @@ struct benchmark_range {
 };
 
 // Larger Range query values are required for int8 wikipedia dataset.
-// Default values gives 0 results
+// Default values give 0 results
 #define INT8_RANGE_RADII                                                                           \
     { 50, 65, 80 }
 


### PR DESCRIPTION
This PR change/adds the following:

- Using the apply function to pass benchmark (BF/HNSW) arguments, enabling iteration over radius and epsilon ranges instead of manually specifying combinations.

- Introducing a benchmark_range template struct for better generalization, with static functions returning appropriate arrays based on index data type (default provided if not specialized for type).

- Adding multi int8 benchmarking with a generated dataset.

- Including a single_to_multi Python script (used for generating the int8 multi dataset) for future  use.