### PR TITLE
new:

### DIFF
--- a/src/VecSim/CMakeLists.txt
+++ b/src/VecSim/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(VectorSimilarity ${VECSIM_LIBTYPE}
     index_factories/hnsw_factory.cpp
     index_factories/tiered_factory.cpp
     index_factories/index_factory.cpp
+    index_factories/components/components_factory.cpp
     algorithms/hnsw/visited_nodes_handler.cpp
     vec_sim.cpp
     vec_sim_debug.cpp

--- a/src/VecSim/index_factories/components/components_factory.cpp
+++ b/src/VecSim/index_factories/components/components_factory.cpp
@@ -1,0 +1,21 @@
+/*
+ *Copyright Redis Ltd. 2021 - present
+ *Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ *the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "VecSim/index_factories/components/components_factory.h"
+
+PreprocessorsContainerParams CreatePreprocessorsContainerParams(VecSimMetric metric, size_t dim,
+                                                                bool is_normalized,
+                                                                unsigned char alignment) {
+    // If the index metric is Cosine, and is_normalized == true, we will skip normalizing vectors
+    // and query blobs.
+    VecSimMetric pp_metric;
+    if (is_normalized && metric == VecSimMetric_Cosine) {
+        pp_metric = VecSimMetric_IP;
+    } else {
+        pp_metric = metric;
+    }
+    return {.metric = pp_metric, .dim = dim, .alignment = alignment};
+}

--- a/src/VecSim/index_factories/components/components_factory.h
+++ b/src/VecSim/index_factories/components/components_factory.h
@@ -12,6 +12,10 @@
 #include "VecSim/index_factories/components/preprocessors_factory.h"
 #include "VecSim/spaces/computer/calculator.h"
 
+PreprocessorsContainerParams CreatePreprocessorsContainerParams(VecSimMetric metric, size_t dim,
+                                                                bool is_normalized,
+                                                                unsigned char alignment);
+
 template <typename DataType, typename DistType>
 IndexComponents<DataType, DistType>
 CreateIndexComponents(std::shared_ptr<VecSimAllocator> allocator, VecSimMetric metric, size_t dim,
@@ -22,16 +26,8 @@ CreateIndexComponents(std::shared_ptr<VecSimAllocator> allocator, VecSimMetric m
     // Currently we have only one distance calculator implementation
     auto indexCalculator = new (allocator) DistanceCalculatorCommon<DistType>(allocator, distFunc);
 
-    // If the index metric is Cosine, and is_normalized == true, we will skip normalizing vectors
-    // and query blobs.
-    VecSimMetric pp_metric;
-    if (is_normalized && metric == VecSimMetric_Cosine) {
-        pp_metric = VecSimMetric_IP;
-    } else {
-        pp_metric = metric;
-    }
-    PreprocessorsContainerParams ppParams = {
-        .metric = pp_metric, .dim = dim, .alignment = alignment};
+    PreprocessorsContainerParams ppParams =
+        CreatePreprocessorsContainerParams(metric, dim, is_normalized, alignment);
     auto preprocessors = CreatePreprocessorsContainer<DataType>(allocator, ppParams);
 
     return {indexCalculator, preprocessors};

--- a/src/VecSim/spaces/computer/preprocessor_container.cpp
+++ b/src/VecSim/spaces/computer/preprocessor_container.cpp
@@ -27,6 +27,9 @@ PreprocessorsContainerAbstract::preprocessQuery(const void *original_blob,
 void PreprocessorsContainerAbstract::preprocessQueryInPlace(void *blob,
                                                             size_t processed_bytes_count) const {}
 
+void PreprocessorsContainerAbstract::preprocessStorageInPlace(void *blob,
+                                                              size_t processed_bytes_count) const {}
+
 MemoryUtils::unique_blob
 PreprocessorsContainerAbstract::maybeCopyToAlignedMem(const void *original_blob,
                                                       size_t blob_bytes_count) const {

--- a/src/VecSim/spaces/computer/preprocessor_container.h
+++ b/src/VecSim/spaces/computer/preprocessor_container.h
@@ -31,6 +31,8 @@ public:
 
     virtual void preprocessQueryInPlace(void *blob, size_t processed_bytes_count) const;
 
+    virtual void preprocessStorageInPlace(void *blob, size_t processed_bytes_count) const;
+
     unsigned char getAlignment() const { return alignment; }
 
 protected:
@@ -86,6 +88,8 @@ public:
                                              size_t processed_bytes_count) const override;
 
     void preprocessQueryInPlace(void *blob, size_t processed_bytes_count) const override;
+
+    void preprocessStorageInPlace(void *blob, size_t processed_bytes_count) const override;
 
 #ifdef BUILD_TESTS
     std::array<PreprocessorInterface *, n_preprocessors> getPreprocessors() const {
@@ -235,5 +239,17 @@ void MultiPreprocessorsContainer<DataType, n_preprocessors>::preprocessQueryInPl
             break;
         // modifies the memory in place
         pp->preprocessQueryInPlace(blob, processed_bytes_count, this->alignment);
+    }
+}
+
+template <typename DataType, size_t n_preprocessors>
+void MultiPreprocessorsContainer<DataType, n_preprocessors>::preprocessStorageInPlace(
+    void *blob, size_t processed_bytes_count) const {
+
+    for (auto pp : preprocessors) {
+        if (!pp)
+            break;
+        // modifies the memory in place
+        pp->preprocessStorageInPlace(blob, processed_bytes_count);
     }
 }

--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -32,6 +32,8 @@ public:
                                  size_t processed_bytes_count, unsigned char alignment) const = 0;
     virtual void preprocessQueryInPlace(void *original_blob, size_t processed_bytes_count,
                                         unsigned char alignment) const = 0;
+    virtual void preprocessStorageInPlace(void *original_blob,
+                                          size_t processed_bytes_count) const = 0;
 };
 
 template <typename DataType>
@@ -94,6 +96,11 @@ public:
 
     void preprocessQueryInPlace(void *blob, size_t processed_bytes_count,
                                 unsigned char alignment) const override {
+        assert(blob);
+        normalize_func(blob, this->dim);
+    }
+
+    void preprocessStorageInPlace(void *blob, size_t processed_bytes_count) const override {
         assert(blob);
         normalize_func(blob, this->dim);
     }

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -163,6 +163,13 @@ public:
      */
     void preprocessQueryInPlace(void *blob) const;
 
+    /**
+     * @brief Preprocess a blob for query in place.
+     *
+     * @param blob will be directly modified, not copied.
+     */
+    void preprocessStorageInPlace(void *blob) const;
+
     inline size_t getDim() const { return dim; }
     inline void setLastSearchMode(VecSearchMode mode) override { this->lastMode = mode; }
     inline bool isMultiValue() const { return isMulti; }
@@ -286,4 +293,9 @@ VecSimIndexAbstract<DataType, DistType>::preprocessForStorage(const void *origin
 template <typename DataType, typename DistType>
 void VecSimIndexAbstract<DataType, DistType>::preprocessQueryInPlace(void *blob) const {
     this->preprocessors->preprocessQueryInPlace(blob, this->dataSize);
+}
+
+template <typename DataType, typename DistType>
+void VecSimIndexAbstract<DataType, DistType>::preprocessStorageInPlace(void *blob) const {
+    this->preprocessors->preprocessStorageInPlace(blob, this->dataSize);
 }

--- a/tests/unit/test_components.cpp
+++ b/tests/unit/test_components.cpp
@@ -79,6 +79,12 @@ public:
     }
     void preprocessQueryInPlace(void *blob, size_t processed_bytes_count,
                                 unsigned char alignment) const override {}
+
+    void preprocessStorageInPlace(void *blob, size_t processed_bytes_count) const override {
+        assert(blob);
+        static_cast<DataType *>(blob)[0] += value_to_add_storage;
+    }
+
     void preprocessQuery(const void *original_blob, void *&blob, size_t processed_bytes_count,
                          unsigned char alignment) const override {
         /* do nothing*/
@@ -114,6 +120,7 @@ public:
                                 unsigned char alignment) const override {
         static_cast<DataType *>(blob)[0] += value_to_add_query;
     }
+    void preprocessStorageInPlace(void *blob, size_t processed_bytes_count) const override {}
     void preprocessQuery(const void *original_blob, void *&blob, size_t processed_bytes_count,
                          unsigned char alignment) const override {
         // If the blob was not allocated yet, allocate it.
@@ -165,6 +172,8 @@ public:
     }
     void preprocessQueryInPlace(void *blob, size_t processed_bytes_count,
                                 unsigned char alignment) const override {}
+
+    void preprocessStorageInPlace(void *blob, size_t processed_bytes_count) const override {}
     void preprocessQuery(const void *original_blob, void *&blob, size_t processed_bytes_count,
                          unsigned char alignment) const override {
         // If the blob was not allocated yet, allocate it.

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -4203,6 +4203,13 @@ public:
             static_cast<DataType *>(blob)[i] *= 2;
         }
     }
+
+    void preprocessStorageInPlace(void *blob, size_t processed_bytes_count) const override {
+        for (size_t i = 0; i < dim; i++) {
+            static_cast<DataType *>(blob)[i] *= 2;
+        }
+    }
+
     void preprocessQuery(const void *original_blob, void *&blob, size_t processed_bytes_count,
                          unsigned char alignment) const override {
         // If the blob was not allocated yet, allocate it.


### PR DESCRIPTION
* preprocessStorageInPlace
  - add to PreprocessorInterface, CosinePreprocessor (normalizes in place),
  - add to PreprocessorsContainerAbstract and MultiPreprocessorsContainer (chain preprocessStorageInPlace of its pp array)
  - add to vec_sim_index
  - add to tests: DummyStoragePreprocessor (add value_to_add_storage), DummyQueryPreprocessor(no-op), DummyMixedPreprocessor(no-op)
  - add to hnsw_tired_index:HNSWWithPreprocessor

WIP: add tests for preprocess in place

* components_factory.cpp: CreatePreprocessorsContainerParams

CreateIndexComponents->components_factory.cpp:
moved metric adjustments to the new CreatePreprocessorsContainerParams


**Describe the changes in the pull request**

A clear and concise description of what the PR is solving.

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
