### PR TITLE
[MOD-9303] Update GoogleTest tag to support CMake 4.0 compatibility

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,8 +36,8 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install Cmake   # Install Cmake using the project's fix version
-      run: chmod +x .install/install_cmake.sh && .install/install_cmake.sh sudo
+    # - name: Install Cmake   # Install Cmake using the project's fix version
+    #   run: chmod +x .install/install_cmake.sh && .install/install_cmake.sh sudo
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,10 +35,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-
-    # - name: Install Cmake   # Install Cmake using the project's fix version
-    #   run: chmod +x .install/install_cmake.sh && .install/install_cmake.sh sudo
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
   # jammy:
   #   uses: ./.github/workflows/task-unit-test.yml

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 jobs:
   # jammy:
   #   uses: ./.github/workflows/task-unit-test.yml

--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Without pinning cmake, it will install the latest version(>= 4.0)
-# This leads to to an error:
-# Compatibility with CMake < 3.5 has been removed from CMake.
-# For now we went with pinning cmake to 3.31.6 which is the version that exists in the current macOS image we use
-brew pin cmake
 brew update
 brew install make
 brew install coreutils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if(VECSIM_BUILD_TESTS)
 
 	FetchContent_Declare(
 		googletest
-		URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
+		URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
 	)
 
 	# For Windows: Prevent overriding the parent project's compiler/linker settings


### PR DESCRIPTION
CMake 4.0 removes support for versions earlier than 3.5, causing calls to `cmake_minimum_required()` or `cmake_policy()` with older policy versions to issue an error. 
To address this, the for `GoogleTest` has been updated to fetch **version 1.16.0** to ensure the `cmake_minimum_required` call is valid for CMake 3.5 and above, maintaining compatibility with CMake 4.0 and beyond.
