### PR TITLE
[SVS] Add Tiered SVS index implementation

### DIFF
--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -19,6 +19,7 @@ struct SVSIndexBase {
     virtual ~SVSIndexBase() = default;
     virtual int addVectors(const void *vectors_data, const labelType *labels, size_t n) = 0;
     virtual int deleteVectors(const labelType *labels, size_t n) = 0;
+    virtual bool isLabelExists(const labelType label) const = 0;
 };
 
 template <typename MetricType, typename DataType, size_t QuantBits, size_t ResidualBits = 0>
@@ -242,6 +243,10 @@ public:
           epsilon{getOrDefault(params.epsilon, 0.01)}, impl_{nullptr} {}
 
     ~SVSIndex() = default;
+
+    bool isLabelExists(const labelType label) const override {
+        return impl_ ? impl_->has_id(label) : false;
+    }
 
     size_t indexSize() const override { return impl_ ? impl_->size() : 0; }
 
@@ -467,6 +472,14 @@ public:
         this->lastMode =
             res ? (initial_check ? HYBRID_ADHOC_BF : HYBRID_BATCHES_TO_ADHOC_BF) : HYBRID_BATCHES;
         return res;
+    }
+
+    void runGC() override {
+        if (impl_) {
+            impl_->consolidate();
+            impl_->compact();
+        }
+        changes_num = 0;
     }
 
 #ifdef BUILD_TESTS

--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -166,7 +166,6 @@ protected:
 
     int addVectorsImpl(const void *vectors_data, const labelType *labels, size_t n) {
         if (n == 0) {
-            assert(false && "Empty batch of vectors"); // This case to be enabled for TieredSVS
             return 0;
         }
 

--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -20,6 +20,8 @@ struct SVSIndexBase {
     virtual int addVectors(const void *vectors_data, const labelType *labels, size_t n) = 0;
     virtual int deleteVectors(const labelType *labels, size_t n) = 0;
     virtual bool isLabelExists(const labelType label) const = 0;
+    virtual void setNumThreads(size_t numThreads) = 0;
+    virtual size_t getThreadPoolCapacity() const = 0;
 };
 
 template <typename MetricType, typename DataType, size_t QuantBits, size_t ResidualBits = 0>
@@ -53,6 +55,8 @@ protected:
     size_t search_window_size;
     double epsilon;
 
+    // SVS thread pool
+    VecSimSVSThreadPool threadpool_;
     // SVS Index implementation instance
     std::unique_ptr<impl_type> impl_;
 
@@ -104,8 +108,7 @@ protected:
     // Data should not be empty
     template <svs::data::ImmutableMemoryDataset Dataset>
     void initImpl(const Dataset &points, std::span<const labelType> ids) {
-        VecSimSVSThreadPool threadpool;
-        svs::threads::ThreadPoolHandle threadpool_handle{VecSimSVSThreadPool{threadpool}};
+        svs::threads::ThreadPoolHandle threadpool_handle{VecSimSVSThreadPool{threadpool_}};
         // Construct SVS index initial storage with compression if needed
         auto data = storage_traits_t::create_storage(points, this->blockSize, threadpool_handle,
                                                      this->getAllocator());
@@ -119,12 +122,12 @@ protected:
 
         // Construct initial Vamana Graph
         auto graph =
-            graph_builder_t::build_graph(parameters, data, distance, threadpool, entry_point,
+            graph_builder_t::build_graph(parameters, data, distance, threadpool_, entry_point,
                                          this->blockSize, this->getAllocator());
 
         // Create SVS MutableIndex instance
         impl_ = std::make_unique<impl_type>(std::move(graph), std::move(data), entry_point,
-                                            std::move(distance), ids, std::move(threadpool));
+                                            std::move(distance), ids, threadpool_);
 
         // Set SVS MutableIndex build parameters to be used in future updates
         impl_->set_construction_window_size(parameters.window_size);
@@ -240,7 +243,8 @@ public:
         : Base{abstractInitParams, components}, forcePreprocessing{force_preprocessing},
           changes_num{0}, buildParams{makeVamanaBuildParameters(params)},
           search_window_size{getOrDefault(params.search_window_size, 10)},
-          epsilon{getOrDefault(params.epsilon, 0.01)}, impl_{nullptr} {}
+          epsilon{getOrDefault(params.epsilon, 0.01)},
+          threadpool_{std::max(size_t{1}, params.num_threads)}, impl_{nullptr} {}
 
     ~SVSIndex() = default;
 
@@ -304,6 +308,10 @@ public:
     int deleteVectors(const labelType *labels, size_t n) override {
         return deleteVectorsImpl(labels, n);
     }
+
+    void setNumThreads(size_t numThreads) override { threadpool_.resize(numThreads); }
+
+    size_t getThreadPoolCapacity() const override { return threadpool_.capacity(); }
 
     double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
         if (!impl_ || !impl_->has_id(label)) {

--- a/src/VecSim/algorithms/svs/svs_tiered.h
+++ b/src/VecSim/algorithms/svs/svs_tiered.h
@@ -428,9 +428,11 @@ private:
         assert(index);
         // prevent parallel updates
         std::lock_guard<std::mutex> lock(index->updateJobMutex);
+        // Release the scheduled flag to allow scheduling again
+        index->indexUpdateScheduled.clear();
+        // Update the SVS index
         index->GetSVSIndex()->setNumThreads(availableThreads);
         index->updateSVSIndex();
-        index->indexUpdateScheduled.clear();
     }
 
 #ifdef BUILD_TESTS

--- a/src/VecSim/algorithms/svs/svs_tiered.h
+++ b/src/VecSim/algorithms/svs/svs_tiered.h
@@ -1,0 +1,548 @@
+/* TODO: change the copyright here */
+
+/*
+ *Copyright Redis Ltd. 2021 - present
+ *Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ *the Server Side Public License v1 (SSPLv1).
+ */
+
+/* TODO clean the includes */
+#pragma once
+#include "VecSim/algorithms/brute_force/brute_force_single.h"
+#include "VecSim/vec_sim_tiered_index.h"
+#include "VecSim/algorithms/svs/svs.h"
+#include "VecSim/index_factories/svs_factory.h"
+
+struct SVSIndexUpdateJob : public AsyncJob {
+    SVSIndexUpdateJob(std::shared_ptr<VecSimAllocator> allocator, JobCallback insertCb,
+                      VecSimIndex *index)
+        : AsyncJob(std::move(allocator), HNSW_INSERT_VECTOR_JOB, insertCb, index) {}
+};
+
+template <typename DataType>
+class TieredSVSIndex : public VecSimTieredIndex<DataType, float> {
+    using Self = TieredSVSIndex<DataType>;
+    using Base = VecSimTieredIndex<DataType, float>;
+    using flat_index_t = BruteForceIndex_Single<DataType, float>;
+    using backend_index_t = VecSimIndexAbstract<DataType, float>;
+    using svs_index_t = SVSIndexBase;
+
+    // Add: true, Delete: false
+    using journal_record = std::pair<labelType, bool>;
+    size_t updateJobThreshold;
+    std::vector<journal_record> journal;
+    std::shared_mutex journal_mutex;
+    std::atomic_flag indexUpdateScheduled = ATOMIC_FLAG_INIT;
+    std::mutex updateJobMutex;
+
+    /// <batch_iterator>
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    //  TieredSVS_BatchIterator //
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    class TieredSVS_BatchIterator : public VecSimBatchIterator {
+        // Defining spacial values for the svs_iterator field, to indicate if the iterator is
+        // uninitialized or depleted when we don't have a valid iterator.
+        static constexpr VecSimBatchIterator *depleted() {
+            constexpr VecSimBatchIterator *p = nullptr;
+            return p + 1;
+        }
+
+    private:
+        using Index = TieredSVSIndex<DataType>;
+        const Index *index;
+        VecSimQueryParams *queryParams;
+
+        VecSimQueryResultContainer flat_results;
+        VecSimQueryResultContainer svs_results;
+
+        VecSimBatchIterator *flat_iterator;
+        VecSimBatchIterator *svs_iterator;
+        std::shared_lock<std::shared_mutex> svs_lock;
+
+        // On single value indices, this set holds the IDs of the results that were returned from
+        // the flat buffer.
+        // On multi value indices, this set holds the IDs of all the results that were returned.
+        // The difference between the two cases is that on multi value indices, the same ID can
+        // appear in both indexes and results with different scores, and therefore we can't tell in
+        // advance when we expect a possibility of a duplicate.
+        // On single value indices, a duplicate may appear at the same batch (and we will handle it
+        // when merging the results) Or it may appear in a different batches, first from the flat
+        // buffer and then from the SVS, in the cases where a better result if found later in SVS
+        // because of the approximate nature of the algorithm.
+        vecsim_stl::unordered_set<labelType> returned_results_set;
+
+    private:
+        VecSimQueryReply *compute_current_batch(size_t n_res) {
+            // Merge results
+            // This call will update `svs_res` and `bf_res` to point to the end of the merged
+            // results. results.
+            auto batch_res = new VecSimQueryReply(allocator);
+            auto [from_svs, from_flat] =
+                merge_results<false>(batch_res->results, svs_results, flat_results, n_res);
+            merge_results<false>(batch_res->results, svs_results, flat_results, n_res);
+
+            // We're on a single-value index, update the set of results returned from the FLAT index
+            // before popping them, to prevent them to be returned from the SVS index in later
+            // batches. batches.
+            for (size_t i = 0; i < from_flat; ++i) {
+                returned_results_set.insert(flat_results[i].id);
+            }
+
+            // Update results
+            flat_results.erase(flat_results.begin(), flat_results.begin() + from_flat);
+            svs_results.erase(svs_results.begin(), svs_results.begin() + from_svs);
+
+            // Return current batch
+            return batch_res;
+        }
+
+        void filter_irrelevant_results(VecSimQueryResultContainer &results) {
+            // Filter out results that were already returned.
+            const auto it = std::remove_if(results.begin(), results.end(), [this](const auto &r) {
+                return returned_results_set.count(r.id) != 0;
+            });
+            results.erase(it, results.end());
+        }
+
+        void acquire_svs_iterator() {
+            if (svs_iterator == nullptr) {
+                this->index->mainIndexGuard.lock_shared();
+                svs_iterator = index->backendIndex->newBatchIterator(
+                    this->flat_iterator->getQueryBlob(), queryParams);
+            }
+        }
+
+        void release_svs_iterator() {
+            if (svs_iterator != nullptr && svs_iterator != depleted()) {
+                delete svs_iterator;
+                svs_iterator = nullptr;
+                this->index->mainIndexGuard.unlock_shared();
+            }
+        }
+
+        void handle_svs_depletion() {
+            assert(svs_iterator != depleted());
+            if (svs_iterator->isDepleted()) {
+                release_svs_iterator();
+                svs_iterator = depleted();
+            }
+        }
+
+    public:
+        TieredSVS_BatchIterator(void *query_vector, const Index *index, VecSimQueryParams *params,
+                                std::shared_ptr<VecSimAllocator> allocator)
+            : VecSimBatchIterator(query_vector, queryParams ? queryParams->timeoutCtx : nullptr,
+                                  std::move(allocator)),
+              index(index), queryParams(params ? new VecSimQueryParams{*params} : nullptr),
+              flat_results(this->allocator), svs_results(this->allocator),
+              flat_iterator(index->frontendIndex->newBatchIterator(query_vector, queryParams)),
+              svs_iterator(nullptr), svs_lock(index->mainIndexGuard, std::defer_lock),
+              returned_results_set(this->allocator) {}
+
+        ~TieredSVS_BatchIterator() {
+            release_svs_iterator();
+            delete flat_iterator;
+            if (queryParams) {
+                this->allocator->free_allocation(queryParams);
+            }
+        }
+
+        VecSimQueryReply *getNextResults(size_t n_res, VecSimQueryReply_Order order) override {
+            auto svs_code = VecSim_QueryReply_OK;
+
+            if (svs_iterator == nullptr) { // first call
+                // First call to getNextResults. The call to the BF iterator will include
+                // calculating all the distances and access the BF index. We take the lock on this
+                // call.
+                auto cur_flat_results = [this, n_res]() {
+                    std::shared_lock<std::shared_mutex> flat_lock{index->flatIndexGuard};
+                    return flat_iterator->getNextResults(n_res, BY_SCORE_THEN_ID);
+                }();
+                // This is also the only time `getNextResults` on the BF iterator can fail.
+                if (VecSim_OK != cur_flat_results->code) {
+                    return cur_flat_results;
+                }
+                flat_results.swap(cur_flat_results->results);
+                VecSimQueryReply_Free(cur_flat_results);
+                // We also take the lock on the main index on the first call to getNextResults, and
+                // we hold it until the iterator is depleted or freed.
+                acquire_svs_iterator();
+                auto cur_svs_results = svs_iterator->getNextResults(n_res, BY_SCORE_THEN_ID);
+                svs_code = cur_svs_results->code;
+                svs_results.swap(cur_svs_results->results);
+                VecSimQueryReply_Free(cur_svs_results);
+                handle_svs_depletion();
+            } else {
+                if (flat_results.size() < n_res && !flat_iterator->isDepleted()) {
+                    auto tail = flat_iterator->getNextResults(n_res - flat_results.size(),
+                                                              BY_SCORE_THEN_ID);
+                    flat_results.insert(flat_results.end(), tail->results.begin(),
+                                        tail->results.end());
+                    VecSimQueryReply_Free(tail);
+                }
+
+                while (svs_results.size() < n_res && svs_iterator != depleted() &&
+                       svs_code == VecSim_OK) {
+                    auto tail =
+                        svs_iterator->getNextResults(n_res - svs_results.size(), BY_SCORE_THEN_ID);
+                    svs_code =
+                        tail->code; // Set the svs_results code to the last `getNextResults` code.
+                    // New batch may contain better results than the previous batch, so we need to
+                    // merge. We don't expect duplications (hence the <false>), as the iterator
+                    // guarantees that no result is returned twice.
+                    VecSimQueryResultContainer cur_svs_results(this->allocator);
+                    merge_results<false>(cur_svs_results, svs_results, tail->results, n_res);
+                    VecSimQueryReply_Free(tail);
+                    svs_results.swap(cur_svs_results);
+                    filter_irrelevant_results(svs_results);
+                    handle_svs_depletion();
+                }
+            }
+
+            if (VecSim_OK != svs_code) {
+                return new VecSimQueryReply(this->allocator, svs_code);
+            }
+
+            VecSimQueryReply *batch;
+            batch = compute_current_batch(n_res);
+
+            if (order == BY_ID) {
+                sort_results_by_id(batch);
+            }
+            size_t batch_len = VecSimQueryReply_Len(batch);
+            this->updateResultsCount(batch_len);
+
+            return batch;
+        }
+
+        // DISCLAIMER: After the last batch, one of the iterators may report that it is not
+        // depleted, while all of its remaining results were already returned from the other
+        // iterator. (On single-value indexes, this can happen to the svs iterator only, on
+        // multi-value
+        //  indexes, this can happen to both iterators).
+        // The next call to `getNextResults` will return an empty batch, and then the iterators will
+        // correctly report that they are depleted.
+        bool isDepleted() override {
+            return flat_results.empty() && flat_iterator->isDepleted() && svs_results.empty() &&
+                   svs_iterator == depleted();
+        }
+
+        void reset() override {
+            release_svs_iterator();
+            resetResultsCount();
+            flat_iterator->reset();
+            svs_iterator = nullptr;
+            flat_results.clear();
+            svs_results.clear();
+            returned_results_set.clear();
+        }
+    };
+
+    /// <batch_iterator>
+
+#ifdef BUILD_TESTS
+public:
+#endif
+    flat_index_t *GetFlatIndex() {
+        auto result = dynamic_cast<flat_index_t *>(this->frontendIndex);
+        assert(result);
+        return result;
+    }
+
+    svs_index_t *GetSVSIndex() {
+        auto result = dynamic_cast<svs_index_t *>(this->backendIndex);
+        assert(result);
+        return result;
+    }
+
+#ifdef BUILD_TESTS
+public:
+    backend_index_t *GetBackendIndex() { return this->backendIndex; }
+    void submitSingleJob(AsyncJob *job) { Base::submitSingleJob(job); }
+#endif
+
+private:
+    void TakeSnapshot(std::set<labelType> *to_delete, std::set<labelType> *to_add) {
+        std::vector<journal_record> journal_snapshot;
+        journal_snapshot.reserve(this->updateJobThreshold * 2);
+
+        { // Get current journal and replace with empty
+            std::scoped_lock journal_lock{journal_mutex};
+            std::swap(this->journal, journal_snapshot);
+        }
+
+        for (auto &p : journal_snapshot) {
+            // `id` is the label and `add` is a boolean indicating addition (true) or deletion
+            // (false)
+            const auto [id, add] = p;
+            if (add) {
+                to_add->insert(id);
+            } else {
+                to_delete->insert(id);
+                to_add->erase(id); // add non-deleted only
+            }
+        }
+    }
+
+    static void updateSVSIndexWrapper(AsyncJob *job) {
+        auto index = dynamic_cast<TieredSVSIndex<DataType> *>(job->index);
+        assert(index);
+        // prevent parallel updates
+        std::lock_guard<std::mutex> lock(index->updateJobMutex);
+        index->indexUpdateScheduled.clear();
+        index->updateSVSIndex();
+        delete job;
+    }
+
+#ifdef BUILD_TESTS
+public:
+#endif
+    void scheduleSVSIndexUpdate() {
+        // do not schedule if scheduled already
+        if (indexUpdateScheduled.test_and_set()) {
+            return;
+        }
+
+        auto job =
+            new (this->allocator) SVSIndexUpdateJob{this->allocator, updateSVSIndexWrapper, this};
+        this->submitSingleJob(job);
+    }
+
+private:
+    void updateSVSIndex() {
+        std::set<labelType> to_delete;
+        std::set<labelType> to_add;
+        TakeSnapshot(&to_delete, &to_add);
+
+        std::vector<labelType> labels_to_delete;
+        std::vector<labelType> labels_to_add;
+        std::vector<DataType> vectors_to_add;
+
+        { // lock frontendIndex from modifications
+            std::shared_lock<std::shared_mutex> frontend_lock{this->flatIndexGuard};
+
+            auto flat_index = this->GetFlatIndex();
+            const size_t dim = flat_index->getDim();
+
+            // Update snapshot to sync with current frontend index status
+            TakeSnapshot(&to_delete, &to_add);
+
+            labels_to_delete.reserve(to_delete.size());
+            labels_to_add.reserve(to_add.size());
+            vectors_to_add.reserve(to_add.size() * dim);
+
+            labels_to_delete.insert(labels_to_delete.end(), to_delete.begin(), to_delete.end());
+            labels_to_add.insert(labels_to_add.end(), to_add.begin(), to_add.end());
+            for (auto label : labels_to_add) {
+                if (this->frontendIndex->isLabelExists(label)) {
+                    const auto id = flat_index->getIdOfLabel(label);
+                    if (id != INVALID_ID) {
+                        auto data = flat_index->getDataByInternalId(id);
+                        vectors_to_add.insert(vectors_to_add.end(), data, data + dim);
+                    }
+                }
+            }
+        } // release frontend index
+
+        { // lock both indicies for writing - these changes to be synchronized
+            std::scoped_lock lock(this->flatIndexGuard, this->mainIndexGuard);
+            auto svs_index = GetSVSIndex();
+            // TODO(rfsaliev) remove below assuming that vectors had to be deleted directly
+            auto deleted_num =
+                svs_index->deleteVectors(labels_to_delete.data(), labels_to_delete.size());
+            assert(deleted_num == 0);
+            assert(labels_to_add.size() == vectors_to_add.size() / this->frontendIndex->getDim());
+            svs_index->addVectors(vectors_to_add.data(), labels_to_add.data(),
+                                  labels_to_add.size());
+
+            // clean-up frontend index
+            { // avoid deleting modified vectors
+                std::shared_lock<std::shared_mutex> journal_lock{this->journal_mutex};
+                for (auto &p : this->journal) {
+                    to_add.erase(p.first);
+                }
+            }
+
+            // erase moved vectors
+            size_t deleted = 0;
+            for (auto &label : to_add) {
+                deleted += this->frontendIndex->deleteVector(label);
+            }
+            assert(deleted == to_add.size());
+        }
+    }
+
+public:
+    TieredSVSIndex(VecSimIndexAbstract<DataType, float> *svs_index, flat_index_t *bf_index,
+                   const TieredIndexParams &tiered_index_params,
+                   std::shared_ptr<VecSimAllocator> allocator)
+        : Base(svs_index, bf_index, tiered_index_params, allocator),
+          updateJobThreshold(
+              tiered_index_params.specificParams.tieredSVSParams.updateJobThreshold == 0
+                  ? DEFAULT_PENDING_SWAP_JOBS_THRESHOLD
+                  : std::min(tiered_index_params.specificParams.tieredSVSParams.updateJobThreshold,
+                             MAX_PENDING_SWAP_JOBS_THRESHOLD)) {
+        this->journal.reserve(this->updateJobThreshold * 2);
+        TIERED_LOG(VecSimCommonStrings::LOG_NOTICE_STRING, "TieredSVSIndex created");
+    }
+
+    int addVector(const void *blob, labelType label) override {
+        int ret = 0;
+        auto svs_index = GetSVSIndex();
+        if (this->getWriteMode() == VecSim_WriteInPlace) {
+            // Use the frontend parameters to manually prepare the blob for its transfer to the SVS
+            // index.
+            auto storage_blob = this->frontendIndex->preprocessForStorage(blob);
+            std::unique_lock<std::shared_mutex> svs_lock(this->mainIndexGuard);
+            return svs_index->addVectors(storage_blob.get(), &label, 1);
+        }
+        bool index_update_needed = false;
+        {
+            std::scoped_lock lock(this->flatIndexGuard, this->mainIndexGuard, this->journal_mutex);
+            ret = this->frontendIndex->addVector(blob, label);
+            ret -= svs_index->deleteVectors(&label, 1);
+            // The case when exists in both indicies (ret = 0-1) should not happen
+            // elsewhere search queries may return wrong result.
+            assert(ret >= 0 && "addVector: vector duplication in both indices");
+            journal.emplace_back(label, true);
+            index_update_needed = this->journal.size() >= this->updateJobThreshold;
+        }
+
+        if (index_update_needed) {
+            scheduleSVSIndexUpdate();
+        }
+
+        return ret;
+    }
+
+    int deleteVector(labelType label) override {
+        int ret = 0;
+        auto svs_index = GetSVSIndex();
+        if (this->getWriteMode() == VecSim_WriteInPlace) {
+            assert([&] {
+                std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
+                return !this->frontendIndex->isLabelExists(label);
+            }());
+
+            std::unique_lock<std::shared_mutex> svs_lock(this->mainIndexGuard);
+            return svs_index->deleteVectors(&label, 1);
+        }
+
+        bool label_exists = [&] {
+            std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
+            return this->frontendIndex->isLabelExists(label);
+        }();
+
+        bool index_update_needed = false;
+        if (label_exists) {
+            std::scoped_lock lock(this->flatIndexGuard, this->mainIndexGuard, this->journal_mutex);
+            if (this->frontendIndex->isLabelExists(label)) {
+                ret = this->frontendIndex->deleteVector(label);
+                assert(ret == 1 && "unexpected deleteVector result");
+            }
+            ret += svs_index->deleteVectors(&label, 1);
+            assert(ret < 2 && "deleteVector: vector duplication in both indices");
+            journal.emplace_back(label, false);
+            index_update_needed = this->journal.size() >= this->updateJobThreshold;
+        } else {
+            std::scoped_lock lock(this->mainIndexGuard);
+            ret += svs_index->deleteVectors(&label, 1);
+        }
+
+        if (index_update_needed) {
+            scheduleSVSIndexUpdate();
+        }
+        return ret;
+    }
+
+    size_t indexSize() const override {
+        std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
+        std::shared_lock<std::shared_mutex> main_lock(this->mainIndexGuard);
+        return this->frontendIndex->indexSize() + this->backendIndex->indexSize();
+    }
+
+    size_t indexLabelCount() const override {
+        std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
+        std::shared_lock<std::shared_mutex> main_lock(this->mainIndexGuard);
+        return this->frontendIndex->indexLabelCount() + this->backendIndex->indexLabelCount();
+    }
+    size_t indexCapacity() const override {
+        std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
+        std::shared_lock<std::shared_mutex> main_lock(this->mainIndexGuard);
+        return this->frontendIndex->indexCapacity() + this->backendIndex->indexCapacity();
+    }
+
+    double getDistanceFrom_Unsafe(labelType label, const void *blob) const override {
+        double flat_dist = std::numeric_limits<double>::quiet_NaN();
+        {
+            std::shared_lock<decltype(this->flatIndexGuard)> lock(this->flatIndexGuard);
+            flat_dist = this->frontendIndex->getDistanceFrom_Unsafe(label, blob);
+        }
+        if (!std::isnan(flat_dist)) {
+            return flat_dist;
+        } else {
+            std::shared_lock<decltype(this->mainIndexGuard)> lock(this->mainIndexGuard);
+            return this->backendIndex->getDistanceFrom_Unsafe(label, blob);
+        }
+    }
+
+    VecSimIndexInfo info() const override {
+        auto info = Base::info();
+        return info;
+    }
+
+    VecSimIndexBasicInfo basicInfo() const override {
+        VecSimIndexBasicInfo info = this->backendIndex->getBasicInfo();
+        info.blockSize = info.blockSize;
+        info.isTiered = true;
+        info.algo = VecSimAlgo_SVS;
+        return info;
+    }
+
+    VecSimInfoIterator *infoIterator() const override {
+        // VecSimIndexInfo info = this->info();
+        //  Get the base tiered fields.
+        auto *infoIterator = Base::infoIterator();
+
+        // TODO Add tiered SVS specific param.
+
+        return infoIterator;
+    }
+
+    VecSimBatchIterator *newBatchIterator(const void *queryBlob,
+                                          VecSimQueryParams *queryParams) const override {
+        size_t blobSize = this->backendIndex->getDim() * sizeof(DataType);
+        void *queryBlobCopy = this->allocator->allocate(blobSize);
+        memcpy(queryBlobCopy, queryBlob, blobSize);
+        return new (this->allocator)
+            TieredSVS_BatchIterator(queryBlobCopy, this, queryParams, this->allocator);
+    }
+
+    void setLastSearchMode(VecSearchMode mode) override {
+        return this->backendIndex->setLastSearchMode(mode);
+    }
+
+    void runGC() override {
+        // Run no more than pendingSwapJobsThreshold value jobs.
+        TIERED_LOG(VecSimCommonStrings::LOG_VERBOSE_STRING,
+                   "running asynchronous GC for tiered SVS index");
+        if (!indexUpdateScheduled.test_and_set()) {
+            auto job = new (this->allocator)
+                SVSIndexUpdateJob{this->allocator, updateSVSIndexWrapper, this};
+            updateSVSIndexWrapper(job);
+        }
+        std::unique_lock<std::shared_mutex> backend_lock{this->mainIndexGuard};
+        static_cast<VecSimIndexInterface *>(this->backendIndex)->runGC();
+    }
+
+    void acquireSharedLocks() override {
+        this->flatIndexGuard.lock_shared();
+        this->mainIndexGuard.lock_shared();
+    }
+
+    void releaseSharedLocks() override {
+        this->flatIndexGuard.unlock_shared();
+        this->mainIndexGuard.unlock_shared();
+    }
+};

--- a/src/VecSim/algorithms/svs/svs_tiered.h
+++ b/src/VecSim/algorithms/svs/svs_tiered.h
@@ -13,10 +13,138 @@
 #include "VecSim/algorithms/svs/svs.h"
 #include "VecSim/index_factories/svs_factory.h"
 
-struct SVSIndexUpdateJob : public AsyncJob {
-    SVSIndexUpdateJob(std::shared_ptr<VecSimAllocator> allocator, JobCallback insertCb,
-                      VecSimIndex *index)
-        : AsyncJob(std::move(allocator), HNSW_INSERT_VECTOR_JOB, insertCb, index) {}
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+class SVSMultiThreadJob : public AsyncJob {
+
+    // Thread reservation control block shared between all threads
+    // to reserve threads and wait for the job to be done
+    // actual reserved threads can be less than requested if timeout is reached
+    class ControlBlock {
+        const size_t requestedThreads;           // number of threads requested to reserve
+        const std::chrono::microseconds timeout; // timeout for threads reservation
+        size_t reservedThreads;                  // number of threads reserved
+        bool jobDone;
+        std::mutex mutex;
+        std::condition_variable cv;
+
+    public:
+        template <typename Rep, typename Period>
+        ControlBlock(size_t requested_threads,
+                     std::chrono::duration<Rep, Period> threads_wait_timeout)
+            : requestedThreads{requested_threads}, timeout{threads_wait_timeout},
+              reservedThreads{0}, jobDone{false} {}
+
+        // reserve a thread and wait for the job to be done
+        void reserveThreadAndWait() {
+            // count current thread
+            {
+                std::lock_guard lock{mutex};
+                ++reservedThreads;
+            }
+            cv.notify_one();
+            // wait for the job to be done
+            {
+                std::unique_lock lock{mutex};
+                cv.wait(lock, [&] { return jobDone; });
+            }
+        }
+
+        // wait for threads to be reserved
+        // return actual number of reserved threads
+        size_t waitForThreads() {
+            std::unique_lock lock{mutex};
+            ++reservedThreads; // count current thread
+            cv.wait_for(lock, timeout, [&] { return reservedThreads >= requestedThreads; });
+            return reservedThreads;
+        }
+
+        // mark the whole job as done
+        void markJobDone() {
+            {
+                std::lock_guard lock{mutex};
+                jobDone = true;
+            }
+            cv.notify_all();
+        }
+    };
+
+    // Job to reserve a thread and wait for the job to be done
+    class ReserveThreadJob : public AsyncJob {
+        std::weak_ptr<ControlBlock> controlBlock; // control block is owned by the main job and can
+                                                  // be destroyed before this job is started
+
+        static void Execute_impl(AsyncJob *job) {
+            auto *jobPtr = static_cast<ReserveThreadJob *>(job);
+            // if control block is already destroyed by the update job, just delete the job
+            auto controlBlock = jobPtr->controlBlock.lock();
+            if (controlBlock) {
+                controlBlock->reserveThreadAndWait();
+            }
+            delete job;
+        }
+
+    public:
+        ReserveThreadJob(std::shared_ptr<VecSimAllocator> allocator, JobType jobType,
+                         VecSimIndex *index, std::weak_ptr<ControlBlock> controlBlock)
+            : AsyncJob(std::move(allocator), jobType, Execute_impl, index),
+              controlBlock(std::move(controlBlock)) {}
+    };
+
+    using task_type = std::function<void(VecSimIndex *, size_t)>;
+    task_type task;
+    std::shared_ptr<ControlBlock> controlBlock;
+
+    static void Execute_impl(AsyncJob *job) {
+        auto *jobPtr = static_cast<SVSMultiThreadJob *>(job);
+        auto controlBlock = jobPtr->controlBlock;
+        size_t num_threads = 1;
+        if (controlBlock) {
+            num_threads = controlBlock->waitForThreads();
+        }
+        assert(num_threads > 0);
+        jobPtr->task(jobPtr->index, num_threads);
+        if (controlBlock) {
+            jobPtr->controlBlock->markJobDone();
+        }
+        delete job;
+    }
+
+    SVSMultiThreadJob(std::shared_ptr<VecSimAllocator> allocator, JobType jobType,
+                      task_type callback, VecSimIndex *index,
+                      std::shared_ptr<ControlBlock> controlBlock)
+        : AsyncJob(std::move(allocator), jobType, Execute_impl, index), task(std::move(callback)),
+          controlBlock(std::move(controlBlock)) {}
+
+public:
+    template <typename Rep, typename Period>
+    static vecsim_stl::vector<AsyncJob *>
+    createJobs(const std::shared_ptr<VecSimAllocator> &allocator, JobType jobType,
+               std::function<void(VecSimIndex *, size_t)> callback, VecSimIndex *index,
+               size_t num_threads, std::chrono::duration<Rep, Period> threads_wait_timeout) {
+        assert(num_threads > 0);
+        std::shared_ptr<ControlBlock> controlBlock =
+            num_threads == 1 ? nullptr
+                             : std::make_shared<ControlBlock>(num_threads, threads_wait_timeout);
+
+        vecsim_stl::vector<AsyncJob *> jobs(num_threads, allocator);
+        jobs[0] =
+            new (allocator) SVSMultiThreadJob(allocator, jobType, callback, index, controlBlock);
+        for (size_t i = 1; i < num_threads; ++i) {
+            jobs[i] = new (allocator) ReserveThreadJob(allocator, jobType, index, controlBlock);
+        }
+        return jobs;
+    }
+
+#ifdef BUILD_TESTS
+public:
+    static constexpr size_t estimateSize(size_t num_threads) {
+        return sizeof(SVSMultiThreadJob) + (num_threads - 1) * sizeof(ReserveThreadJob);
+    }
+#endif
 };
 
 template <typename DataType>
@@ -30,6 +158,7 @@ class TieredSVSIndex : public VecSimTieredIndex<DataType, float> {
     // Add: true, Delete: false
     using journal_record = std::pair<labelType, bool>;
     size_t updateJobThreshold;
+    size_t updateJobWaitTime;
     std::vector<journal_record> journal;
     std::shared_mutex journal_mutex;
     std::atomic_flag indexUpdateScheduled = ATOMIC_FLAG_INIT;
@@ -130,22 +259,30 @@ class TieredSVSIndex : public VecSimTieredIndex<DataType, float> {
         }
 
     public:
-        TieredSVS_BatchIterator(void *query_vector, const Index *index, VecSimQueryParams *params,
+        TieredSVS_BatchIterator(void *query_vector, const Index *index,
+                                VecSimQueryParams *queryParams,
                                 std::shared_ptr<VecSimAllocator> allocator)
             : VecSimBatchIterator(query_vector, queryParams ? queryParams->timeoutCtx : nullptr,
                                   std::move(allocator)),
-              index(index), queryParams(params ? new VecSimQueryParams{*params} : nullptr),
-              flat_results(this->allocator), svs_results(this->allocator),
+              index(index), flat_results(this->allocator), svs_results(this->allocator),
               flat_iterator(index->frontendIndex->newBatchIterator(query_vector, queryParams)),
               svs_iterator(nullptr), svs_lock(index->mainIndexGuard, std::defer_lock),
-              returned_results_set(this->allocator) {}
+              returned_results_set(this->allocator) {
+            if (queryParams) {
+                this->queryParams =
+                    (VecSimQueryParams *)this->allocator->allocate(sizeof(VecSimQueryParams));
+                *this->queryParams = *queryParams;
+            } else {
+                this->queryParams = nullptr;
+            }
+        }
 
         ~TieredSVS_BatchIterator() {
             release_svs_iterator();
-            delete flat_iterator;
             if (queryParams) {
                 this->allocator->free_allocation(queryParams);
             }
+            delete flat_iterator;
         }
 
         VecSimQueryReply *getNextResults(size_t n_res, VecSimQueryReply_Order order) override {
@@ -260,6 +397,7 @@ public:
 public:
     backend_index_t *GetBackendIndex() { return this->backendIndex; }
     void submitSingleJob(AsyncJob *job) { Base::submitSingleJob(job); }
+    void submitJobs(vecsim_stl::vector<AsyncJob *> &jobs) { Base::submitJobs(jobs); }
 #endif
 
 private:
@@ -285,14 +423,14 @@ private:
         }
     }
 
-    static void updateSVSIndexWrapper(AsyncJob *job) {
-        auto index = dynamic_cast<TieredSVSIndex<DataType> *>(job->index);
+    static void updateSVSIndexWrapper(VecSimIndex *idx, size_t availableThreads) {
+        auto index = static_cast<TieredSVSIndex<DataType> *>(idx);
         assert(index);
         // prevent parallel updates
         std::lock_guard<std::mutex> lock(index->updateJobMutex);
-        index->indexUpdateScheduled.clear();
+        index->GetSVSIndex()->setNumThreads(availableThreads);
         index->updateSVSIndex();
-        delete job;
+        index->indexUpdateScheduled.clear();
     }
 
 #ifdef BUILD_TESTS
@@ -304,9 +442,11 @@ public:
             return;
         }
 
-        auto job =
-            new (this->allocator) SVSIndexUpdateJob{this->allocator, updateSVSIndexWrapper, this};
-        this->submitSingleJob(job);
+        auto total_threads = this->GetSVSIndex()->getThreadPoolCapacity();
+        auto jobs = SVSMultiThreadJob::createJobs(this->allocator, HNSW_INSERT_VECTOR_JOB,
+                                                  updateSVSIndexWrapper, this, total_threads,
+                                                  std::chrono::microseconds(updateJobWaitTime));
+        this->submitJobs(jobs);
     }
 
 private:
@@ -382,9 +522,12 @@ public:
               tiered_index_params.specificParams.tieredSVSParams.updateJobThreshold == 0
                   ? DEFAULT_PENDING_SWAP_JOBS_THRESHOLD
                   : std::min(tiered_index_params.specificParams.tieredSVSParams.updateJobThreshold,
-                             MAX_PENDING_SWAP_JOBS_THRESHOLD)) {
+                             MAX_PENDING_SWAP_JOBS_THRESHOLD)),
+          updateJobWaitTime(
+              tiered_index_params.specificParams.tieredSVSParams.updateJobWaitTime == 0
+                  ? 1000 // default wait time: 1ms
+                  : tiered_index_params.specificParams.tieredSVSParams.updateJobWaitTime) {
         this->journal.reserve(this->updateJobThreshold * 2);
-        TIERED_LOG(VecSimCommonStrings::LOG_NOTICE_STRING, "TieredSVSIndex created");
     }
 
     int addVector(const void *blob, labelType label) override {
@@ -406,7 +549,8 @@ public:
             // elsewhere search queries may return wrong result.
             assert(ret >= 0 && "addVector: vector duplication in both indices");
             journal.emplace_back(label, true);
-            index_update_needed = this->journal.size() >= this->updateJobThreshold;
+            index_update_needed = this->backendIndex->indexSize() > 0 ||
+                                  this->journal.size() >= this->updateJobThreshold;
         }
 
         if (index_update_needed) {
@@ -528,11 +672,10 @@ public:
         TIERED_LOG(VecSimCommonStrings::LOG_VERBOSE_STRING,
                    "running asynchronous GC for tiered SVS index");
         if (!indexUpdateScheduled.test_and_set()) {
-            auto job = new (this->allocator)
-                SVSIndexUpdateJob{this->allocator, updateSVSIndexWrapper, this};
-            updateSVSIndexWrapper(job);
+            updateSVSIndexWrapper(this, 1);
         }
         std::unique_lock<std::shared_mutex> backend_lock{this->mainIndexGuard};
+        // VecSimIndexAbstract::runGC() is protected
         static_cast<VecSimIndexInterface *>(this->backendIndex)->runGC();
     }
 

--- a/src/VecSim/algorithms/svs/svs_tiered.h
+++ b/src/VecSim/algorithms/svs/svs_tiered.h
@@ -1,12 +1,3 @@
-/* TODO: change the copyright here */
-
-/*
- *Copyright Redis Ltd. 2021 - present
- *Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- *the Server Side Public License v1 (SSPLv1).
- */
-
-/* TODO clean the includes */
 #pragma once
 #include "VecSim/algorithms/brute_force/brute_force_single.h"
 #include "VecSim/vec_sim_tiered_index.h"
@@ -490,7 +481,6 @@ private:
         { // lock both indicies for writing - these changes to be synchronized
             std::scoped_lock lock(this->flatIndexGuard, this->mainIndexGuard);
             auto svs_index = GetSVSIndex();
-            // TODO(rfsaliev) remove below assuming that vectors had to be deleted directly
             auto deleted_num =
                 svs_index->deleteVectors(labels_to_delete.data(), labels_to_delete.size());
             assert(deleted_num == 0);
@@ -650,9 +640,6 @@ public:
         // VecSimIndexInfo info = this->info();
         //  Get the base tiered fields.
         auto *infoIterator = Base::infoIterator();
-
-        // TODO Add tiered SVS specific param.
-
         return infoIterator;
     }
 

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -223,5 +223,102 @@ struct SVSGraphBuilder {
     }
 };
 
-// The sequential thread pool is used for single-threaded execution
-using VecSimSVSThreadPool = svs::threads::SequentialThreadPool;
+// Custom thread pool for SVS index
+// Based on svs::threads::NativeThreadPoolBase with changes:
+// * Number of threads is fixed on construction time
+// * Pool is resizable in bounds of pre-allocated threads
+class VecSimSVSThreadPoolImpl {
+public:
+    // Allocate `num_threads - 1` threads since the main thread participates in the work
+    // as well.
+    explicit VecSimSVSThreadPoolImpl(size_t num_threads = 1)
+        : size_{num_threads}, threads_(num_threads - 1) {}
+
+    size_t capacity() const { return threads_.size() + 1; }
+    size_t size() const { return size_; }
+
+    // Support resize - do not modify threads container just limit the size
+    void resize(size_t new_size) {
+        std::lock_guard lock{use_mutex_};
+        size_ = std::clamp(new_size, size_t{1}, threads_.size() + 1);
+    }
+
+    void parallel_for(std::function<void(size_t)> f, size_t n) {
+        if (n == 0) {
+            return;
+        } else if (n == 1) {
+            f(0);
+            return;
+        } else {
+            std::lock_guard lock{use_mutex_};
+            for (size_t i = 0; i < n - 1; ++i) {
+                threads_[i % (size_)].assign({&f, i + 1});
+            }
+            // Run on the main function.
+            try {
+                f(0);
+            } catch (const std::exception &error) {
+                manage_exception_during_run(error.what());
+            }
+
+            // Wait until all threads are done.
+            // If any thread fails, then we're throwing.
+            for (size_t i = 0; i < size_ - 1; ++i) {
+                auto &thread = threads_[i];
+                thread.wait();
+                if (!thread.is_okay()) {
+                    manage_exception_during_run();
+                }
+            }
+        }
+    }
+
+    void manage_exception_during_run(const std::string &thread_0_message = {}) {
+        auto message = std::string{};
+        auto inserter = std::back_inserter(message);
+        if (!thread_0_message.empty()) {
+            fmt::format_to(inserter, "Thread 0: {}\n", thread_0_message);
+        }
+
+        // Manage all other exceptions thrown, restarting crashed threads.
+        for (size_t i = 0; i < size_ - 1; ++i) {
+            auto &thread = threads_[i];
+            thread.wait();
+            if (!thread.is_okay()) {
+                try {
+                    thread.unsafe_get_exception();
+                } catch (const std::exception &error) {
+                    fmt::format_to(inserter, "Thread {}: {}\n", i + 1, error.what());
+                }
+                // Restart the thread.
+                threads_[i].shutdown();
+                threads_[i] = svs::threads::Thread{};
+            }
+        }
+        throw svs::threads::ThreadingException{std::move(message)};
+    }
+
+private:
+    std::mutex use_mutex_;
+    size_t size_;
+    std::vector<svs::threads::Thread> threads_;
+};
+
+// Copy-movable wrapper for VecSimSVSThreadPoolImpl
+class VecSimSVSThreadPool {
+private:
+    std::shared_ptr<VecSimSVSThreadPoolImpl> pool_;
+
+public:
+    explicit VecSimSVSThreadPool(size_t num_threads = 1)
+        : pool_{std::make_shared<VecSimSVSThreadPoolImpl>(num_threads)} {}
+
+    size_t capacity() const { return pool_->capacity(); }
+    size_t size() const { return pool_->size(); }
+
+    void parallel_for(std::function<void(size_t)> f, size_t n) {
+        pool_->parallel_for(std::move(f), n);
+    }
+
+    void resize(size_t new_size) { pool_->resize(new_size); }
+};

--- a/src/VecSim/index_factories/tiered_factory.cpp
+++ b/src/VecSim/index_factories/tiered_factory.cpp
@@ -7,8 +7,10 @@
 #include "VecSim/index_factories/tiered_factory.h"
 #include "VecSim/index_factories/hnsw_factory.h"
 #include "VecSim/index_factories/brute_force_factory.h"
+#include "VecSim/index_factories/svs_factory.h"
 
 #include "VecSim/algorithms/hnsw/hnsw_tiered.h"
+#include "VecSim/algorithms/svs/svs_tiered.h"
 #include "VecSim/types/bfloat16.h"
 #include "VecSim/types/float16.h"
 
@@ -114,21 +116,122 @@ VecSimIndex *NewIndex(const TieredIndexParams *params) {
 }
 } // namespace TieredHNSWFactory
 
+namespace TieredSVSFactory {
+
+static inline BFParams NewBFParams(const TieredIndexParams *params) {
+    auto &svs_params = params->primaryIndexParams->algoParams.svsParams;
+    return BFParams{.type = svs_params.type,
+                    .dim = svs_params.dim,
+                    .metric = svs_params.metric,
+                    .multi = false, // multi not supported
+                    .blockSize = svs_params.blockSize};
+}
+
+template <typename DataType>
+inline VecSimIndex *NewIndex(const TieredIndexParams *params) {
+
+    // initialize svs index
+    // Normalization is done by the frontend index.
+    auto *svs_index = static_cast<VecSimIndexAbstract<DataType, float> *>(
+        SVSFactory::NewIndex(params->primaryIndexParams, true));
+    assert(svs_index != nullptr);
+    // initialize brute force index
+
+    auto bf_params = NewBFParams(params);
+
+    std::shared_ptr<VecSimAllocator> flat_allocator = VecSimAllocator::newVecsimAllocator();
+    size_t dataSize = VecSimParams_GetDataSize(bf_params.type, bf_params.dim, bf_params.metric);
+
+    AbstractIndexInitParams abstractInitParams = {.allocator = flat_allocator,
+                                                  .dim = bf_params.dim,
+                                                  .vecType = bf_params.type,
+                                                  .dataSize = dataSize,
+                                                  .metric = bf_params.metric,
+                                                  .blockSize = bf_params.blockSize,
+                                                  .multi = bf_params.multi,
+                                                  .logCtx = params->primaryIndexParams->logCtx};
+    auto frontendIndex = static_cast<BruteForceIndex_Single<DataType, float> *>(
+        BruteForceFactory::NewIndex(&bf_params, abstractInitParams, false));
+
+    // Create new tiered svs index
+    std::shared_ptr<VecSimAllocator> management_layer_allocator =
+        VecSimAllocator::newVecsimAllocator();
+
+    return new (management_layer_allocator)
+        TieredSVSIndex<DataType>(svs_index, frontendIndex, *params, management_layer_allocator);
+}
+
+inline size_t EstimateInitialSize(const TieredIndexParams *params) {
+    auto &svs_params = params->primaryIndexParams->algoParams.svsParams;
+
+    // Add size estimation of VecSimTieredIndex sub indexes.
+    size_t est = SVSFactory::EstimateInitialSize(&svs_params, true);
+
+    // Management layer allocator overhead.
+    size_t allocations_overhead = VecSimAllocator::getAllocationOverheadSize();
+    est += sizeof(VecSimAllocator) + allocations_overhead;
+
+    // Size of the TieredHNSWIndex struct.
+    switch (svs_params.type) {
+    case VecSimType_FLOAT32:
+        est += sizeof(TieredSVSIndex<float>);
+        break;
+    case VecSimType_FLOAT16:
+        est += sizeof(TieredSVSIndex<float16>);
+        break;
+    default:
+        assert(false && "Unsupported data type");
+        break;
+    }
+
+    return est;
+}
+
 VecSimIndex *NewIndex(const TieredIndexParams *params) {
     // Tiered index that contains HNSW index as primary index
-    if (params->primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
-        return TieredHNSWFactory::NewIndex(params);
+    VecSimType type = params->primaryIndexParams->algoParams.svsParams.type;
+    switch (type) {
+    case VecSimType_FLOAT32:
+        return TieredSVSFactory::NewIndex<float>(params);
+    case VecSimType_FLOAT16:
+        return TieredSVSFactory::NewIndex<float16>(params);
+    default:
+        assert(false && "Unsupported data type");
+        return nullptr; // Invalid type.
     }
-    return nullptr; // Invalid algorithm or type.
+    return nullptr; // Invalid type.
 }
+} // namespace TieredSVSFactory
+
+VecSimIndex *NewIndex(const TieredIndexParams *params) {
+    switch (params->primaryIndexParams->algo) {
+    // Tiered index that contains HNSW index as primary index
+    case VecSimAlgo_HNSWLIB:
+        return TieredHNSWFactory::NewIndex(params);
+    // Tiered index that contains SVS index as primary index
+    case VecSimAlgo_SVS:
+        return TieredSVSFactory::NewIndex(params);
+    default:
+        return nullptr; // Invalid algorithm.
+    }
+}
+
 size_t EstimateInitialSize(const TieredIndexParams *params) {
 
     size_t est = 0;
 
     BFParams bf_params{};
-    if (params->primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
+    switch (params->primaryIndexParams->algo) {
+    case VecSimAlgo_HNSWLIB:
         est += TieredHNSWFactory::EstimateInitialSize(params);
         bf_params = TieredHNSWFactory::NewBFParams(params);
+        break;
+    case VecSimAlgo_SVS:
+        est += TieredSVSFactory::EstimateInitialSize(params);
+        bf_params = TieredSVSFactory::NewBFParams(params);
+        break;
+    default:
+        assert(false && "Invalid algorithm");
     }
 
     est += BruteForceFactory::EstimateInitialSize(&bf_params, false);
@@ -137,8 +240,15 @@ size_t EstimateInitialSize(const TieredIndexParams *params) {
 
 size_t EstimateElementSize(const TieredIndexParams *params) {
     size_t est = 0;
-    if (params->primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
+    switch (params->primaryIndexParams->algo) {
+    case VecSimAlgo_HNSWLIB:
         est = HNSWFactory::EstimateElementSize(&params->primaryIndexParams->algoParams.hnswParams);
+        break;
+    case VecSimAlgo_SVS:
+        est = SVSFactory::EstimateElementSize(&params->primaryIndexParams->algoParams.svsParams);
+        break;
+    default:
+        assert(false && "Invalid algorithm");
     }
     return est;
 }

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -153,6 +153,7 @@ typedef struct {
     size_t prune_to;                 // Amount that candidates will be pruned.
     VecSimOptionMode use_search_history; // Either the contents of the search buffer can be used or
                                          // the entire search history.
+    size_t num_threads;                  // Maximum number of threads in threadpool.
     size_t search_window_size;           // Search window size to use during search.
     double epsilon; // Epsilon parameter for SVS graph accuracy/latency for range search.
 } SVSParams;
@@ -166,6 +167,8 @@ typedef struct {
 // A struct that contains SVS tiered index specific params.
 typedef struct {
     size_t updateJobThreshold; // The flat index size threshold to trigger the update job.
+    size_t updateJobWaitTime;  // The time (microseconds) to wait for threads reservation before
+                               // executing the update job.
 } TieredSVSParams;
 
 // A struct that contains the common tiered index params.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -163,6 +163,11 @@ typedef struct {
                              // all the ready swap jobs in a batch.
 } TieredHNSWParams;
 
+// A struct that contains SVS tiered index specific params.
+typedef struct {
+    size_t updateJobThreshold; // The flat index size threshold to trigger the update job.
+} TieredSVSParams;
+
 // A struct that contains the common tiered index params.
 typedef struct {
     void *jobQueue;         // External queue that holds the jobs.
@@ -173,6 +178,7 @@ typedef struct {
     VecSimParams *primaryIndexParams; // Parameters to initialize the index.
     union {
         TieredHNSWParams tieredHnswParams;
+        TieredSVSParams tieredSVSParams;
     } specificParams;
 } TieredIndexParams;
 

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -269,7 +269,7 @@ VecSimIndexInfo VecSimTieredIndex<DataType, DistType>::info() const {
     case VecSimAlgo_HNSWLIB:
         info.tieredInfo.backendInfo.hnswInfo = backendInfo.hnswInfo;
         break;
-    case VecSimAlgo_SVS: // TODO: Add SVS info.
+    case VecSimAlgo_SVS:
         break;
     case VecSimAlgo_BF:
     case VecSimAlgo_TIERED:

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -269,9 +269,10 @@ VecSimIndexInfo VecSimTieredIndex<DataType, DistType>::info() const {
     case VecSimAlgo_HNSWLIB:
         info.tieredInfo.backendInfo.hnswInfo = backendInfo.hnswInfo;
         break;
+    case VecSimAlgo_SVS: // TODO: Add SVS info.
+        break;
     case VecSimAlgo_BF:
     case VecSimAlgo_TIERED:
-    case VecSimAlgo_SVS:
         assert(false && "Invalid backend algorithm");
     }
 

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -677,7 +677,8 @@ PYBIND11_MODULE(VecSim, m) {
         .def_readwrite("prune_to", &SVSParams::prune_to)
         .def_readwrite("use_search_history", &SVSParams::use_search_history)
         .def_readwrite("search_window_size", &SVSParams::search_window_size)
-        .def_readwrite("epsilon", &SVSParams::epsilon);
+        .def_readwrite("epsilon", &SVSParams::epsilon)
+        .def_readwrite("num_threads", &SVSParams::num_threads);
 
     py::class_<TieredHNSWParams>(m, "TieredHNSWParams")
         .def(py::init())
@@ -685,7 +686,8 @@ PYBIND11_MODULE(VecSim, m) {
 
     py::class_<TieredSVSParams>(m, "TieredSVSParams")
         .def(py::init())
-        .def_readwrite("updateJobThreshold", &TieredSVSParams::updateJobThreshold);
+        .def_readwrite("updateJobThreshold", &TieredSVSParams::updateJobThreshold)
+        .def_readwrite("updateJobWaitTime", &TieredSVSParams::updateJobWaitTime);
 
     py::class_<AlgoParams>(m, "AlgoParams")
         .def(py::init())

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -209,6 +209,8 @@ public:
         return PyBatchIterator(index, py_batch_ptr);
     }
 
+    void runGC() { VecSimTieredIndex_GC(index.get()); }
+
     py::object getVector(labelType label) {
         VecSimIndexInfo info = index->info();
         size_t dim = info.commonInfo.basicInfo.dim;
@@ -573,6 +575,30 @@ public:
     }
 };
 
+class PyTiered_SVSIndex : public PyTieredIndex {
+public:
+    explicit PyTiered_SVSIndex(const SVSParams &svs_params,
+                               const TieredSVSParams &tiered_svs_params, size_t buffer_limit) {
+
+        // Create primaryIndexParams and specific params for hnsw tiered index.
+        VecSimParams primary_index_params = {.algo = VecSimAlgo_SVS,
+                                             .algoParams = {.svsParams = svs_params}};
+
+        auto tiered_params = this->getTieredIndexParams(buffer_limit);
+        tiered_params.primaryIndexParams = &primary_index_params;
+        tiered_params.specificParams.tieredSVSParams = tiered_svs_params;
+
+        // Create VecSimParams for TieredIndexParams
+        VecSimParams params = {.algo = VecSimAlgo_TIERED,
+                               .algoParams = {.tieredParams = tiered_params}};
+
+        this->index = std::shared_ptr<VecSimIndex>(VecSimIndex_New(&params), VecSimIndex_Free);
+
+        // Set the created tiered index in the index external context.
+        this->mock_thread_pool.ctx->index_strong_ref = this->index;
+    }
+};
+
 PYBIND11_MODULE(VecSim, m) {
     py::enum_<VecSimAlgo>(m, "VecSimAlgo")
         .value("VecSimAlgo_HNSWLIB", VecSimAlgo_HNSWLIB)
@@ -657,6 +683,10 @@ PYBIND11_MODULE(VecSim, m) {
         .def(py::init())
         .def_readwrite("swapJobThreshold", &TieredHNSWParams::swapJobThreshold);
 
+    py::class_<TieredSVSParams>(m, "TieredSVSParams")
+        .def(py::init())
+        .def_readwrite("updateJobThreshold", &TieredSVSParams::updateJobThreshold);
+
     py::class_<AlgoParams>(m, "AlgoParams")
         .def(py::init())
         .def_readwrite("hnswParams", &AlgoParams::hnswParams)
@@ -699,7 +729,8 @@ PYBIND11_MODULE(VecSim, m) {
         .def("index_memory", &PyVecSimIndex::indexMemory)
         .def("create_batch_iterator", &PyVecSimIndex::createBatchIterator, py::arg("query_blob"),
              py::arg("query_param") = nullptr)
-        .def("get_vector", &PyVecSimIndex::getVector);
+        .def("get_vector", &PyVecSimIndex::getVector)
+        .def("run_gc", &PyVecSimIndex::runGC);
 
     py::class_<PyHNSWLibIndex, PyVecSimIndex>(m, "HNSWIndex")
         .def(py::init([](const HNSWParams &params) { return new PyHNSWLibIndex(params); }),
@@ -741,6 +772,13 @@ PYBIND11_MODULE(VecSim, m) {
              py::arg("params"))
         .def("add_vector_parallel", &PySVSIndex::addVectorsParallel, py::arg("vectors"),
              py::arg("labels"));
+
+    py::class_<PyTiered_SVSIndex, PyTieredIndex>(m, "Tiered_SVSIndex")
+        .def(py::init([](const SVSParams &svs_params, const TieredSVSParams &tiered_svs_params,
+                         size_t flat_buffer_size = DEFAULT_BLOCK_SIZE) {
+                 return new PyTiered_SVSIndex(svs_params, tiered_svs_params, flat_buffer_size);
+             }),
+             py::arg("svs_params"), py::arg("tiered_svs_params"), py::arg("flat_buffer_size"));
 
     py::class_<PyBatchIterator>(m, "BatchIterator")
         .def("has_next", &PyBatchIterator::hasNext)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(test_hnsw ../utils/mock_thread_pool.cpp test_hnsw.cpp test_hnsw_m
 add_executable(test_hnsw_parallel test_hnsw_parallel.cpp ../utils/mock_thread_pool.cpp unit_test_utils.cpp)
 add_executable(test_bruteforce test_bruteforce.cpp test_bruteforce_multi.cpp ../utils/mock_thread_pool.cpp unit_test_utils.cpp)
 add_executable(test_allocator test_allocator.cpp ../utils/mock_thread_pool.cpp unit_test_utils.cpp)
-add_executable(test_svs ../utils/mock_thread_pool.cpp test_svs.cpp unit_test_utils.cpp)
+add_executable(test_svs ../utils/mock_thread_pool.cpp test_svs.cpp test_svs_tiered.cpp unit_test_utils.cpp)
 add_executable(test_spaces test_spaces.cpp)
 add_executable(test_types test_types.cpp)
 add_executable(test_common ../utils/mock_thread_pool.cpp test_common.cpp unit_test_utils.cpp)

--- a/tests/unit/test_svs_tiered.cpp
+++ b/tests/unit/test_svs_tiered.cpp
@@ -1,0 +1,2993 @@
+#include "VecSim/index_factories/tiered_factory.h"
+#include "VecSim/algorithms/svs/svs_tiered.h"
+#include "VecSim/algorithms/svs/svs.h"
+#include "VecSim/vec_sim_debug.h"
+#include <string>
+#include <array>
+
+#include "unit_test_utils.h"
+#include "mock_thread_pool.h"
+
+#include <thread>
+
+// Runs the test for all combination of data type(float/double) - label type (single/multi)
+
+template <typename index_type_t>
+class SVSTieredIndexTest : public ::testing::Test {
+public:
+    using data_t = typename index_type_t::data_t;
+
+protected:
+    TieredSVSIndex<data_t> *CastToTieredSVS(VecSimIndex *index) {
+        return reinterpret_cast<TieredSVSIndex<data_t> *>(index);
+    }
+
+    TieredIndexParams CreateTieredSVSParams(VecSimParams &svs_params,
+                                            tieredIndexMock &mock_thread_pool,
+                                            size_t update_job_threshold = 1024,
+                                            size_t flat_buffer_limit = SIZE_MAX) {
+        svs_params.algoParams.svsParams.quantBits = index_type_t::get_quant_bits();
+        return TieredIndexParams{
+            .jobQueue = &mock_thread_pool.jobQ,
+            .jobQueueCtx = mock_thread_pool.ctx,
+            .submitCb = tieredIndexMock::submit_callback,
+            .flatBufferLimit = flat_buffer_limit,
+            .primaryIndexParams = &svs_params,
+            .specificParams = {.tieredSVSParams =
+                                   TieredSVSParams{.updateJobThreshold = update_job_threshold}}};
+    }
+
+    TieredSVSIndex<data_t> *CreateTieredSVSIndex(const TieredIndexParams &tiered_params,
+                                                 tieredIndexMock &mock_thread_pool) {
+        auto *tiered_index =
+            reinterpret_cast<TieredSVSIndex<data_t> *>(TieredFactory::NewIndex(&tiered_params));
+
+        // Set the created tiered index in the index external context (it will take ownership over
+        // the index, and we'll need to release the ctx at the end of the test.
+        mock_thread_pool.ctx->index_strong_ref.reset(tiered_index);
+        return tiered_index;
+    }
+
+    TieredSVSIndex<data_t> *CreateTieredSVSIndex(VecSimParams &svs_params,
+                                                 tieredIndexMock &mock_thread_pool,
+                                                 size_t update_job_threshold = 1024,
+                                                 size_t flat_buffer_limit = SIZE_MAX) {
+        svs_params.algoParams.svsParams.quantBits = index_type_t::get_quant_bits();
+        TieredIndexParams tiered_params = CreateTieredSVSParams(
+            svs_params, mock_thread_pool, update_job_threshold, flat_buffer_limit);
+        return CreateTieredSVSIndex(tiered_params, mock_thread_pool);
+    }
+};
+
+// TEST_DATA_T and TEST_DIST_T are defined in test_utils.h
+
+template <VecSimType type, typename DataType, VecSimQuantBits quantBits>
+struct SVSIndexType {
+    static constexpr VecSimType get_index_type() { return type; }
+    static constexpr VecSimQuantBits get_quant_bits() { return quantBits; }
+    typedef DataType data_t;
+};
+
+// clang-format off
+using SVSDataTypeSet = ::testing::Types<SVSIndexType<VecSimType_FLOAT32, float, VecSimQuant_NONE>
+                                    //   ,SVSIndexType<VecSimType_FLOAT32, float, VecSimQuant_8>
+                                    //   ,SVSIndexType<VecSimType_FLOAT32, float, VecSimQuant_4>
+                                        >;
+// clang-format on
+
+TYPED_TEST_SUITE(SVSTieredIndexTest, SVSDataTypeSet);
+
+// Runs the test for each data type(float/double). The label type should be explicitly
+// set in the test.
+
+template <typename index_type_t>
+class SVSTieredIndexTestBasic : public SVSTieredIndexTest<index_type_t> {};
+TYPED_TEST_SUITE(SVSTieredIndexTestBasic, DataTypeSet);
+
+TYPED_TEST(SVSTieredIndexTest, CreateIndexInstance) {
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = 4, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+
+    // Get the allocator from the tiered index.
+    auto allocator = tiered_index->getAllocator();
+
+    // Add a vector to the flat index.
+    TEST_DATA_T vector[params.dim];
+    GenerateVector<TEST_DATA_T>(vector, params.dim);
+    labelType vector_label = 1;
+    VecSimIndex_AddVector(tiered_index, vector, vector_label);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 1);
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 0);
+
+    // Submit the index update job.
+    tiered_index->scheduleSVSIndexUpdate();
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 1);
+
+    // Execute the job from the queue and validate that the index was updated properly.
+    mock_thread_pool.thread_iteration();
+    ASSERT_EQ(tiered_index->indexSize(), 1);
+    ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(1, vector), 0);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 0);
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 1);
+}
+
+TYPED_TEST(SVSTieredIndexTest, addVector) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto tiered_params = this->CreateTieredSVSParams(svs_params, mock_thread_pool, 1);
+    auto *tiered_index = this->CreateTieredSVSIndex(tiered_params, mock_thread_pool);
+
+    // Get the allocator from the tiered index.
+    auto allocator = tiered_index->getAllocator();
+
+    BFParams bf_params = {
+        .type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2, .multi = false};
+
+    // Validate that memory upon creating the tiered index is as expected (no more than 2%
+    // above te expected, since in different platforms there are some minor additional
+    // allocations).
+    size_t expected_mem = TieredFactory::EstimateInitialSize(&tiered_params);
+    ASSERT_LE(expected_mem, tiered_index->getAllocationSize());
+    ASSERT_GE(expected_mem * 1.02, tiered_index->getAllocationSize());
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 0);
+
+    // Create a vector and add it to the tiered index.
+    labelType vec_label = 1;
+    TEST_DATA_T vector[dim];
+    GenerateVector<TEST_DATA_T>(vector, dim, vec_label);
+    VecSimIndex_AddVector(tiered_index, vector, vec_label);
+    // Validate that the vector was inserted to the flat buffer properly.
+    ASSERT_EQ(tiered_index->indexSize(), 1);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 1);
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 0);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexCapacity(), DEFAULT_BLOCK_SIZE);
+    ASSERT_EQ(tiered_index->indexCapacity(), DEFAULT_BLOCK_SIZE + 1);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->getDistanceFrom_Unsafe(vec_label, vector), 0);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 1);
+    // Validate that the job was created properly
+    // ASSERT_EQ(tiered_index->labelToInsertJobs.at(vec_label).size(), 1);
+    // ASSERT_EQ(tiered_index->labelToInsertJobs.at(vec_label)[0]->label, vec_label);
+    // ASSERT_EQ(tiered_index->labelToInsertJobs.at(vec_label)[0]->id, 0);
+
+    // Account for the allocation of a new block due to the vector insertion.
+    expected_mem += (BruteForceFactory::EstimateElementSize(&bf_params)) * DEFAULT_BLOCK_SIZE;
+    // Account for the memory that was allocated in the labelToId map (approx.)
+    expected_mem += sizeof(vecsim_stl::unordered_map<labelType, idType>::value_type) +
+                    sizeof(void *) + sizeof(size_t);
+    // Account for the insert job that was created.
+    expected_mem += sizeof(SVSIndexUpdateJob) + sizeof(size_t);
+    auto actual_mem = tiered_index->getAllocationSize();
+    ASSERT_GE(expected_mem * 1.02, tiered_index->getAllocationSize());
+    ASSERT_LE(expected_mem, tiered_index->getAllocationSize());
+}
+
+TYPED_TEST(SVSTieredIndexTest, insertJob) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1);
+    auto allocator = tiered_index->getAllocator();
+
+    // Create a vector and add it to the tiered index.
+    labelType vec_label = 1;
+    TEST_DATA_T vector[dim];
+    GenerateVector<TEST_DATA_T>(vector, dim, vec_label);
+    VecSimIndex_AddVector(tiered_index, vector, vec_label);
+    ASSERT_EQ(tiered_index->indexSize(), 1);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 1);
+
+    // Execute the insert job manually (in a synchronous manner).
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 1);
+    auto *insertion_job = reinterpret_cast<SVSIndexUpdateJob *>(mock_thread_pool.jobQ.front().job);
+    ASSERT_EQ(insertion_job->jobType, HNSW_INSERT_VECTOR_JOB);
+
+    mock_thread_pool.thread_iteration();
+    ASSERT_EQ(tiered_index->indexSize(), 1);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 0);
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 1);
+    // SVS index should have allocated a single record, while flat index should remove the
+    // block.
+    ASSERT_EQ(tiered_index->indexCapacity(), 1 + 1);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexCapacity(), 0);
+    ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(vec_label, vector), 0);
+}
+
+TYPED_TEST(SVSTieredIndexTest, insertJobAsync) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    size_t n = 5000;
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    mock_thread_pool.init_threads();
+    // Insert vectors
+    for (size_t i = 0; i < n; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, i, i);
+    }
+
+    mock_thread_pool.thread_pool_join();
+    ASSERT_EQ(tiered_index->indexSize(), n);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 0);
+    auto sz_f = tiered_index->GetFlatIndex()->indexSize();
+    auto sz_b = tiered_index->GetBackendIndex()->indexSize();
+    EXPECT_EQ(sz_f + sz_b, n);
+
+    // Verify that the vectors were inserted to SVS as expected
+    for (size_t i = 0; i < n; i++) {
+        TEST_DATA_T expected_vector[dim];
+        GenerateVector<TEST_DATA_T>(expected_vector, dim, i);
+        ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(i, expected_vector), 0)
+            << "Vector label: " << i;
+    }
+
+    // Verify that all vectors were moved to SVS as expected
+    sz_f = tiered_index->GetFlatIndex()->indexSize();
+    sz_b = tiered_index->GetBackendIndex()->indexSize();
+    EXPECT_EQ(sz_f, 0);
+    EXPECT_EQ(sz_b, n);
+
+    // Verify that the vectors were inserted to SVS as expected
+    for (size_t i = 0; i < n; i++) {
+        TEST_DATA_T expected_vector[dim];
+        GenerateVector<TEST_DATA_T>(expected_vector, dim, i);
+        ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(i, expected_vector), 0)
+            << "Vector label: " << i;
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTest, KNNSearch) {
+    size_t dim = 4;
+    size_t k = 10;
+
+    size_t n = k * 3;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+    };
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    size_t cur_memory_usage;
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, k);
+    auto allocator = tiered_index->getAllocator();
+    EXPECT_EQ(mock_thread_pool.ctx->index_strong_ref.use_count(), 1);
+
+    auto svs_index = tiered_index->GetBackendIndex();
+    auto flat_index = tiered_index->GetFlatIndex();
+
+    TEST_DATA_T query_0[dim];
+    GenerateVector<TEST_DATA_T>(query_0, dim, 0);
+    TEST_DATA_T query_1mid[dim];
+    GenerateVector<TEST_DATA_T>(query_1mid, dim, n / 3);
+    TEST_DATA_T query_2mid[dim];
+    GenerateVector<TEST_DATA_T>(query_2mid, dim, n * 2 / 3);
+    TEST_DATA_T query_n[dim];
+    GenerateVector<TEST_DATA_T>(query_n, dim, n - 1);
+
+    // Search for vectors when the index is empty.
+    runTopKSearchTest(tiered_index, query_0, k, nullptr);
+
+    // Define the verification functions.
+    auto ver_res_0 = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(id, index);
+        ASSERT_DOUBLE_EQ(score, dim * id * id);
+    };
+
+    auto ver_res_1mid = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(std::abs(int(id - query_1mid[0])), (index + 1) / 2);
+        ASSERT_DOUBLE_EQ(score, dim * pow((index + 1) / 2, 2));
+    };
+
+    auto ver_res_2mid = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(std::abs(int(id - query_2mid[0])), (index + 1) / 2);
+        ASSERT_DOUBLE_EQ(score, dim * pow((index + 1) / 2, 2));
+    };
+
+    auto ver_res_n = [&](size_t id, double score, size_t index) {
+        ASSERT_EQ(id, n - 1 - index);
+        ASSERT_DOUBLE_EQ(score, dim * index * index);
+    };
+
+    // Insert n/2 vectors to the main index.
+    for (size_t i = 0; i < n / 2; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(svs_index, dim, i, i);
+    }
+    ASSERT_EQ(tiered_index->indexSize(), n / 2);
+    ASSERT_EQ(tiered_index->indexSize(), svs_index->indexSize());
+
+    // Search for k vectors with the flat index empty.
+    cur_memory_usage = allocator->getAllocationSize();
+    runTopKSearchTest(tiered_index, query_0, k, ver_res_0);
+    runTopKSearchTest(tiered_index, query_1mid, k, ver_res_1mid);
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // Insert n/2 vectors to the flat index.
+    for (size_t i = n / 2; i < n; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(flat_index, dim, i, i);
+    }
+    ASSERT_EQ(tiered_index->indexSize(), n);
+    ASSERT_EQ(tiered_index->indexSize(), svs_index->indexSize() + flat_index->indexSize());
+
+    cur_memory_usage = allocator->getAllocationSize();
+    // Search for k vectors so all the vectors will be from the flat index.
+    runTopKSearchTest(tiered_index, query_0, k, ver_res_0);
+    // Search for k vectors so all the vectors will be from the main index.
+    runTopKSearchTest(tiered_index, query_n, k, ver_res_n);
+    // Search for k so some of the results will be from the main and some from the flat index.
+    runTopKSearchTest(tiered_index, query_1mid, k, ver_res_1mid);
+    runTopKSearchTest(tiered_index, query_2mid, k, ver_res_2mid);
+    // Memory usage should not change.
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // Add some overlapping vectors to the main and flat index.
+    // adding directly to the underlying indexes to avoid jobs logic.
+    // The main index will have vectors 0 - 2n/3 and the flat index will have vectors n/3 - n
+    for (size_t i = n / 3; i < n / 2; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(flat_index, dim, i, i);
+    }
+    for (size_t i = n / 2; i < n * 2 / 3; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(svs_index, dim, i, i);
+    }
+
+    cur_memory_usage = allocator->getAllocationSize();
+    // Search for k vectors so all the vectors will be from the main index.
+    runTopKSearchTest(tiered_index, query_0, k, ver_res_0);
+    // Search for k vectors so all the vectors will be from the flat index.
+    runTopKSearchTest(tiered_index, query_n, k, ver_res_n);
+    // Search for k so some of the results will be from the main and some from the flat index.
+    runTopKSearchTest(tiered_index, query_1mid, k, ver_res_1mid);
+    runTopKSearchTest(tiered_index, query_2mid, k, ver_res_2mid);
+    // Memory usage should not change.
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // More edge cases:
+
+    // Search for more vectors than the index size.
+    k = n + 1;
+    runTopKSearchTest(tiered_index, query_0, k, n, ver_res_0);
+    runTopKSearchTest(tiered_index, query_n, k, n, ver_res_n);
+
+    // Search for less vectors than the index size, but more than the flat and main index sizes.
+    k = n * 5 / 6;
+    runTopKSearchTest(tiered_index, query_0, k, ver_res_0);
+    runTopKSearchTest(tiered_index, query_n, k, ver_res_n);
+
+    // Memory usage should not change.
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // Search for more vectors than the main index size, but less than the flat index size.
+    for (size_t i = n / 2; i < n * 2 / 3; i++) {
+        VecSimIndex_DeleteVector(svs_index, i);
+    }
+    ASSERT_EQ(flat_index->indexSize(), n * 2 / 3);
+    ASSERT_EQ(svs_index->indexSize(), n / 2);
+    k = n * 2 / 3;
+    cur_memory_usage = allocator->getAllocationSize();
+    runTopKSearchTest(tiered_index, query_0, k, ver_res_0);
+    runTopKSearchTest(tiered_index, query_n, k, ver_res_n);
+    runTopKSearchTest(tiered_index, query_1mid, k, ver_res_1mid);
+    runTopKSearchTest(tiered_index, query_2mid, k, ver_res_2mid);
+    // Memory usage should not change.
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // Search for more vectors than the flat index size, but less than the main index size.
+    for (size_t i = n / 2; i < n; i++) {
+        VecSimIndex_DeleteVector(flat_index, i);
+    }
+    ASSERT_EQ(flat_index->indexSize(), n / 6);
+    ASSERT_EQ(svs_index->indexSize(), n / 2);
+    k = n / 4;
+    cur_memory_usage = allocator->getAllocationSize();
+    runTopKSearchTest(tiered_index, query_0, k, ver_res_0);
+    runTopKSearchTest(tiered_index, query_1mid, k, ver_res_1mid);
+    // Memory usage should not change.
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // Search for vectors when the flat index is not empty but the main index is empty.
+    for (size_t i = 0; i < n * 2 / 3; i++) {
+        VecSimIndex_DeleteVector(svs_index, i);
+        GenerateAndAddVector<TEST_DATA_T>(flat_index, dim, i, i);
+    }
+    ASSERT_EQ(flat_index->indexSize(), n * 2 / 3);
+    ASSERT_EQ(svs_index->indexSize(), 0);
+    k = n / 3;
+    cur_memory_usage = allocator->getAllocationSize();
+    runTopKSearchTest(tiered_index, query_0, k, ver_res_0);
+    runTopKSearchTest(tiered_index, query_1mid, k, ver_res_1mid);
+    // Memory usage should not change.
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // TODO: add timeouts support to SVS index and test it here.
+    // // // // // // // // // // // // //
+    // // Check behavior upon timeout.  //
+    // // // // // // // // // // // // //
+
+    // VecSimQueryReply *res;
+    // // Add a vector to the SVS index so there will be a reason to query it.
+    // GenerateAndAddVector<TEST_DATA_T>(svs_index, dim, n, n);
+
+    // // Set timeout callback to always return 1 (will fail while querying the flat buffer).
+    // VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out
+
+    // res = VecSimIndex_TopKQuery(tiered_index, query_0, k, nullptr, BY_SCORE);
+    // ASSERT_TRUE(res->results.empty());
+    // ASSERT_EQ(VecSimQueryReply_GetCode(res), VecSim_QueryReply_TimedOut);
+    // VecSimQueryReply_Free(res);
+
+    // // Set timeout callback to return 1 after n checks (will fail while querying the SVS index).
+    // // Brute-force index checks for timeout after each vector.
+    // size_t checks_in_flat = flat_index->indexSize();
+    // VecSimQueryParams qparams = {.timeoutCtx = &checks_in_flat};
+    // VecSim_SetTimeoutCallbackFunction([](void *ctx) {
+    //     auto count = static_cast<size_t *>(ctx);
+    //     if (*count == 0) {
+    //         return 1;
+    //     }
+    //     (*count)--;
+    //     return 0;
+    // });
+    // res = VecSimIndex_TopKQuery(tiered_index, query_0, k, &qparams, BY_SCORE);
+    // ASSERT_TRUE(res->results.empty());
+    // ASSERT_EQ(VecSimQueryReply_GetCode(res), VecSim_QueryReply_TimedOut);
+    // VecSimQueryReply_Free(res);
+    // // Make sure we didn't get the timeout in the flat index.
+    // checks_in_flat = flat_index->indexSize(); // Reset the counter.
+    // res = VecSimIndex_TopKQuery(flat_index, query_0, k, &qparams, BY_SCORE);
+    // ASSERT_EQ(VecSimQueryReply_GetCode(res), VecSim_QueryReply_OK);
+    // VecSimQueryReply_Free(res);
+
+    // Clean up.
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; });
+}
+
+TYPED_TEST(SVSTieredIndexTest, deleteVector) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1);
+    auto allocator = tiered_index->getAllocator();
+
+    labelType vec_label = 0;
+    // Delete from an empty index.
+    ASSERT_EQ(tiered_index->deleteVector(vec_label), 0);
+
+    // Create a vector and add it to the tiered index (expect it to go into the flat buffer).
+    TEST_DATA_T vector[dim];
+    GenerateVector<TEST_DATA_T>(vector, dim, vec_label);
+    VecSimIndex_AddVector(tiered_index, vector, vec_label);
+    ASSERT_EQ(tiered_index->indexSize(), 1);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 1);
+
+    // Remove vector from flat buffer.
+    ASSERT_EQ(tiered_index->deleteVector(vec_label), 1);
+    ASSERT_EQ(tiered_index->indexSize(), 0);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 0);
+
+    mock_thread_pool.thread_iteration();
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 0);
+
+    // Create a vector and add it to SVS in the tiered index.
+    VecSimIndex_AddVector(tiered_index->GetBackendIndex(), vector, vec_label);
+    ASSERT_EQ(tiered_index->indexSize(), 1);
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 1);
+
+    // Remove from main index.
+    ASSERT_EQ(tiered_index->deleteVector(vec_label), 1);
+    ASSERT_EQ(tiered_index->indexLabelCount(), 0);
+    ASSERT_EQ(tiered_index->indexSize(), 0);
+    // ASSERT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 1);
+
+    // Re-insert a deleted label with a different vector.
+    TEST_DATA_T new_vec_val = 2.0;
+    GenerateVector<TEST_DATA_T>(vector, dim, new_vec_val);
+    VecSimIndex_AddVector(tiered_index, vector, vec_label);
+    ASSERT_EQ(tiered_index->indexSize(), 1);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 1);
+
+    // Move the vector to SVS by executing the insert job.
+    mock_thread_pool.thread_iteration();
+    ASSERT_EQ(tiered_index->indexLabelCount(), 1);
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 1);
+    // Check that the distance from the deleted vector (of zeros) to the label is the distance
+    // to the new vector (L2 distance).
+    TEST_DATA_T deleted_vector[dim];
+    GenerateVector<TEST_DATA_T>(deleted_vector, dim, 0);
+    ASSERT_EQ(tiered_index->GetBackendIndex()->getDistanceFrom_Unsafe(vec_label, deleted_vector),
+              dim * pow(new_vec_val, 2));
+}
+
+TYPED_TEST(SVSTieredIndexTest, manageIndexOwnership) {
+
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+
+    // Get the allocator from the tiered index.
+    auto allocator = tiered_index->getAllocator();
+
+    EXPECT_EQ(mock_thread_pool.ctx->index_strong_ref.use_count(), 1);
+    size_t initial_mem = allocator->getAllocationSize();
+
+    // Create a dummy job callback that insert one vector to the underline SVS index.
+    auto dummy_job = [](AsyncJob *job) {
+        auto *my_index = reinterpret_cast<TieredSVSIndex<TEST_DATA_T> *>(job->index);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        size_t dim = 4;
+        TEST_DATA_T vector[dim];
+        GenerateVector<TEST_DATA_T>(vector, dim);
+        my_index->GetBackendIndex()->addVector(vector, my_index->GetBackendIndex()->indexSize());
+    };
+
+    std::atomic_int successful_executions(0);
+    auto job1 =
+        new (allocator) AsyncJob(allocator, HNSW_INSERT_VECTOR_JOB, dummy_job, tiered_index);
+    auto job2 =
+        new (allocator) AsyncJob(allocator, HNSW_INSERT_VECTOR_JOB, dummy_job, tiered_index);
+
+    // Wrap this job with an array and submit the jobs to the queue.
+    tiered_index->submitSingleJob(job1);
+    tiered_index->submitSingleJob(job2);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 2);
+
+    // Execute the job from the queue asynchronously, delete the index in the meantime.
+    auto run_fn = [&successful_executions, &mock_thread_pool]() {
+        // Create a temporary strong reference of the index from the weak reference that the
+        // job holds, to ensure that the index is not deleted while the job is running.
+        if (auto temp_ref = mock_thread_pool.jobQ.front().index_weak_ref.lock()) {
+            // At this point we wish to validate that we have both the index strong ref (stored
+            // in index_ctx) and the weak ref owned by the job (that we currently promoted).
+            EXPECT_EQ(mock_thread_pool.jobQ.front().index_weak_ref.use_count(), 2);
+
+            mock_thread_pool.jobQ.front().job->Execute(mock_thread_pool.jobQ.front().job);
+            successful_executions++;
+        }
+        mock_thread_pool.jobQ.kick();
+    };
+    std::thread t1(run_fn);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Delete the index while the job is still running, to ensure that the weak ref protects
+    // the index.
+    mock_thread_pool.reset_ctx();
+    EXPECT_EQ(mock_thread_pool.jobQ.front().index_weak_ref.use_count(), 1);
+    t1.join();
+    // Expect that the first job will succeed.
+    ASSERT_EQ(successful_executions, 1);
+
+    // The second job should not run, since the weak reference is not supposed to become a
+    // strong references now.
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 1);
+    ASSERT_EQ(mock_thread_pool.jobQ.front().index_weak_ref.use_count(), 0);
+    std::thread t2(run_fn);
+    t2.join();
+    // Expect that the second job is ot successful.
+    ASSERT_EQ(successful_executions, 1);
+}
+
+TYPED_TEST(SVSTieredIndexTest, parallelSearch) {
+    size_t dim = 4;
+    size_t k = 10;
+    size_t n = 2000;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+        .search_window_size = n,
+    };
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+    EXPECT_EQ(mock_thread_pool.ctx->index_strong_ref.use_count(), 1);
+
+    std::atomic_int successful_searches(0);
+    auto parallel_knn_search = [](AsyncJob *job) {
+        auto *search_job = reinterpret_cast<tieredIndexMock::SearchJobMock *>(job);
+        size_t k = search_job->k;
+        size_t dim = search_job->dim;
+        auto query = search_job->query;
+
+        auto verify_res = [&](size_t id, double score, size_t res_index) {
+            TEST_DATA_T element = *(TEST_DATA_T *)query;
+            ASSERT_EQ(std::abs(id - element), (res_index + 1) / 2);
+            ASSERT_EQ(score, dim * (id - element) * (id - element));
+        };
+        runTopKSearchTest(job->index, query, k, verify_res);
+        (*search_job->successful_searches)++;
+        delete job;
+    };
+
+    size_t n_labels = n;
+
+    // Fill the job queue with insert and search jobs, while filling the flat index, before
+    // initializing the thread pool.
+    for (size_t i = 0; i < n; i++) {
+        // Insert a vector to the flat index and add a job to insert it to the main index.
+        GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, i % n_labels, i);
+
+        // Add a search job. Make sure the query element is between k and n - k.
+        auto query = (TEST_DATA_T *)allocator->allocate(dim * sizeof(TEST_DATA_T));
+        GenerateVector<TEST_DATA_T>(query, dim, (i % (n_labels - (2 * k))) + k);
+        auto search_job = new (allocator) tieredIndexMock::SearchJobMock(
+            allocator, parallel_knn_search, tiered_index, k, query, n, dim, &successful_searches);
+        tiered_index->submitSingleJob(search_job);
+    }
+
+    EXPECT_EQ(tiered_index->indexSize(), n);
+    EXPECT_EQ(tiered_index->indexLabelCount(), n_labels);
+    EXPECT_EQ(tiered_index->GetFlatIndex()->indexSize(), n);
+    EXPECT_EQ(tiered_index->GetBackendIndex()->indexSize(), 0);
+
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    // All the vectors are already in the tiered index, so we expect to find the expected
+    // results from the get-go.
+    mock_thread_pool.init_threads();
+    mock_thread_pool.thread_pool_join();
+
+    EXPECT_EQ(tiered_index->GetBackendIndex()->indexSize(), n);
+    EXPECT_EQ(tiered_index->GetBackendIndex()->indexLabelCount(), n_labels);
+    EXPECT_EQ(tiered_index->GetFlatIndex()->indexSize(), 0);
+    EXPECT_EQ(successful_searches, n);
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 0);
+}
+
+TYPED_TEST(SVSTieredIndexTest, parallelInsertSearch) {
+    size_t dim = 4;
+    size_t k = 10;
+    size_t n = 3000;
+
+    size_t block_size = n / 100;
+
+    // Create TieredSVS index instance with a mock queue.
+    size_t n_labels = n;
+    SVSParams params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+        .blockSize = block_size,
+    };
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+    EXPECT_EQ(mock_thread_pool.ctx->index_strong_ref.use_count(), 1);
+
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    // Save the number fo tasks done by thread i in the i-th entry.
+    std::vector<size_t> completed_tasks(mock_thread_pool.thread_pool_size, 0);
+    mock_thread_pool.init_threads();
+    std::atomic_int successful_searches(0);
+
+    auto parallel_knn_search = [](AsyncJob *job) {
+        auto *search_job = reinterpret_cast<tieredIndexMock::SearchJobMock *>(job);
+        size_t k = search_job->k;
+        auto query = search_job->query;
+        // In this test we don't care about the results, just that the search doesn't crash
+        // and returns the correct number of valid results.
+        auto verify_res = [&](size_t id, double score, size_t res_index) {};
+        runTopKSearchTest(job->index, query, k, verify_res);
+        (*search_job->successful_searches)++;
+        delete job;
+    };
+
+    // Insert vectors in parallel to search.
+    for (size_t i = 0; i < n; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, i % n_labels, i);
+        auto query = (TEST_DATA_T *)allocator->allocate(dim * sizeof(TEST_DATA_T));
+        GenerateVector<TEST_DATA_T>(query, dim, (TEST_DATA_T)n / 4 + (i % 1000) * M_PI);
+        auto search_job = new (allocator) tieredIndexMock::SearchJobMock(
+            allocator, parallel_knn_search, tiered_index, k, query, n, dim, &successful_searches);
+        tiered_index->submitSingleJob(search_job);
+    }
+
+    mock_thread_pool.thread_pool_join();
+
+    auto sz_f = tiered_index->GetFlatIndex()->indexSize();
+    auto sz_b = tiered_index->GetBackendIndex()->indexSize();
+    EXPECT_EQ(sz_f + sz_b, n);
+    EXPECT_EQ(successful_searches, n);
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 0);
+}
+
+TYPED_TEST(SVSTieredIndexTest, testSizeEstimation) {
+    size_t dim = 128;
+    size_t n = DEFAULT_BLOCK_SIZE;
+    size_t graph_degree = 31; // power of 2 - 1
+    size_t bs = DEFAULT_BLOCK_SIZE;
+
+    SVSParams svs_params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+        .graph_max_degree = graph_degree,
+    };
+    VecSimParams vecsim_svs_params = CreateParams(svs_params);
+
+    auto mock_thread_pool = tieredIndexMock();
+    TieredIndexParams tiered_params = {.jobQueue = &mock_thread_pool.jobQ,
+                                       .jobQueueCtx = mock_thread_pool.ctx,
+                                       .submitCb = tieredIndexMock::submit_callback,
+                                       .flatBufferLimit = SIZE_MAX,
+                                       .primaryIndexParams = &vecsim_svs_params};
+    VecSimParams params = CreateParams(tiered_params);
+    auto *index = VecSimIndex_New(&params);
+    mock_thread_pool.ctx->index_strong_ref.reset(index);
+    mock_thread_pool.init_threads();
+
+    auto allocator = index->getAllocator();
+
+    size_t initial_size_estimation = VecSimIndex_EstimateInitialSize(&params);
+
+    ASSERT_EQ(initial_size_estimation, index->getAllocationSize());
+
+    // Add vectors up to initial capacity (initial capacity == block size).
+    for (size_t i = 0; i < n; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(index, dim, i, i);
+    }
+    mock_thread_pool.thread_pool_join();
+
+    // Estimate memory delta for filling up the first block and adding another block.
+    size_t estimation = VecSimIndex_EstimateElementSize(&params) * bs;
+
+    size_t before = index->getAllocationSize();
+    GenerateAndAddVector<TEST_DATA_T>(index, dim, bs + n, bs + n);
+    // Run the GC to move last vector to the SVS index.
+    index->runGC();
+    size_t actual = index->getAllocationSize() - before;
+
+    auto tiered_index = this->CastToTieredSVS(index);
+
+    // Flat index should be empty, hence the index size includes only svs size.
+    EXPECT_EQ(tiered_index->GetFlatIndex()->indexSize(), 0);
+    EXPECT_EQ(tiered_index->GetBackendIndex()->indexSize(), n + 1);
+
+    // We added n + 1 vectors
+    EXPECT_EQ(index->indexSize(), n + 1);
+
+    EXPECT_EQ(index->indexCapacity(), tiered_index->GetBackendIndex()->indexCapacity());
+
+    // We check that the actual size is within 1% of the estimation.
+    EXPECT_GE(estimation, actual * 0.99);
+    EXPECT_LE(estimation, actual * 1.01);
+}
+
+TYPED_TEST(SVSTieredIndexTest, parallelInsertAdHoc) {
+    size_t dim = 4;
+    size_t n = 1000;
+
+    size_t block_size = n / 100;
+
+    // Create TieredSVS index instance with a mock queue.
+    size_t n_labels = n;
+    SVSParams params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+        .blockSize = block_size,
+    };
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+    EXPECT_EQ(mock_thread_pool.ctx->index_strong_ref.use_count(), 1);
+
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    mock_thread_pool.init_threads();
+    std::atomic_int successful_searches(0);
+
+    auto parallel_adhoc_search = [](AsyncJob *job) {
+        auto *search_job = reinterpret_cast<tieredIndexMock::SearchJobMock *>(job);
+        auto query = search_job->query;
+        size_t element = *(TEST_DATA_T *)query;
+        size_t label = element % search_job->n;
+        VecSimTieredIndex_AcquireSharedLocks(search_job->index);
+        ASSERT_EQ(0, VecSimIndex_GetDistanceFrom_Unsafe(search_job->index, label, query));
+        VecSimTieredIndex_ReleaseSharedLocks(search_job->index);
+        (*search_job->successful_searches)++;
+        delete job;
+    };
+
+    // Insert vectors in parallel to search.
+    for (size_t i = 0; i < n; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, i % n_labels, i);
+        auto query = (TEST_DATA_T *)allocator->allocate(dim * sizeof(TEST_DATA_T));
+        GenerateVector<TEST_DATA_T>(query, dim, i);
+        auto search_job = new (allocator)
+            tieredIndexMock::SearchJobMock(allocator, parallel_adhoc_search, tiered_index, 1, query,
+                                           n_labels, dim, &successful_searches);
+        tiered_index->submitSingleJob(search_job);
+    }
+
+    tiered_index->scheduleSVSIndexUpdate();
+    mock_thread_pool.thread_pool_join();
+
+    EXPECT_EQ(successful_searches, n);
+    EXPECT_EQ(tiered_index->GetBackendIndex()->indexSize(), n);
+    EXPECT_EQ(tiered_index->GetBackendIndex()->indexLabelCount(), n_labels);
+    EXPECT_EQ(tiered_index->GetFlatIndex()->indexSize(), 0);
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 0);
+}
+
+// TODO: Uncomment tests below or remove if not relevant.
+/*
+TYPED_TEST(SVSTieredIndexTest, deleteVectorAndRepairAsync) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    size_t n = 1000;
+    for (size_t maxSwapJobs : {(int)n + 1, 10, 1}) {
+        SVSParams params = {.type = TypeParam::get_index_type(),
+                             .dim = dim,
+                             .metric = VecSimMetric_L2,
+                             .blockSize = 100};
+        VecSimParams svs_params = CreateParams(params);
+        auto mock_thread_pool = tieredIndexMock();
+
+        auto *tiered_index =
+            this->CreateTieredSVSIndex(svs_params, mock_thread_pool, maxSwapJobs);
+        auto allocator = tiered_index->getAllocator();
+
+        size_t per_label = TypeParam::isMulti() ? 50 : 1;
+        size_t n_labels = n / per_label;
+
+        // Launch the BG threads loop that takes jobs from the queue and executes them.
+
+        for (size_t i = 0; i < mock_thread_pool.thread_pool_size; i++) {
+            mock_thread_pool.thread_pool.emplace_back(tieredIndexMock::thread_main_loop, i,
+                                                      std::ref(mock_thread_pool));
+        }
+
+        // Create and insert vectors one by one, then delete them one by one.
+        std::srand(10); // create pseudo random generator with any arbitrary seed.
+        for (size_t i = 0; i < n; i++) {
+            TEST_DATA_T vector[dim];
+            for (size_t j = 0; j < dim; j++) {
+                vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+            }
+            VecSimIndex_AddVector(tiered_index, vector, i % n_labels);
+        }
+        // While a thread is ingesting a vector into SVS, a vector may appear in both indexes
+        // (hence it will be counted twice in the index size calculation).
+        size_t index_size = tiered_index->indexSize();
+        EXPECT_GE(index_size, n);
+        EXPECT_LE(index_size, n + mock_thread_pool.thread_pool_size);
+        EXPECT_EQ(tiered_index->indexLabelCount(), n_labels);
+        for (size_t i = 0; i < n_labels; i++) {
+            // Every vector associated with the label may appear in flat/SVS index or in both if
+            // its just being ingested.
+            int num_deleted = tiered_index->deleteVector(i);
+            EXPECT_GE(num_deleted, per_label);
+            EXPECT_LE(num_deleted,
+                      std::min(2 * per_label, per_label + mock_thread_pool.thread_pool_size));
+            EXPECT_EQ(tiered_index->deleteVector(i), 0); // delete already deleted label
+        }
+        EXPECT_EQ(tiered_index->indexLabelCount(), 0);
+
+        mock_thread_pool.thread_pool_join();
+
+        EXPECT_EQ(tiered_index->getSVSIndex()->checkIntegrity().connections_to_repair, 0);
+        EXPECT_EQ(tiered_index->getSVSIndex()->safeGetEntryPointState().first, INVALID_ID);
+        // Verify that we have no pending jobs.
+        EXPECT_EQ(tiered_index->labelToInsertJobs.size(), 0);
+        EXPECT_EQ(tiered_index->idToRepairJobs.size(), 0);
+        for (auto &it : tiered_index->idToSwapJob) {
+            EXPECT_EQ(it.second->pending_repair_jobs_counter.load(), 0);
+        }
+        // Trigger swapping of vectors that hadn't been swapped yet.
+        tiered_index->executeReadySwapJobs();
+        ASSERT_EQ(tiered_index->idToSwapJob.size(), 0);
+        EXPECT_EQ(tiered_index->indexSize(), 0);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTest, alternateInsertDeleteAsync) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 16;
+    size_t n = 1000;
+    for (size_t maxSwapJobs : {(int)n + 1, 10, 1}) {
+        for (size_t M : {2, 16}) {
+            SVSParams params = {.type = TypeParam::get_index_type(),
+                                 .dim = dim,
+                                 .metric = VecSimMetric_L2,
+                                 .blockSize = 100,
+                                 .M = M};
+            VecSimParams svs_params = CreateParams(params);
+            auto mock_thread_pool = tieredIndexMock();
+
+            auto *tiered_index =
+                this->CreateTieredSVSIndex(svs_params, mock_thread_pool, maxSwapJobs);
+            auto allocator = tiered_index->getAllocator();
+
+            size_t per_label = TypeParam::isMulti() ? 5 : 1;
+            size_t n_labels = n / per_label;
+
+            // Launch the BG threads loop that takes jobs from the queue and executes them.
+
+            for (size_t i = 0; i < mock_thread_pool.thread_pool_size; i++) {
+                mock_thread_pool.thread_pool.emplace_back(tieredIndexMock::thread_main_loop, i,
+                                                          std::ref(mock_thread_pool));
+            }
+
+            // Create and insert 10 vectors, then delete them right after.
+            size_t batch_size = 5;
+            std::srand(10); // create pseudo random generator with any arbitrary seed.
+            for (size_t i = 0; i < n / batch_size; i++) {
+                for (size_t l = 0; l < batch_size; l++) {
+                    TEST_DATA_T vector[dim];
+                    for (size_t j = 0; j < dim; j++) {
+                        vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+                    }
+                    tiered_index->addVector(vector, (i * batch_size + l) / per_label);
+                }
+                for (size_t l = 0; l < batch_size / per_label; l++) {
+                    // Every vector associated with the label may appear in flat/SVS index or in
+                    // both if its just being ingested.
+                    int num_deleted = tiered_index->deleteVector(i * batch_size / per_label + l);
+                    EXPECT_GE(num_deleted, per_label);
+                    EXPECT_LE(num_deleted, 2 * per_label);
+                }
+            }
+            // Vectors are deleted from flat buffer in place (in SVS they are only marked as
+            // deleted).
+            EXPECT_GE(tiered_index->frontendIndex->indexSize(), 0);
+            EXPECT_EQ(tiered_index->indexLabelCount(), 0);
+
+            mock_thread_pool.thread_pool_join();
+
+            EXPECT_EQ(tiered_index->getSVSIndex()->checkIntegrity().connections_to_repair, 0);
+            EXPECT_EQ(tiered_index->getSVSIndex()->safeGetEntryPointState().first, INVALID_ID);
+            // Verify that we have no pending jobs.
+            EXPECT_EQ(tiered_index->labelToInsertJobs.size(), 0);
+            EXPECT_EQ(tiered_index->idToRepairJobs.size(), 0);
+            for (auto &it : tiered_index->idToSwapJob) {
+                EXPECT_EQ(it.second->pending_repair_jobs_counter.load(), 0);
+            }
+            // Trigger swapping of vectors that hadn't been swapped yet.
+            tiered_index->executeReadySwapJobs();
+            ASSERT_LE(tiered_index->idToSwapJob.size(), 0);
+            ASSERT_EQ(tiered_index->indexSize(), 0);
+        }
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTest, swapJobBasic) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    SVSParams params = {.type = TypeParam::get_index_type(),
+                         .dim = dim,
+                         .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+
+    // Test initialization of the pendingSwapJobsThreshold value.
+    ASSERT_EQ(tiered_index->pendingSwapJobsThreshold, DEFAULT_PENDING_SWAP_JOBS_THRESHOLD);
+    mock_thread_pool.ctx->index_strong_ref.reset();
+
+    tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool,
+                                               MAX_PENDING_SWAP_JOBS_THRESHOLD + 1);
+    allocator = tiered_index->getAllocator();
+    ASSERT_EQ(tiered_index->pendingSwapJobsThreshold, MAX_PENDING_SWAP_JOBS_THRESHOLD);
+    mock_thread_pool.ctx->index_strong_ref.reset();
+
+    tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1);
+    ASSERT_EQ(tiered_index->pendingSwapJobsThreshold, 1);
+
+    allocator = tiered_index->getAllocator();
+
+    // Call reserve for the unordered maps that are going to be used, since upon initialization it
+    // consumed 0 memory, but after insertion and deletion they will consume a minimal amount of
+    // memory (that is equivalent to the memory consumption upon reserving 0 buckets).
+    tiered_index->idToRepairJobs.reserve(0);
+    tiered_index->idToSwapJob.reserve(0);
+    TypeParam::isMulti() ? reinterpret_cast<SVSIndex_Multi<TEST_DATA_T, TEST_DIST_T> *>(
+                               tiered_index->getSVSIndex())
+                               ->labelLookup.reserve(0)
+                         : reinterpret_cast<SVSIndex_Single<TEST_DATA_T, TEST_DIST_T> *>(
+                               tiered_index->getSVSIndex())
+                               ->labelLookup.reserve(0);
+
+    size_t initial_mem = tiered_index->getAllocationSize();
+    size_t initial_mem_backend = tiered_index->backendIndex->getAllocationSize();
+    size_t initial_mem_frontend = tiered_index->frontendIndex->getAllocationSize();
+
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 0, 0);
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 1, 1);
+    EXPECT_EQ(tiered_index->indexLabelCount(), 2);
+    EXPECT_EQ(tiered_index->indexSize(), 2);
+    // Delete both vectors.
+    EXPECT_EQ(tiered_index->deleteVector(0), 1);
+    EXPECT_EQ(tiered_index->deleteVector(1), 1);
+    EXPECT_EQ(tiered_index->idToSwapJob.size(), 2);
+    EXPECT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 2);
+    // Expect to have pending repair jobs, so that swap job cannot be executed yet - for each
+    // deleted vector there should be a single repair job.
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 2);
+    EXPECT_EQ(tiered_index->idToSwapJob.at(0)->pending_repair_jobs_counter.load(), 1);
+    EXPECT_EQ(tiered_index->idToSwapJob.at(1)->pending_repair_jobs_counter.load(), 1);
+    mock_thread_pool.thread_iteration();
+    mock_thread_pool.thread_iteration();
+    EXPECT_EQ(tiered_index->idToSwapJob.size(), 2);
+    // Insert another vector and remove it. expect it to have no neighbors.
+    // Threshold for is set to be 1, so now we expect that a single deleted vector (which has no
+    // pending repair jobs) will be swapped - and 2 will remain.
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 2, 2);
+    EXPECT_EQ(tiered_index->deleteVector(2), 1);
+    EXPECT_EQ(tiered_index->idToSwapJob.size(), 2);
+    EXPECT_EQ(tiered_index->indexSize(), 2);
+    EXPECT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 2);
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 0);
+
+    // Now swap the rest of the jobs.
+    tiered_index->executeReadySwapJobs();
+    EXPECT_EQ(tiered_index->idToSwapJob.size(), 0);
+    EXPECT_EQ(tiered_index->indexSize(), 0);
+    EXPECT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 0);
+
+    // Reserve manually 0 buckets in the hash tables so that memory would be as it was before we
+    // started inserting vectors.
+    tiered_index->idToRepairJobs.reserve(0);
+    tiered_index->idToSwapJob.reserve(0);
+    // Manually shrink the vectors so that memory would be as it was before we started inserting
+    tiered_index->getSVSIndex()->vectorBlocks.shrink_to_fit();
+    tiered_index->getSVSIndex()->graphDataBlocks.shrink_to_fit();
+
+    EXPECT_EQ(tiered_index->backendIndex->getAllocationSize(), initial_mem_backend);
+    EXPECT_EQ(tiered_index->frontendIndex->getAllocationSize(), initial_mem_frontend);
+    EXPECT_EQ(tiered_index->getAllocationSize(), initial_mem);
+    mock_thread_pool.reset_ctx();
+
+    // VecSimAllocator::allocation_header_size = size_t, this should be the only memory that we
+    // account for at this point.
+    EXPECT_EQ(allocator->getAllocationSize(), sizeof(size_t));
+}
+
+TYPED_TEST(SVSTieredIndexTest, swapJobBasic2) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    SVSParams params = {.type = TypeParam::get_index_type(),
+                         .dim = dim,
+                         .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1);
+    ASSERT_EQ(tiered_index->pendingSwapJobsThreshold, 1);
+    auto allocator = tiered_index->getAllocator();
+
+    // Insert 3 vectors, expect to have a fully connected graph.
+    idType invalid_jobs_counter = 0;
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 0, 0);
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 1, 1);
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 2, 2);
+    // Delete 0, expect to have two repair jobs pending for 1 and 2 and execute it.
+    EXPECT_EQ(tiered_index->deleteVector(0), 1);
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 2);
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->jobType, SVS_REPAIR_NODE_CONNECTIONS_JOB);
+    mock_thread_pool.thread_iteration();
+    EXPECT_EQ(tiered_index->idToSwapJob.at(0)->pending_repair_jobs_counter.load(), 1);
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->jobType, SVS_REPAIR_NODE_CONNECTIONS_JOB);
+    mock_thread_pool.thread_iteration();
+    EXPECT_EQ(tiered_index->idToSwapJob.at(0)->pending_repair_jobs_counter.load(), 0);
+    // Delete 2, expect to create two repair job pending from 0 and 1. Also, expect that swap
+    // job for 0 will be executed, so that 2 and 0 are swapped. Then, we should have only 1
+    // pending repair job for the "new" 0 - for deleting the old 1->2, while the second job for
+    // deleting the old 0->2 is invalid and reduced from the pending repair jobs counter.
+    EXPECT_EQ(tiered_index->deleteVector(2), 1);
+    EXPECT_EQ(tiered_index->indexSize(), 2);
+    EXPECT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 1);
+
+    EXPECT_EQ(tiered_index->idToSwapJob.at(0)->pending_repair_jobs_counter.load(), 1);
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 2);
+    // The first repair job should remove 1->0 (originally was 1->2).
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->jobType, SVS_REPAIR_NODE_CONNECTIONS_JOB);
+    ASSERT_EQ(reinterpret_cast<SVSRepairJob *>(mock_thread_pool.jobQ.front().job)->node_id, 1);
+    ASSERT_EQ(reinterpret_cast<SVSRepairJob *>(mock_thread_pool.jobQ.front().job)
+                  ->associatedSwapJobs[0]
+                  ->deleted_id,
+              0);
+    mock_thread_pool.thread_iteration();
+    EXPECT_EQ(tiered_index->idToSwapJob.at(0)->pending_repair_jobs_counter.load(), 0);
+    // The second repair job is invalid due to the removal of (the original) 0.
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->jobType, SVS_REPAIR_NODE_CONNECTIONS_JOB);
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->isValid, false);
+    ASSERT_EQ(reinterpret_cast<SVSRepairJob *>(mock_thread_pool.jobQ.front().job)->node_id,
+              invalid_jobs_counter++);
+    ASSERT_EQ(reinterpret_cast<SVSRepairJob *>(mock_thread_pool.jobQ.front().job)
+                  ->associatedSwapJobs[0]
+                  ->deleted_id,
+              0);
+    mock_thread_pool.thread_iteration();
+    // Delete 1, that should still have 0->1 edge that should be repaired. This should cause
+    // the swap and removal of 0 (that has no more pending jobs at that point) - so that 1 would
+    // get id 0, and then the new 0 should have no pending repair jobs.
+    EXPECT_EQ(tiered_index->deleteVector(1), 1);
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 1);
+    EXPECT_EQ(tiered_index->idToSwapJob.size(), 1);
+    EXPECT_EQ(tiered_index->idToSwapJob.at(0)->deleted_id, 0);
+    EXPECT_EQ(tiered_index->idToSwapJob.at(0)->pending_repair_jobs_counter.load(), 0);
+    // The repair job is invalid due to the removal of (the previous) 0.
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->jobType, SVS_REPAIR_NODE_CONNECTIONS_JOB);
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->isValid, false);
+    ASSERT_EQ(reinterpret_cast<SVSRepairJob *>(mock_thread_pool.jobQ.front().job)->node_id,
+              invalid_jobs_counter);
+    ASSERT_EQ(reinterpret_cast<SVSRepairJob *>(mock_thread_pool.jobQ.front().job)
+                  ->associatedSwapJobs[0]
+                  ->deleted_id,
+              0);
+    mock_thread_pool.thread_iteration();
+    EXPECT_EQ(tiered_index->indexSize(), 1);
+    EXPECT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 1);
+    EXPECT_EQ(tiered_index->getSVSIndex()->safeGetEntryPointState().first, INVALID_ID);
+
+    // Call delete again, this should only trigger the swap and removal of 1
+    // (which has already deleted)
+    EXPECT_EQ(tiered_index->deleteVector(1), 0);
+    EXPECT_EQ(tiered_index->indexSize(), 0);
+    EXPECT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 0);
+}
+
+// A set of lambdas that determine whether a vector should be inserted to the
+// SVS index (returns true) or to the flat index (returns false).
+inline constexpr std::array<std::pair<std::string_view, bool (*)(size_t, size_t)>, 11> lambdas = {{
+    {"100% SVS,   0% FLAT ", [](size_t idx, size_t n) -> bool { return 1; }},
+    {" 50% SVS,  50% FLAT ", [](size_t idx, size_t n) -> bool { return idx % 2; }},
+    {"  0% SVS, 100% FLAT ", [](size_t idx, size_t n) -> bool { return 0; }},
+    {" 90% SVS,  10% FLAT ", [](size_t idx, size_t n) -> bool { return idx % 10; }},
+    {" 10% SVS,  90% FLAT ", [](size_t idx, size_t n) -> bool { return !(idx % 10); }},
+    {" 99% SVS,   1% FLAT ", [](size_t idx, size_t n) -> bool { return idx % 100; }},
+    {"  1% SVS,  99% FLAT ", [](size_t idx, size_t n) -> bool { return !(idx % 100); }},
+    {"first 10% are in SVS", [](size_t idx, size_t n) -> bool { return idx < (n / 10); }},
+    {"first 10% are in FLAT", [](size_t idx, size_t n) -> bool { return idx >= (n / 10); }},
+    {" last 10% are in FLAT", [](size_t idx, size_t n) -> bool { return idx < (9 * n / 10); }},
+    {" last 10% are in SVS", [](size_t idx, size_t n) -> bool { return idx >= (9 * n / 10); }},
+}};
+
+TYPED_TEST(SVSTieredIndexTest, BatchIterator) {
+    size_t d = 4;
+    size_t M = 8;
+    size_t ef = 20;
+    size_t n = 1000;
+
+    size_t per_label = TypeParam::isMulti() ? 10 : 1;
+    size_t n_labels = n / per_label;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams svs_params = {
+        .type = TypeParam::get_index_type(),
+        .dim = d,
+        .metric = VecSimMetric_L2,
+        .efConstruction = ef,
+        .efRuntime = ef,
+    };
+    VecSimParams params = CreateParams(svs_params);
+
+    // for (auto &[decider_name, decider] : lambdas) { // TODO: not supported by clang < 16
+    for (auto &lambda : lambdas) {
+        // manually deconstruct the pair to avoid the clang error
+        auto &decider_name = lambda.first;
+        auto &decider = lambda.second;
+
+        auto mock_thread_pool = tieredIndexMock();
+
+        auto *tiered_index = this->CreateTieredSVSIndex(params, mock_thread_pool);
+        auto allocator = tiered_index->getAllocator();
+
+        auto *svs = tiered_index->backendIndex;
+        auto *flat = tiered_index->frontendIndex;
+
+        // For every i, add the vector (i,i,i,i) under the label i.
+        for (size_t i = 0; i < n; i++) {
+            auto cur = decider(i, n) ? svs : flat;
+            GenerateAndAddVector<TEST_DATA_T>(cur, d, i % n_labels, i);
+        }
+        ASSERT_EQ(VecSimIndex_IndexSize(tiered_index), n) << decider_name;
+
+        // Query for (n,n,n,n) vector (recall that n-1 is the largest id in te index).
+        TEST_DATA_T query[d];
+        GenerateVector<TEST_DATA_T>(query, d, n);
+
+        VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(tiered_index, query, nullptr);
+        size_t iteration_num = 0;
+
+        // Get the 5 vectors whose ids are the maximal among those that hasn't been returned yet
+        // in every iteration. The results order should be sorted by their score (distance from
+        // the query vector), which means sorted from the largest id to the lowest.
+        size_t n_res = 5;
+        while (VecSimBatchIterator_HasNext(batchIterator)) {
+            std::vector<size_t> expected_ids(n_res);
+            for (size_t i = 0; i < n_res; i++) {
+                expected_ids[i] = (n - iteration_num * n_res - i - 1) % n_labels;
+            }
+            auto verify_res = [&](size_t id, double score, size_t index) {
+                ASSERT_EQ(expected_ids[index], id) << decider_name;
+            };
+            runBatchIteratorSearchTest(batchIterator, n_res, verify_res);
+            iteration_num++;
+        }
+        ASSERT_EQ(iteration_num, n_labels / n_res) << decider_name;
+        VecSimBatchIterator_Free(batchIterator);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTest, BatchIteratorReset) {
+    size_t d = 4;
+    size_t M = 8;
+    size_t ef = 20;
+    size_t n = 1000;
+
+    size_t per_label = TypeParam::isMulti() ? 10 : 1;
+    size_t n_labels = n / per_label;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams svs_params = {
+        .type = TypeParam::get_index_type(),
+        .dim = d,
+        .metric = VecSimMetric_L2,
+        .efConstruction = ef,
+        .efRuntime = ef,
+    };
+    VecSimParams params = CreateParams(svs_params);
+
+    // for (auto &[decider_name, decider] : lambdas) { // TODO: not supported by clang < 16
+    for (auto &lambda : lambdas) {
+        // manually deconstruct the pair to avoid the clang error
+        auto &decider_name = lambda.first;
+        auto &decider = lambda.second;
+
+        auto mock_thread_pool = tieredIndexMock();
+
+        auto *tiered_index = this->CreateTieredSVSIndex(params, mock_thread_pool);
+        auto allocator = tiered_index->getAllocator();
+
+        auto *svs = tiered_index->backendIndex;
+        auto *flat = tiered_index->frontendIndex;
+
+        // For every i, add the vector (i,i,i,i) under the label i.
+        for (size_t i = 0; i < n; i++) {
+            auto cur = decider(i, n) ? svs : flat;
+            GenerateAndAddVector<TEST_DATA_T>(cur, d, i % n_labels, i);
+        }
+        ASSERT_EQ(VecSimIndex_IndexSize(tiered_index), n) << decider_name;
+
+        // Query for (n,n,n,n) vector (recall that n-1 is the largest id in te index).
+        TEST_DATA_T query[d];
+        GenerateVector<TEST_DATA_T>(query, d, n);
+
+        VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(tiered_index, query, nullptr);
+        ASSERT_NO_FATAL_FAILURE(VecSimBatchIterator_Reset(batchIterator));
+
+        // Get the 100 vectors whose ids are the maximal among those that hasn't been returned yet,
+        // in every iteration. Run this flow for 3 times, and reset the iterator.
+        size_t n_res = 100;
+        size_t re_runs = 3;
+
+        for (size_t take = 0; take < re_runs; take++) {
+            size_t iteration_num = 0;
+            while (VecSimBatchIterator_HasNext(batchIterator)) {
+                std::vector<size_t> expected_ids(n_res);
+                for (size_t i = 0; i < n_res; i++) {
+                    expected_ids[i] = (n - iteration_num * n_res - i - 1) % n_labels;
+                }
+                auto verify_res = [&](size_t id, double score, size_t index) {
+                    ASSERT_EQ(expected_ids[index], id) << decider_name;
+                };
+                runBatchIteratorSearchTest(batchIterator, n_res, verify_res, BY_SCORE);
+                iteration_num++;
+            }
+            ASSERT_EQ(iteration_num, n_labels / n_res) << decider_name;
+            VecSimBatchIterator_Reset(batchIterator);
+        }
+
+        // Try resetting the iterator before it is depleted.
+        n_res = 10;
+        for (size_t take = 0; take < re_runs; take++) {
+            size_t iteration_num = 0;
+            do {
+                ASSERT_TRUE(VecSimBatchIterator_HasNext(batchIterator)) << decider_name;
+                std::vector<size_t> expected_ids(n_res);
+                for (size_t i = 0; i < n_res; i++) {
+                    expected_ids[i] = (n - iteration_num * n_res - i - 1) % n_labels;
+                }
+                auto verify_res = [&](size_t id, double score, size_t index) {
+                    ASSERT_EQ(expected_ids[index], id) << decider_name;
+                };
+                runBatchIteratorSearchTest(batchIterator, n_res, verify_res, BY_SCORE);
+            } while (5 > iteration_num++);
+            VecSimBatchIterator_Reset(batchIterator);
+        }
+        VecSimBatchIterator_Free(batchIterator);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTest, BatchIteratorSize1) {
+    size_t d = 4;
+    size_t M = 8;
+    size_t ef = 20;
+    size_t n = 1000;
+
+    size_t per_label = TypeParam::isMulti() ? 10 : 1;
+    size_t n_labels = n / per_label;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams svs_params = {
+        .type = TypeParam::get_index_type(),
+        .dim = d,
+        .metric = VecSimMetric_L2,
+        .efConstruction = ef,
+        .efRuntime = ef,
+    };
+    VecSimParams params = CreateParams(svs_params);
+
+    // for (auto &[decider_name, decider] : lambdas) { // TODO: not supported by clang < 16
+    for (auto &lambda : lambdas) {
+        // manually deconstruct the pair to avoid the clang error
+        auto &decider_name = lambda.first;
+        auto &decider = lambda.second;
+
+        auto mock_thread_pool = tieredIndexMock();
+
+        auto *tiered_index = this->CreateTieredSVSIndex(params, mock_thread_pool);
+        auto allocator = tiered_index->getAllocator();
+
+        auto *svs = tiered_index->backendIndex;
+        auto *flat = tiered_index->frontendIndex;
+
+        // For every i, add the vector (i,i,i,i) under the label `n_labels - (i % n_labels)`.
+        for (size_t i = 0; i < n; i++) {
+            auto cur = decider(i, n) ? svs : flat;
+            GenerateAndAddVector<TEST_DATA_T>(cur, d, n_labels - (i % n_labels), i);
+        }
+        ASSERT_EQ(VecSimIndex_IndexSize(tiered_index), n) << decider_name;
+
+        // Query for (n,n,n,n) vector (recall that n-1 is the largest id in te index).
+        TEST_DATA_T query[d];
+        GenerateVector<TEST_DATA_T>(query, d, n);
+
+        VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(tiered_index, query, nullptr);
+
+        size_t iteration_num = 0;
+        size_t n_res = 1, expected_n_res = 1;
+        while (VecSimBatchIterator_HasNext(batchIterator)) {
+            iteration_num++;
+            // Expect to get results in the reverse order of labels - which is the order of the
+            // distance from the query vector. Get one result in every iteration.
+            auto verify_res = [&](size_t id, double score, size_t index) {
+                ASSERT_EQ(id, iteration_num) << decider_name;
+            };
+            runBatchIteratorSearchTest(batchIterator, n_res, verify_res, BY_SCORE, expected_n_res);
+        }
+
+        ASSERT_EQ(iteration_num, n_labels) << decider_name;
+        VecSimBatchIterator_Free(batchIterator);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTest, BatchIteratorAdvanced) {
+    size_t d = 4;
+    size_t M = 8;
+    size_t ef = 1000;
+    size_t n = 1000;
+
+    size_t per_label = TypeParam::isMulti() ? 10 : 1;
+    size_t n_labels = n / per_label;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams svs_params = {
+        .type = TypeParam::get_index_type(),
+        .dim = d,
+        .metric = VecSimMetric_L2,
+        .efConstruction = ef,
+    };
+    VecSimParams params = CreateParams(svs_params);
+    SVSRuntimeParams svsRuntimeParams = {.efRuntime = ef};
+    VecSimQueryParams query_params = CreateQueryParams(svsRuntimeParams);
+
+    // for (auto &[decider_name, decider] : lambdas) { // TODO: not supported by clang < 16
+    for (auto &lambda : lambdas) {
+        // manually deconstruct the pair to avoid the clang error
+        auto &decider_name = lambda.first;
+        auto &decider = lambda.second;
+
+        auto mock_thread_pool = tieredIndexMock();
+
+        auto *tiered_index = this->CreateTieredSVSIndex(params, mock_thread_pool);
+        auto allocator = tiered_index->getAllocator();
+
+        auto *svs = tiered_index->backendIndex;
+        auto *flat = tiered_index->frontendIndex;
+
+        TEST_DATA_T query[d];
+        GenerateVector<TEST_DATA_T>(query, d, n);
+
+        VecSimBatchIterator *batchIterator =
+            VecSimBatchIterator_New(tiered_index, query, &query_params);
+
+        // Try to get results even though there are no vectors in the index.
+        VecSimQueryReply *res = VecSimBatchIterator_Next(batchIterator, 10, BY_SCORE);
+        ASSERT_EQ(VecSimQueryReply_Len(res), 0) << decider_name;
+        VecSimQueryReply_Free(res);
+        ASSERT_FALSE(VecSimBatchIterator_HasNext(batchIterator)) << decider_name;
+
+        // Insert one label and query again. The internal id will be 0.
+        for (size_t j = 0; j < per_label; j++) {
+            GenerateAndAddVector<TEST_DATA_T>(decider(n_labels, n) ? svs : flat, d, n_labels,
+                                              n - j);
+        }
+        VecSimBatchIterator_Reset(batchIterator);
+        res = VecSimBatchIterator_Next(batchIterator, 10, BY_SCORE);
+        ASSERT_EQ(VecSimQueryReply_Len(res), 1) << decider_name;
+        VecSimQueryReply_Free(res);
+        ASSERT_FALSE(VecSimBatchIterator_HasNext(batchIterator)) << decider_name;
+        VecSimBatchIterator_Free(batchIterator);
+
+        // Insert vectors to the index and re-create the batch iterator.
+        for (size_t i = 1; i < n_labels; i++) {
+            auto cur = decider(i, n) ? svs : flat;
+            for (size_t j = 1; j <= per_label; j++) {
+                GenerateAndAddVector<TEST_DATA_T>(cur, d, i, (i - 1) * per_label + j);
+            }
+        }
+        ASSERT_EQ(VecSimIndex_IndexSize(tiered_index), n) << decider_name;
+        batchIterator = VecSimBatchIterator_New(tiered_index, query, &query_params);
+
+        // Try to get 0 results.
+        res = VecSimBatchIterator_Next(batchIterator, 0, BY_SCORE);
+        ASSERT_EQ(VecSimQueryReply_Len(res), 0) << decider_name;
+        VecSimQueryReply_Free(res);
+
+        // n_res does not divide into ef or vice versa - expect leftovers between the graph scans.
+        size_t n_res = 7;
+        size_t iteration_num = 0;
+
+        while (VecSimBatchIterator_HasNext(batchIterator)) {
+            iteration_num++;
+            std::vector<size_t> expected_ids;
+            // We ask to get the results sorted by ID in a specific batch (in ascending order), but
+            // in every iteration the ids should be lower than the previous one, according to the
+            // distance from the query.
+            for (size_t i = 1; i <= n_res; i++) {
+                expected_ids.push_back(n_labels - iteration_num * n_res + i);
+            }
+            auto verify_res = [&](size_t id, double score, size_t index) {
+                ASSERT_EQ(expected_ids[index], id) << decider_name;
+            };
+            if (iteration_num <= n_labels / n_res) {
+                runBatchIteratorSearchTest(batchIterator, n_res, verify_res, BY_ID);
+            } else {
+                // In the last iteration there are `n_labels % n_res` results left to return.
+                size_t n_left = n_labels % n_res;
+                // Remove the first `n_res - n_left` ids from the expected ids.
+                while (expected_ids.size() > n_left) {
+                    expected_ids.erase(expected_ids.begin());
+                }
+                runBatchIteratorSearchTest(batchIterator, n_res, verify_res, BY_ID, n_left);
+            }
+        }
+        ASSERT_EQ(iteration_num, n_labels / n_res + 1) << decider_name;
+        // Try to get more results even though there are no.
+        res = VecSimBatchIterator_Next(batchIterator, 1, BY_SCORE);
+        ASSERT_EQ(VecSimQueryReply_Len(res), 0) << decider_name;
+        VecSimQueryReply_Free(res);
+
+        VecSimBatchIterator_Free(batchIterator);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTest, BatchIteratorWithOverlaps) {
+    size_t d = 4;
+    size_t M = 8;
+    size_t ef = 20;
+    size_t n = 1000;
+
+    size_t per_label = TypeParam::isMulti() ? 10 : 1;
+    size_t n_labels = n / per_label;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams svs_params = {
+        .type = TypeParam::get_index_type(),
+        .dim = d,
+        .metric = VecSimMetric_L2,
+        .efConstruction = ef,
+        .efRuntime = ef,
+    };
+    VecSimParams params = CreateParams(svs_params);
+
+    // for (auto &[decider_name, decider] : lambdas) { // TODO: not supported by clang < 16
+    for (auto &lambda : lambdas) {
+        // manually deconstruct the pair to avoid the clang error
+        auto &decider_name = lambda.first;
+        auto &decider = lambda.second;
+
+        auto mock_thread_pool = tieredIndexMock();
+
+        auto *tiered_index = this->CreateTieredSVSIndex(params, mock_thread_pool);
+        auto allocator = tiered_index->getAllocator();
+
+        auto *svs = tiered_index->backendIndex;
+        auto *flat = tiered_index->frontendIndex;
+
+        // For every i, add the vector (i,i,i,i) under the label i.
+        size_t flat_count = 0;
+        for (size_t i = 0; i < n; i++) {
+            auto cur = decider(i, n) ? svs : flat;
+            GenerateAndAddVector<TEST_DATA_T>(cur, d, i % n_labels, i);
+            if (cur == flat) {
+                flat_count++;
+                // Add 10% of the vectors in FLAT to SVS as well.
+                if (flat_count % 10 == 0) {
+                    GenerateAndAddVector<TEST_DATA_T>(svs, d, i % n_labels, i);
+                }
+            }
+        }
+        // The index size should be 100-110% of n.
+        ASSERT_LE(VecSimIndex_IndexSize(tiered_index), n * 1.1) << decider_name;
+        ASSERT_GE(VecSimIndex_IndexSize(tiered_index), n) << decider_name;
+        // The number of unique labels should be n_labels.
+        ASSERT_EQ(tiered_index->indexLabelCount(), n_labels) << decider_name;
+
+        // Query for (n,n,n,n) vector (recall that n-1 is the largest id in te index).
+        TEST_DATA_T query[d];
+        GenerateVector<TEST_DATA_T>(query, d, n);
+
+        VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(tiered_index, query, nullptr);
+        size_t iteration_num = 0;
+
+        // Get the 5 vectors whose ids are the maximal among those that hasn't been returned yet
+        // in every iteration. The results order should be sorted by their score (distance from
+        // the query vector), which means sorted from the largest id to the lowest.
+        size_t n_res = 5;
+        size_t n_expected = n_res;
+        size_t excessive_iterations = 0;
+        while (VecSimBatchIterator_HasNext(batchIterator)) {
+            if (iteration_num * n_res == n_labels) {
+                // in some cases, the batch iterator may report that it has more results to return,
+                // but it's actually not true and the next call to `VecSimBatchIterator_Next` will
+                // return 0 results. This is safe because we don't guarantee how many results the
+                // batch iterator will return, and a similar scenario can happen when checking
+                // `VecSimBatchIterator_HasNext` on an empty index for the first time (before the
+                // first call to `VecSimBatchIterator_Next`). we check that this scenario doesn't
+                // happen more than once.
+                ASSERT_EQ(excessive_iterations, 0) << decider_name;
+                excessive_iterations = 1;
+                n_expected = 0;
+            }
+            std::vector<size_t> expected_ids(n_expected);
+            for (size_t i = 0; i < n_expected; i++) {
+                expected_ids[i] = (n - iteration_num * n_expected - i - 1) % n_labels;
+            }
+            auto verify_res = [&](size_t id, double score, size_t index) {
+                ASSERT_EQ(expected_ids[index], id) << decider_name;
+            };
+            runBatchIteratorSearchTest(batchIterator, n_res, verify_res, BY_SCORE, n_expected);
+            iteration_num++;
+        }
+        ASSERT_EQ(iteration_num - excessive_iterations, n_labels / n_res)
+            << decider_name << "\nHad excessive iterations: " << (excessive_iterations != 0);
+        VecSimBatchIterator_Free(batchIterator);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, BatchIteratorWithOverlaps_SpacialMultiCases) {
+    size_t d = 4;
+
+    std::shared_ptr<VecSimAllocator> allocator;
+    TieredSVSIndex<TEST_DATA_T, TEST_DIST_T> *tiered_index;
+    VecSimIndex *svs, *flat;
+    TEST_DATA_T query[d];
+    VecSimBatchIterator *iterator;
+    VecSimQueryReply *batch;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams svs_params = {
+        .type = TypeParam::get_index_type(),
+        .dim = d,
+        .metric = VecSimMetric_L2,
+    };
+    VecSimParams params = CreateParams(svs_params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto L2 = [&](size_t element) { return element * element * d; };
+
+    // TEST 1:
+    // first batch contains duplicates with different scores.
+    tiered_index = this->CreateTieredSVSIndex(params, mock_thread_pool);
+    allocator = tiered_index->getAllocator();
+    svs = tiered_index->backendIndex;
+    flat = tiered_index->frontendIndex;
+
+    GenerateAndAddVector<TEST_DATA_T>(flat, d, 0, 0);
+    GenerateAndAddVector<TEST_DATA_T>(flat, d, 1, 1);
+    GenerateAndAddVector<TEST_DATA_T>(flat, d, 2, 2);
+
+    GenerateAndAddVector<TEST_DATA_T>(svs, d, 1, 3);
+    GenerateAndAddVector<TEST_DATA_T>(svs, d, 0, 4);
+    GenerateAndAddVector<TEST_DATA_T>(svs, d, 3, 5);
+
+    ASSERT_EQ(tiered_index->indexLabelCount(), 4);
+
+    GenerateVector<TEST_DATA_T>(query, d, 0);
+    iterator = VecSimBatchIterator_New(tiered_index, query, nullptr);
+
+    // batch size is 3 (the size of each index). Internally the tiered batch iterator will have to
+    // handle the duplicates with different scores.
+    ASSERT_TRUE(VecSimBatchIterator_HasNext(iterator));
+    batch = VecSimBatchIterator_Next(iterator, 3, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(batch), 3);
+    ASSERT_EQ(VecSimQueryResult_GetId(batch->results.data() + 0), 0);
+    ASSERT_EQ(VecSimQueryResult_GetScore(batch->results.data() + 0), L2(0));
+    ASSERT_EQ(VecSimQueryResult_GetId(batch->results.data() + 1), 1);
+    ASSERT_EQ(VecSimQueryResult_GetScore(batch->results.data() + 1), L2(1));
+    ASSERT_EQ(VecSimQueryResult_GetId(batch->results.data() + 2), 2);
+    ASSERT_EQ(VecSimQueryResult_GetScore(batch->results.data() + 2), L2(2));
+    VecSimQueryReply_Free(batch);
+
+    // we have 1 more label in the index. we expect the tiered batch iterator to return it only and
+    // filter out the duplicates.
+    ASSERT_TRUE(VecSimBatchIterator_HasNext(iterator));
+    batch = VecSimBatchIterator_Next(iterator, 2, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(batch), 1);
+    ASSERT_EQ(VecSimQueryResult_GetId(batch->results.data() + 0), 3);
+    ASSERT_EQ(VecSimQueryResult_GetScore(batch->results.data() + 0), L2(5));
+    ASSERT_FALSE(VecSimBatchIterator_HasNext(iterator));
+    VecSimQueryReply_Free(batch);
+    // TEST 1 clean up.
+    VecSimBatchIterator_Free(iterator);
+
+    // TEST 2:
+    // second batch contains duplicates (different scores) from the first batch.
+    auto *ctx = new tieredIndexMock::IndexExtCtx(&mock_thread_pool);
+    mock_thread_pool.reset_ctx(ctx);
+    tiered_index = this->CreateTieredSVSIndex(params, mock_thread_pool);
+    allocator = tiered_index->getAllocator();
+    svs = tiered_index->backendIndex;
+    flat = tiered_index->frontendIndex;
+
+    GenerateAndAddVector<TEST_DATA_T>(svs, d, 0, 0);
+    GenerateAndAddVector<TEST_DATA_T>(svs, d, 1, 1);
+    GenerateAndAddVector<TEST_DATA_T>(svs, d, 2, 2);
+    GenerateAndAddVector<TEST_DATA_T>(svs, d, 3, 3);
+
+    GenerateAndAddVector<TEST_DATA_T>(flat, d, 2, 0);
+    GenerateAndAddVector<TEST_DATA_T>(flat, d, 3, 1);
+    GenerateAndAddVector<TEST_DATA_T>(flat, d, 0, 2);
+    GenerateAndAddVector<TEST_DATA_T>(flat, d, 1, 3);
+
+    ASSERT_EQ(tiered_index->indexLabelCount(), 4);
+
+    iterator = VecSimBatchIterator_New(tiered_index, query, nullptr);
+
+    // ask for 2 results. The internal batch iterators will return 2 results: svs - [0, 1], flat -
+    // [2, 3] so there are no duplicates.
+    ASSERT_TRUE(VecSimBatchIterator_HasNext(iterator));
+    batch = VecSimBatchIterator_Next(iterator, 2, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(batch), 2);
+    ASSERT_EQ(VecSimQueryResult_GetId(batch->results.data() + 0), 0);
+    ASSERT_EQ(VecSimQueryResult_GetScore(batch->results.data() + 0), L2(0));
+    ASSERT_EQ(VecSimQueryResult_GetId(batch->results.data() + 1), 2);
+    ASSERT_EQ(VecSimQueryResult_GetScore(batch->results.data() + 1), L2(0));
+    VecSimQueryReply_Free(batch);
+
+    // first batch contained 1 result from each index, so there is one leftover from each iterator.
+    // Asking for 3 results will return additional 2 results from each iterator and the tiered batch
+    // iterator will have to handle the duplicates that each iterator returned (both labels that
+    // were returned in the first batch and duplicates in the current batch).
+    ASSERT_TRUE(VecSimBatchIterator_HasNext(iterator));
+    batch = VecSimBatchIterator_Next(iterator, 3, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(batch), 2);
+    ASSERT_EQ(VecSimQueryResult_GetId(batch->results.data() + 0), 1);
+    ASSERT_EQ(VecSimQueryResult_GetScore(batch->results.data() + 0), L2(1));
+    ASSERT_EQ(VecSimQueryResult_GetId(batch->results.data() + 1), 3);
+    ASSERT_EQ(VecSimQueryResult_GetScore(batch->results.data() + 1), L2(1));
+    ASSERT_FALSE(VecSimBatchIterator_HasNext(iterator));
+    VecSimQueryReply_Free(batch);
+    // TEST 2 clean up.
+    VecSimBatchIterator_Free(iterator);
+}
+
+TYPED_TEST(SVSTieredIndexTest, parallelBatchIteratorSearch) {
+    size_t dim = 4;
+    size_t ef = 500;
+    size_t n = 1000;
+    size_t n_res_min = 3;  // minimum number of results to return per batch
+    size_t n_res_max = 15; // maximum number of results to return per batch
+    bool isMulti = TypeParam::isMulti();
+
+    size_t per_label = isMulti ? 5 : 1;
+    size_t n_labels = n / per_label;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+        .efRuntime = ef,
+    };
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+
+    std::atomic_int successful_searches(0);
+    auto parallel_10_batches = [](AsyncJob *job) {
+        auto *search_job = reinterpret_cast<tieredIndexMock::SearchJobMock *>(job);
+        const size_t res_per_batch = search_job->k;
+        const size_t dim = search_job->dim;
+        const auto query = search_job->query;
+
+        size_t iteration = 0;
+        auto verify_res = [&](size_t id, double score, size_t res_index) {
+            TEST_DATA_T element = *(TEST_DATA_T *)query;
+            res_index += iteration * res_per_batch;
+            ASSERT_EQ(std::abs(id - element), (res_index + 1) / 2);
+            ASSERT_EQ(score, dim * (id - element) * (id - element));
+        };
+
+        // Run 10 batches of search.
+        auto tiered_iterator = VecSimBatchIterator_New(search_job->index, query, nullptr);
+        do {
+            runBatchIteratorSearchTest(tiered_iterator, res_per_batch, verify_res);
+        } while (++iteration < 10 && VecSimBatchIterator_HasNext(tiered_iterator));
+
+        VecSimBatchIterator_Free(tiered_iterator);
+        (*search_job->successful_searches)++;
+        delete job;
+    };
+
+    // Fill the job queue with insert and batch-search jobs, while filling the flat index, before
+    // initializing the thread pool.
+    for (size_t i = 0; i < n; i++) {
+        // Insert a vector to the flat index and add a job to insert it to the main index.
+        GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, i % n_labels, i);
+
+        // Add a search job.
+        size_t cur_res_per_batch = i % (n_res_max - n_res_min) + n_res_min;
+        size_t n_res = cur_res_per_batch * 10;
+        auto query = (TEST_DATA_T *)allocator->allocate(dim * sizeof(TEST_DATA_T));
+        // make sure there are `n_res / 2` vectors in the index in each "side" of the query vector.
+        GenerateVector<TEST_DATA_T>(query, dim, (i % (n_labels - n_res)) + (n_res / 2));
+        auto search_job = new (allocator)
+            tieredIndexMock::SearchJobMock(allocator, parallel_10_batches, tiered_index,
+                                           cur_res_per_batch, query, n, dim, &successful_searches);
+        tiered_index->submitSingleJob(search_job);
+    }
+
+    EXPECT_EQ(tiered_index->indexSize(), n);
+    EXPECT_EQ(tiered_index->indexLabelCount(), n_labels);
+    EXPECT_EQ(tiered_index->labelToInsertJobs.size(), n_labels);
+    for (auto &it : tiered_index->labelToInsertJobs) {
+        EXPECT_EQ(it.second.size(), per_label);
+    }
+    EXPECT_EQ(tiered_index->frontendIndex->indexSize(), n);
+    EXPECT_EQ(tiered_index->backendIndex->indexSize(), 0);
+
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    // All the vectors are already in the tiered index, so we expect to find the expected
+    // results from the get-go.
+    mock_thread_pool.init_threads();
+    mock_thread_pool.thread_pool_join();
+
+    EXPECT_EQ(tiered_index->backendIndex->indexSize(), n);
+    EXPECT_EQ(tiered_index->backendIndex->indexLabelCount(), n_labels);
+    EXPECT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+    EXPECT_EQ(tiered_index->labelToInsertJobs.size(), 0);
+    EXPECT_EQ(successful_searches, n);
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 0);
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, overwriteVectorBasic) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    size_t n = 1000;
+    SVSParams params = {
+        .type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1);
+    auto allocator = tiered_index->getAllocator();
+
+    TEST_DATA_T val = 1.0;
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, 0, val);
+    // Overwrite label 0 (in the flat buffer) with a different value.
+    val = 2.0;
+    TEST_DATA_T overwritten_vec[] = {val, val, val, val};
+    ASSERT_EQ(tiered_index->addVector(overwritten_vec, 0), 0);
+    ASSERT_EQ(tiered_index->indexLabelCount(), 1);
+    ASSERT_EQ(tiered_index->indexSize(), 1);
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
+    ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(0, overwritten_vec), 0);
+
+    // Validate that jobs were created properly - first job should be invalid after overwrite,
+    // the second should be a pending insert job.
+    ASSERT_EQ(tiered_index->labelToInsertJobs.at(0).size(), 1);
+    auto *pending_insert_job = tiered_index->labelToInsertJobs.at(0)[0];
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 2);
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->jobType, SVS_INSERT_VECTOR_JOB);
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->isValid, false);
+    ASSERT_EQ(reinterpret_cast<SVSInsertJob *>(mock_thread_pool.jobQ.front().job)->label, 0);
+    ASSERT_EQ(reinterpret_cast<SVSInsertJob *>(mock_thread_pool.jobQ.front().job)->id, 0);
+    mock_thread_pool.thread_iteration();
+
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->jobType, SVS_INSERT_VECTOR_JOB);
+    ASSERT_EQ(reinterpret_cast<SVSInsertJob *>(mock_thread_pool.jobQ.front().job)->label, 0);
+    ASSERT_EQ(reinterpret_cast<SVSInsertJob *>(mock_thread_pool.jobQ.front().job)->id, 0);
+    ASSERT_EQ(reinterpret_cast<SVSInsertJob *>(mock_thread_pool.jobQ.front().job),
+              pending_insert_job);
+
+    // Ingest vector into SVS, and then overwrite it.
+    mock_thread_pool.thread_iteration();
+    ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+    val = 3.0;
+    overwritten_vec[0] = overwritten_vec[1] = overwritten_vec[2] = overwritten_vec[3] = val;
+    ASSERT_EQ(tiered_index->addVector(overwritten_vec, 0), 0);
+    ASSERT_EQ(tiered_index->indexLabelCount(), 1);
+    // Swap job should be executed for the overwritten vector since limit is 1, and we are calling
+    // swap job execution prior to insert jobs.
+    ASSERT_EQ(tiered_index->backendIndex->indexSize(), 0);
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
+    ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(0, overwritten_vec), 0);
+
+    // Ingest the updated vector to SVS.
+    mock_thread_pool.thread_iteration();
+    ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+    ASSERT_EQ(tiered_index->indexLabelCount(), 1);
+    ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(0, overwritten_vec), 0);
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, overwriteVectorAsync) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    size_t n = 1000;
+    SVSParams params = {
+        .type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    for (size_t maxSwapJobs : {(int)n + 1, 1}) {
+        auto mock_thread_pool = tieredIndexMock();
+
+        auto *tiered_index =
+            this->CreateTieredSVSIndex(svs_params, mock_thread_pool, maxSwapJobs);
+        auto allocator = tiered_index->getAllocator();
+
+        // Launch the BG threads loop that takes jobs from the queue and executes them.
+
+        for (size_t i = 0; i < mock_thread_pool.thread_pool_size; i++) {
+            mock_thread_pool.thread_pool.emplace_back(tieredIndexMock::thread_main_loop, i,
+                                                      std::ref(mock_thread_pool));
+        }
+
+        // Insert vectors and overwrite them multiple times while thread run in the background.
+        std::srand(10); // create pseudo random generator with any arbitrary seed.
+        for (size_t i = 0; i < n; i++) {
+            TEST_DATA_T vector[dim];
+            for (size_t j = 0; j < dim; j++) {
+                vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+            }
+            tiered_index->addVector(vector, i);
+        }
+        EXPECT_EQ(tiered_index->indexLabelCount(), n);
+
+        size_t num_overwrites = 1000;
+        for (size_t i = 0; i < num_overwrites; i++) {
+            size_t label_to_overwrite = std::rand() % n;
+            TEST_DATA_T vector[dim];
+            for (size_t j = 0; j < dim; j++) {
+                vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+            }
+            EXPECT_EQ(tiered_index->addVector(vector, label_to_overwrite), 0);
+        }
+
+        mock_thread_pool.thread_pool_join();
+
+        EXPECT_EQ(tiered_index->indexSize() - tiered_index->getSVSIndex()->getNumMarkedDeleted(),
+                  n);
+        EXPECT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+        EXPECT_EQ(tiered_index->indexLabelCount(), n);
+        auto report = tiered_index->getSVSIndex()->checkIntegrity();
+        EXPECT_EQ(report.connections_to_repair, 0);
+        EXPECT_EQ(report.valid_state, true);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTest, testInfo) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    size_t n = 1000;
+    SVSParams params = {.type = TypeParam::get_index_type(),
+                         .dim = dim,
+                         .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1, 1000);
+    auto allocator = tiered_index->getAllocator();
+
+    VecSimIndexInfo info = tiered_index->info();
+    EXPECT_EQ(info.commonInfo.basicInfo.algo, VecSimAlgo_SVSLIB);
+    EXPECT_EQ(info.commonInfo.indexSize, 0);
+    EXPECT_EQ(info.commonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.commonInfo.memory, tiered_index->getAllocationSize());
+    EXPECT_EQ(info.commonInfo.basicInfo.isMulti, TypeParam::isMulti());
+    EXPECT_EQ(info.commonInfo.basicInfo.dim, dim);
+    EXPECT_EQ(info.commonInfo.basicInfo.metric, VecSimMetric_L2);
+    EXPECT_EQ(info.commonInfo.basicInfo.type, TypeParam::get_index_type());
+    EXPECT_EQ(info.commonInfo.basicInfo.blockSize, DEFAULT_BLOCK_SIZE);
+    VecSimIndexInfo frontendIndexInfo = tiered_index->frontendIndex->info();
+    VecSimIndexInfo backendIndexInfo = tiered_index->backendIndex->info();
+
+    compareCommonInfo(info.tieredInfo.frontendCommonInfo, frontendIndexInfo.commonInfo);
+    compareFlatInfo(info.tieredInfo.bfInfo, frontendIndexInfo.bfInfo);
+    compareCommonInfo(info.tieredInfo.backendCommonInfo, backendIndexInfo.commonInfo);
+    compareSVSInfo(info.tieredInfo.backendInfo.svsInfo, backendIndexInfo.svsInfo);
+
+    EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                          backendIndexInfo.commonInfo.memory +
+                                          frontendIndexInfo.commonInfo.memory);
+    EXPECT_EQ(info.tieredInfo.backgroundIndexing, false);
+    EXPECT_EQ(info.tieredInfo.bufferLimit, 1000);
+    EXPECT_EQ(info.tieredInfo.specificTieredBackendInfo.svsTieredInfo.pendingSwapJobsThreshold, 1);
+
+    // Validate that Static info returns the right restricted info as well.
+    VecSimIndexBasicInfo s_info = VecSimIndex_BasicInfo(tiered_index);
+    ASSERT_EQ(info.commonInfo.basicInfo.algo, s_info.algo);
+    ASSERT_EQ(info.commonInfo.basicInfo.dim, s_info.dim);
+    ASSERT_EQ(info.commonInfo.basicInfo.blockSize, s_info.blockSize);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    ASSERT_EQ(info.commonInfo.basicInfo.isMulti, s_info.isMulti);
+    ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
+    ASSERT_EQ(info.commonInfo.basicInfo.isTiered, s_info.isTiered);
+
+    GenerateAndAddVector(tiered_index, dim, 1, 1);
+    info = tiered_index->info();
+
+    EXPECT_EQ(info.commonInfo.indexSize, 1);
+    EXPECT_EQ(info.commonInfo.indexLabelCount, 1);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexSize, 0);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexSize, 1);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexLabelCount, 1);
+    EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                          info.tieredInfo.backendCommonInfo.memory +
+                                          info.tieredInfo.frontendCommonInfo.memory);
+    EXPECT_EQ(info.tieredInfo.backgroundIndexing, true);
+
+    mock_thread_pool.thread_iteration();
+    info = tiered_index->info();
+
+    EXPECT_EQ(info.commonInfo.indexSize, 1);
+    EXPECT_EQ(info.commonInfo.indexLabelCount, 1);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexSize, 1);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexLabelCount, 1);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexSize, 0);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                          info.tieredInfo.backendCommonInfo.memory +
+                                          info.tieredInfo.frontendCommonInfo.memory);
+    EXPECT_EQ(info.tieredInfo.backgroundIndexing, false);
+
+    if (TypeParam::isMulti()) {
+        GenerateAndAddVector(tiered_index, dim, 1, 1);
+        info = tiered_index->info();
+
+        EXPECT_EQ(info.commonInfo.indexSize, 2);
+        EXPECT_EQ(info.commonInfo.indexLabelCount, 1);
+        EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexSize, 1);
+        EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexLabelCount, 1);
+        EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexSize, 1);
+        EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexLabelCount, 1);
+        EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                              info.tieredInfo.backendCommonInfo.memory +
+                                              info.tieredInfo.frontendCommonInfo.memory);
+        EXPECT_EQ(info.tieredInfo.backgroundIndexing, true);
+    }
+
+    VecSimIndex_DeleteVector(tiered_index, 1);
+    info = tiered_index->info();
+
+    EXPECT_EQ(info.commonInfo.indexSize, 0);
+    EXPECT_EQ(info.commonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexSize, 0);
+    EXPECT_EQ(info.tieredInfo.backendCommonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexSize, 0);
+    EXPECT_EQ(info.tieredInfo.frontendCommonInfo.indexLabelCount, 0);
+    EXPECT_EQ(info.commonInfo.memory, info.tieredInfo.management_layer_memory +
+                                          info.tieredInfo.backendCommonInfo.memory +
+                                          info.tieredInfo.frontendCommonInfo.memory);
+    EXPECT_EQ(info.tieredInfo.backgroundIndexing, false);
+}
+
+TYPED_TEST(SVSTieredIndexTest, testInfoIterator) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    size_t n = 1000;
+    SVSParams params = {.type = TypeParam::get_index_type(),
+                         .dim = dim,
+                         .metric = VecSimMetric_L2};
+
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1);
+    auto allocator = tiered_index->getAllocator();
+
+    GenerateAndAddVector(tiered_index, dim, 1, 1);
+    VecSimIndexInfo info = tiered_index->info();
+    VecSimIndexInfo frontendIndexInfo = tiered_index->frontendIndex->info();
+    VecSimIndexInfo backendIndexInfo = tiered_index->backendIndex->info();
+
+    VecSimInfoIterator *infoIterator = tiered_index->infoIterator();
+    EXPECT_EQ(infoIterator->numberOfFields(), 15);
+
+    while (infoIterator->hasNext()) {
+        VecSim_InfoField *infoField = VecSimInfoIterator_NextField(infoIterator);
+
+        if (!strcmp(infoField->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
+            // Algorithm type.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
+            ASSERT_STREQ(infoField->fieldValue.stringValue, VecSimCommonStrings::TIERED_STRING);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TYPE_STRING)) {
+            // Vector type.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
+            ASSERT_STREQ(infoField->fieldValue.stringValue,
+                         VecSimType_ToString(info.commonInfo.basicInfo.type));
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::DIMENSION_STRING)) {
+            // Vector dimension.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.dim);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::METRIC_STRING)) {
+            // Metric.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
+            ASSERT_STREQ(infoField->fieldValue.stringValue,
+                         VecSimMetric_ToString(info.commonInfo.basicInfo.metric));
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::SEARCH_MODE_STRING)) {
+            // Search mode.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_STRING);
+            ASSERT_STREQ(infoField->fieldValue.stringValue,
+                         VecSimSearchMode_ToString(info.commonInfo.lastMode));
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::INDEX_SIZE_STRING)) {
+            // Index size.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.indexSize);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::INDEX_LABEL_COUNT_STRING)) {
+            // Index label count.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.indexLabelCount);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::IS_MULTI_STRING)) {
+            // Is the index multi value.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.basicInfo.isMulti);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::MEMORY_STRING)) {
+            // Memory.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.memory);
+        } else if (!strcmp(infoField->fieldName,
+                           VecSimCommonStrings::TIERED_MANAGEMENT_MEMORY_STRING)) {
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.tieredInfo.management_layer_memory);
+        } else if (!strcmp(infoField->fieldName,
+                           VecSimCommonStrings::TIERED_BACKGROUND_INDEXING_STRING)) {
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.tieredInfo.backgroundIndexing);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::FRONTEND_INDEX_STRING)) {
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_ITERATOR);
+            compareFlatIndexInfoToIterator(frontendIndexInfo, infoField->fieldValue.iteratorValue);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::BACKEND_INDEX_STRING)) {
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_ITERATOR);
+            compareSVSIndexInfoToIterator(backendIndexInfo, infoField->fieldValue.iteratorValue);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::TIERED_BUFFER_LIMIT_STRING)) {
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, info.tieredInfo.bufferLimit);
+        } else if (!strcmp(infoField->fieldName,
+                           VecSimCommonStrings::TIERED_SVS_SWAP_JOBS_THRESHOLD_STRING)) {
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(
+                infoField->fieldValue.uintegerValue,
+                info.tieredInfo.specificTieredBackendInfo.svsTieredInfo.pendingSwapJobsThreshold);
+        } else {
+            FAIL();
+        }
+    }
+    VecSimInfoIterator_Free(infoIterator);
+}
+
+TYPED_TEST(SVSTieredIndexTest, writeInPlaceMode) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+
+    SVSParams params = {.type = TypeParam::get_index_type(),
+                         .dim = dim,
+                         .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+
+    VecSim_SetWriteMode(VecSim_WriteInPlace);
+    // Validate that the vector was inserted directly to the SVS index.
+    labelType vec_label = 0;
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, vec_label, 0);
+    ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+    ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 0);
+
+    // Overwrite inplace - only in single-value mode
+    if (!TypeParam::isMulti()) {
+        TEST_DATA_T overwritten_vec[] = {1, 1, 1, 1};
+        tiered_index->addVector(overwritten_vec, vec_label);
+        ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
+        ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+        ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 0);
+        ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(vec_label, overwritten_vec), 0);
+    }
+
+    // Validate that the vector is removed in place.
+    tiered_index->deleteVector(vec_label);
+    ASSERT_EQ(tiered_index->backendIndex->indexSize(), 0);
+    ASSERT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 0);
+}
+
+TYPED_TEST(SVSTieredIndexTest, switchWriteModes) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    size_t n = 500;
+    SVSParams params = {.type = TypeParam::get_index_type(),
+                         .dim = dim,
+                         .metric = VecSimMetric_L2,
+                         .M = 32,
+                         .efRuntime = 3 * n};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+    VecSim_SetWriteMode(VecSim_WriteAsync);
+
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    mock_thread_pool.init_threads();
+
+    // Create and insert vectors one by one async.
+    size_t per_label = TypeParam::isMulti() ? 5 : 1;
+    size_t n_labels = n / per_label;
+    std::srand(10); // create pseudo random generator with any arbitrary seed.
+    for (size_t i = 0; i < n; i++) {
+        TEST_DATA_T vector[dim];
+        for (size_t j = 0; j < dim; j++) {
+            vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+        }
+        VecSimIndex_AddVector(tiered_index, vector, i % n_labels);
+    }
+
+    // Insert another n more vectors INPLACE, while the previous vectors are still being indexed.
+    VecSim_SetWriteMode(VecSim_WriteInPlace);
+    EXPECT_LE(tiered_index->backendIndex->indexSize(), n);
+    for (size_t i = 0; i < n; i++) {
+        TEST_DATA_T vector[dim];
+        for (size_t j = 0; j < dim; j++) {
+            vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+        }
+        VecSimIndex_AddVector(tiered_index, vector, i % n_labels + n_labels);
+    }
+    mock_thread_pool.thread_pool_join();
+    EXPECT_EQ(tiered_index->backendIndex->indexSize(), 2 * n);
+
+    // Now delete the last n inserted vectors of the index using async jobs.
+    VecSim_SetWriteMode(VecSim_WriteAsync);
+    mock_thread_pool.init_threads();
+    for (size_t i = 0; i < n_labels; i++) {
+        VecSimIndex_DeleteVector(tiered_index, n_labels + i);
+    }
+    // At this point, repair jobs should be executed in the background.
+    EXPECT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), n);
+
+    // Insert INPLACE another n vector (instead of the ones that were deleted).
+    VecSim_SetWriteMode(VecSim_WriteInPlace);
+    auto svs_index = tiered_index->getSVSIndex();
+    // Run twice, at first run we insert non-existing labels, in the second run we overwrite them
+    // (for single-value index only).
+    for (auto overwrite : {0, 1}) {
+        for (size_t i = 0; i < n; i++) {
+            TEST_DATA_T vector[dim];
+            for (size_t j = 0; j < dim; j++) {
+                vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+            }
+            labelType cur_label = i % n_labels + n_labels;
+            EXPECT_EQ(tiered_index->addVector(vector, cur_label),
+                      TypeParam::isMulti() ? 1 : 1 - overwrite);
+            // Run a query over svs index and see that we only receive ids with label < n_labels+i
+            // (the label that we just inserted), and the first result should be this vector
+            // (unless it is unreachable)
+            auto ver_res = [&](size_t res_label, double score, size_t index) {
+                if (index == 0) {
+                    if (res_label == cur_label) {
+                        EXPECT_DOUBLE_EQ(score, 0);
+                    } else {
+                        svs_index->lockSharedIndexDataGuard();
+                        ASSERT_EQ(svs_index->getDistanceFrom_Unsafe(cur_label, vector), 0);
+                        svs_index->unlockSharedIndexDataGuard();
+                    }
+                }
+                if (!overwrite) {
+                    ASSERT_LE(res_label, i + n_labels);
+                }
+            };
+            runTopKSearchTest(svs_index, vector, 10, ver_res);
+        }
+    }
+
+    mock_thread_pool.thread_pool_join();
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+    ASSERT_EQ(tiered_index->backendIndex->indexLabelCount(), 2 * n_labels);
+}
+
+TYPED_TEST(SVSTieredIndexTest, bufferLimit) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    SVSParams params = {.type = TypeParam::get_index_type(),
+                         .dim = dim,
+                         .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    // Create tiered index with buffer limit set to 0.
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool,
+                                                     DEFAULT_PENDING_SWAP_JOBS_THRESHOLD, 0);
+    auto allocator = tiered_index->getAllocator();
+
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, 0);
+    ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+    ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 0);
+
+    // Set the flat limit to 1 and insert another vector - expect it to go to the flat buffer.
+    tiered_index->flatBufferLimit = 1;
+    labelType vec_label = 1;
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, vec_label, 0); // vector is [0,0,0,0]
+    ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
+    ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 1);
+
+    // Overwrite the vector, expect removing it from the flat buffer and replace it with the new one
+    // only in single-value mode
+    if (!TypeParam::isMulti()) {
+        TEST_DATA_T overwritten_vec[] = {1, 1, 1, 1};
+        ASSERT_EQ(tiered_index->addVector(overwritten_vec, vec_label), 0);
+        ASSERT_EQ(tiered_index->backendIndex->indexSize(), 1);
+        ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
+        ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 1);
+        ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(vec_label, overwritten_vec), 0);
+        // The first job in Q should be the invalid overwritten insert vector job.
+        ASSERT_EQ(mock_thread_pool.jobQ.front().job->isValid, false);
+        ASSERT_EQ(reinterpret_cast<SVSInsertJob *>(mock_thread_pool.jobQ.front().job)->id, 0);
+        mock_thread_pool.jobQ.pop();
+    }
+
+    // Insert another vector, this one should go directly to SVS index since the buffer limit has
+    // reached.
+    vec_label = 2;
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, vec_label, 0); // vector is [0,0,0,0]
+    ASSERT_EQ(tiered_index->backendIndex->indexSize(), 2);
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
+    ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 1);
+    ASSERT_EQ(tiered_index->indexLabelCount(), 3);
+
+    // Overwrite the vector, expect marking it as deleted in SVS and insert the new one directly
+    // to SVS as well.
+    if (!TypeParam::isMulti()) {
+        TEST_DATA_T overwritten_vec[] = {1, 1, 1, 1};
+        ASSERT_EQ(tiered_index->addVector(overwritten_vec, vec_label), 0);
+        ASSERT_EQ(tiered_index->backendIndex->indexSize(), 3);
+        ASSERT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 1);
+        ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 1);
+        ASSERT_EQ(tiered_index->labelToInsertJobs.size(), 1);
+        ASSERT_EQ(tiered_index->indexLabelCount(), 3);
+        ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(vec_label, overwritten_vec), 0);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTest, bufferLimitAsync) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    size_t n = 500;
+    SVSParams params = {.type = TypeParam::get_index_type(),
+                         .dim = dim,
+                         .metric = VecSimMetric_L2,
+                         .M = 64};
+
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    // Create tiered index with buffer limit set to 100.
+    size_t flat_buffer_limit = 100;
+    auto *tiered_index = this->CreateTieredSVSIndex(
+        svs_params, mock_thread_pool, DEFAULT_PENDING_SWAP_JOBS_THRESHOLD, flat_buffer_limit);
+    auto allocator = tiered_index->getAllocator();
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    mock_thread_pool.init_threads();
+    // Create and insert vectors one by one async. At some point, buffer limit gets full and vectors
+    // are inserted directly to SVS.
+    size_t per_label = TypeParam::isMulti() ? 5 : 1;
+    size_t n_labels = n / per_label;
+    std::srand(10); // create pseudo random generator with any arbitrary seed.
+    // Run twice, at first run we insert non-existing labels, in the second run we overwrite them
+    // (for single-value index only).
+    for (auto overwrite : {0, 1}) {
+        for (size_t i = 0; i < n; i++) {
+            TEST_DATA_T vector[dim];
+            for (size_t j = 0; j < dim; j++) {
+                vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+            }
+            EXPECT_EQ(tiered_index->addVector(vector, i % n_labels),
+                      TypeParam::isMulti() ? 1 : 1 - overwrite);
+            EXPECT_LE(tiered_index->frontendIndex->indexSize(), flat_buffer_limit);
+        }
+        // In first run, wait until all vectors are moved from flat index to SVS backend index.
+        while (tiered_index->backendIndex->indexSize() < n) {
+            //do nothing
+        }
+    }
+    mock_thread_pool.thread_pool_join();
+    EXPECT_EQ(tiered_index->backendIndex->indexSize(), 2 * n);
+    EXPECT_EQ(tiered_index->indexLabelCount(), n_labels);
+}
+
+TYPED_TEST(SVSTieredIndexTest, RangeSearch) {
+    size_t dim = 4;
+    size_t k = 11;
+    size_t per_label = TypeParam::isMulti() ? 5 : 1;
+
+    size_t n_labels = k * 3;
+    size_t n = n_labels * per_label;
+
+    auto edge_delta = (k - 0.8) * per_label;
+    auto mid_delta = edge_delta / 2;
+    // `range` for querying the "edges" of the index and get k results.
+    double range = dim * edge_delta * edge_delta; // L2 distance.
+    // `half_range` for querying a point in the "middle" of the index and get k results around it.
+    double half_range = dim * mid_delta * mid_delta; // L2 distance.
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+        .epsilon = 3.0 * per_label,
+    };
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    size_t cur_memory_usage;
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+    ASSERT_EQ(mock_thread_pool.ctx->index_strong_ref.use_count(), 1);
+
+    auto svs_index = tiered_index->backendIndex;
+    auto flat_index = tiered_index->frontendIndex;
+
+    TEST_DATA_T query_0[dim];
+    GenerateVector<TEST_DATA_T>(query_0, dim, 0);
+    TEST_DATA_T query_1mid[dim];
+    GenerateVector<TEST_DATA_T>(query_1mid, dim, n / 3);
+    TEST_DATA_T query_2mid[dim];
+    GenerateVector<TEST_DATA_T>(query_2mid, dim, n * 2 / 3);
+    TEST_DATA_T query_n[dim];
+    GenerateVector<TEST_DATA_T>(query_n, dim, n - 1);
+
+    // Search for vectors when the index is empty.
+    runRangeQueryTest(tiered_index, query_0, range, nullptr, 0);
+
+    // Define the verification functions.
+    auto ver_res_0 = [&](size_t id, double score, size_t index) {
+        EXPECT_EQ(id, index);
+        // The expected score is the distance to the first vector of `id` label.
+        auto element = id * per_label;
+        EXPECT_DOUBLE_EQ(score, dim * element * element);
+    };
+
+    auto ver_res_1mid_by_id = [&](size_t id, double score, size_t index) {
+        size_t q_id = query_1mid[0] / per_label;
+        size_t mod = query_1mid[0] - q_id * per_label;
+        // In single value mode, `per_label` is always 1 and `mod` is always 0, so the following
+        // branchings is simply `expected_score = abs(id - q_id)`.
+        // In multi value mode, for ids higher than the query id, the score is the distance to the
+        // first vector of `id` label, and for ids lower than the query id, the score is the
+        // distance to the last vector of `id` label. `mod` is the distance to the first vector of
+        // `q_id` label.
+        double expected_score = 0;
+        if (id > q_id) {
+            expected_score = (id - q_id) * per_label - mod;
+        } else if (id < q_id) {
+            expected_score = (q_id - id) * per_label - (per_label - mod - 1);
+        }
+        expected_score = expected_score * expected_score * dim;
+        EXPECT_DOUBLE_EQ(score, expected_score);
+    };
+
+    auto ver_res_2mid_by_id = [&](size_t id, double score, size_t index) {
+        size_t q_id = query_2mid[0] / per_label;
+        size_t mod = query_2mid[0] - q_id * per_label;
+        // In single value mode, `per_label` is always 1 and `mod` is always 0, so the following
+        // branchings is simply `expected_score = abs(id - q_id)`.
+        // In multi value mode, for ids higher than the query id, the score is the distance to the
+        // first vector of `id` label, and for ids lower than the query id, the score is the
+        // distance to the last vector of `id` label. `mod` is the distance to the first vector of
+        // `q_id` label.
+        double expected_score = 0;
+        if (id > q_id) {
+            expected_score = (id - q_id) * per_label - mod;
+        } else if (id < q_id) {
+            expected_score = (q_id - id) * per_label - (per_label - mod - 1);
+        }
+        expected_score = expected_score * expected_score * dim;
+        EXPECT_DOUBLE_EQ(score, expected_score);
+    };
+
+    auto ver_res_1mid_by_score = [&](size_t id, double score, size_t index) {
+        size_t q_id = query_1mid[0] / per_label;
+        EXPECT_EQ(std::abs(int(id - q_id)), (index + 1) / 2);
+        ver_res_1mid_by_id(id, score, index);
+    };
+
+    auto ver_res_2mid_by_score = [&](size_t id, double score, size_t index) {
+        size_t q_id = query_2mid[0] / per_label;
+        EXPECT_EQ(std::abs(int(id - q_id)), (index + 1) / 2);
+        ver_res_2mid_by_id(id, score, index);
+    };
+
+    auto ver_res_n = [&](size_t id, double score, size_t index) {
+        EXPECT_EQ(id, n_labels - 1 - index);
+        auto element = index * per_label;
+        EXPECT_DOUBLE_EQ(score, dim * element * element);
+    };
+
+    // Insert n/2 vectors to the main index.
+    for (size_t i = 0; i < (n + 1) / 2; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(svs_index, dim, i / per_label, i);
+    }
+    ASSERT_EQ(tiered_index->indexSize(), (n + 1) / 2);
+    ASSERT_EQ(tiered_index->indexSize(), svs_index->indexSize());
+
+    // Search for `range` with the flat index empty.
+    cur_memory_usage = allocator->getAllocationSize();
+    runRangeQueryTest(tiered_index, query_0, range, ver_res_0, k, BY_ID);
+    runRangeQueryTest(tiered_index, query_0, range, ver_res_0, k, BY_SCORE);
+    runRangeQueryTest(tiered_index, query_1mid, half_range, ver_res_1mid_by_score, k, BY_SCORE);
+    runRangeQueryTest(tiered_index, query_1mid, half_range, ver_res_1mid_by_id, k, BY_ID);
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // Insert n/2 vectors to the flat index.
+    for (size_t i = (n + 1) / 2; i < n; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(flat_index, dim, i / per_label, i);
+    }
+    ASSERT_EQ(tiered_index->indexSize(), n);
+    ASSERT_EQ(tiered_index->indexSize(), svs_index->indexSize() + flat_index->indexSize());
+
+    cur_memory_usage = allocator->getAllocationSize();
+    // Search for `range` so all the vectors will be from the SVS index.
+    runRangeQueryTest(tiered_index, query_0, range, ver_res_0, k, BY_ID);
+    runRangeQueryTest(tiered_index, query_0, range, ver_res_0, k, BY_SCORE);
+    // Search for `range` so all the vectors will be from the flat index.
+    runRangeQueryTest(tiered_index, query_n, range, ver_res_n, k, BY_SCORE);
+    // Search for `range` so some of the results will be from the main and some from the flat index.
+    runRangeQueryTest(tiered_index, query_1mid, half_range, ver_res_1mid_by_score, k, BY_SCORE);
+    runRangeQueryTest(tiered_index, query_2mid, half_range, ver_res_2mid_by_score, k, BY_SCORE);
+    runRangeQueryTest(tiered_index, query_1mid, half_range, ver_res_1mid_by_id, k, BY_ID);
+    runRangeQueryTest(tiered_index, query_2mid, half_range, ver_res_2mid_by_id, k, BY_ID);
+    // Memory usage should not change.
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // Add some overlapping vectors to the main and flat index.
+    // adding directly to the underlying indexes to avoid jobs logic.
+    // The main index will have vectors 0 - 2n/3 and the flat index will have vectors n/3 - n
+    for (size_t i = n / 3; i < n / 2; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(flat_index, dim, i / per_label, i);
+    }
+    for (size_t i = n / 2; i < n * 2 / 3; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(svs_index, dim, i / per_label, i);
+    }
+
+    cur_memory_usage = allocator->getAllocationSize();
+    // Search for `range` so all the vectors will be from the main index.
+    runRangeQueryTest(tiered_index, query_0, range, ver_res_0, k, BY_ID);
+    runRangeQueryTest(tiered_index, query_0, range, ver_res_0, k, BY_SCORE);
+    // Search for `range` so all the vectors will be from the flat index.
+    runRangeQueryTest(tiered_index, query_n, range, ver_res_n, k, BY_SCORE);
+    // Search for `range` so some of the results will be from the main and some from the flat index.
+    runRangeQueryTest(tiered_index, query_1mid, half_range, ver_res_1mid_by_score, k, BY_SCORE);
+    runRangeQueryTest(tiered_index, query_2mid, half_range, ver_res_2mid_by_score, k, BY_SCORE);
+    runRangeQueryTest(tiered_index, query_1mid, half_range, ver_res_1mid_by_id, k, BY_ID);
+    runRangeQueryTest(tiered_index, query_2mid, half_range, ver_res_2mid_by_id, k, BY_ID);
+    // Memory usage should not change.
+    ASSERT_EQ(allocator->getAllocationSize(), cur_memory_usage);
+
+    // // // // // // // // // // // //
+    // Check behavior upon timeout.  //
+    // // // // // // // // // // // //
+
+    VecSimQueryReply *res;
+    // Add a vector to the SVS index so there will be a reason to query it.
+    GenerateAndAddVector<TEST_DATA_T>(svs_index, dim, n, n);
+
+    // Set timeout callback to always return 1 (will fail while querying the flat buffer).
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 1; }); // Always times out
+
+    res = VecSimIndex_RangeQuery(tiered_index, query_0, range, nullptr, BY_ID);
+    ASSERT_EQ(VecSimQueryReply_GetCode(res), VecSim_QueryReply_TimedOut);
+    VecSimQueryReply_Free(res);
+
+    // Set timeout callback to return 1 after n checks (will fail while querying the SVS index).
+    // Brute-force index checks for timeout after each vector.
+    size_t checks_in_flat = flat_index->indexSize();
+    VecSimQueryParams qparams = {.timeoutCtx = &checks_in_flat};
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) {
+        auto count = static_cast<size_t *>(ctx);
+        if (*count == 0) {
+            return 1;
+        }
+        (*count)--;
+        return 0;
+    });
+    res = VecSimIndex_RangeQuery(tiered_index, query_0, range, &qparams, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_GetCode(res), VecSim_QueryReply_TimedOut);
+    VecSimQueryReply_Free(res);
+    // Make sure we didn't get the timeout in the flat index.
+    checks_in_flat = flat_index->indexSize(); // Reset the counter.
+    res = VecSimIndex_RangeQuery(flat_index, query_0, range, &qparams, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_GetCode(res), VecSim_QueryReply_OK);
+    VecSimQueryReply_Free(res);
+
+    // Check again with BY_ID.
+    checks_in_flat = flat_index->indexSize(); // Reset the counter.
+    res = VecSimIndex_RangeQuery(tiered_index, query_0, range, &qparams, BY_ID);
+    ASSERT_EQ(VecSimQueryReply_GetCode(res), VecSim_QueryReply_TimedOut);
+    VecSimQueryReply_Free(res);
+    // Make sure we didn't get the timeout in the flat index.
+    checks_in_flat = flat_index->indexSize(); // Reset the counter.
+    res = VecSimIndex_RangeQuery(flat_index, query_0, range, &qparams, BY_ID);
+    ASSERT_EQ(VecSimQueryReply_GetCode(res), VecSim_QueryReply_OK);
+    VecSimQueryReply_Free(res);
+
+    // Clean up.
+    VecSim_SetTimeoutCallbackFunction([](void *ctx) { return 0; });
+}
+
+TYPED_TEST(SVSTieredIndexTest, parallelRangeSearch) {
+    size_t dim = 4;
+    size_t k = 11;
+    size_t n = 1000;
+    bool isMulti = TypeParam::isMulti();
+
+    size_t per_label = isMulti ? 10 : 1;
+    size_t n_labels = n / per_label;
+
+    // Create TieredSVS index instance with a mock queue.
+    SVSParams params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+        .epsilon = double(dim * k * k),
+    };
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+    EXPECT_EQ(mock_thread_pool.ctx->index_strong_ref.use_count(), 1);
+
+    std::atomic_int successful_searches(0);
+    auto parallel_range_search = [](AsyncJob *job) {
+        auto *search_job = reinterpret_cast<tieredIndexMock::SearchJobMock *>(job);
+        size_t k = search_job->k;
+        size_t dim = search_job->dim;
+        // The range that will get us k results.
+        double range = dim * ((k - 0.5) / 2) * ((k - 0.5) / 2); // L2 distance.
+        auto query = search_job->query;
+
+        auto verify_res = [&](size_t id, double score, size_t res_index) {
+            TEST_DATA_T element = *(TEST_DATA_T *)query;
+            ASSERT_EQ(std::abs(id - element), (res_index + 1) / 2);
+            ASSERT_EQ(score, dim * (id - element) * (id - element));
+        };
+        runRangeQueryTest(job->index, query, range, verify_res, k, BY_SCORE);
+        (*search_job->successful_searches)++;
+        delete job;
+    };
+
+    // Fill the job queue with insert and search jobs, while filling the flat index, before
+    // initializing the thread pool.
+    for (size_t i = 0; i < n; i++) {
+        // Insert a vector to the flat index and add a job to insert it to the main index.
+        GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, i % n_labels, i);
+
+        // Add a search job. Make sure the query element is between k and n_labels - k.
+        auto query = (TEST_DATA_T *)allocator->allocate(dim * sizeof(TEST_DATA_T));
+        GenerateVector<TEST_DATA_T>(query, dim, ((n - i) % (n_labels - (2 * k))) + k);
+        auto search_job = new (allocator) tieredIndexMock::SearchJobMock(
+            allocator, parallel_range_search, tiered_index, k, query, n, dim, &successful_searches);
+        tiered_index->submitSingleJob(search_job);
+    }
+
+    EXPECT_EQ(tiered_index->indexSize(), n);
+    EXPECT_EQ(tiered_index->indexLabelCount(), n_labels);
+    EXPECT_EQ(tiered_index->labelToInsertJobs.size(), n_labels);
+    for (auto &it : tiered_index->labelToInsertJobs) {
+        EXPECT_EQ(it.second.size(), per_label);
+    }
+    EXPECT_EQ(tiered_index->frontendIndex->indexSize(), n);
+    EXPECT_EQ(tiered_index->backendIndex->indexSize(), 0);
+
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    // All the vectors are already in the tiered index, so we expect to find the expected
+    // results from the get-go.
+    mock_thread_pool.init_threads();
+    mock_thread_pool.thread_pool_join();
+
+    EXPECT_EQ(tiered_index->backendIndex->indexSize(), n);
+    EXPECT_EQ(tiered_index->backendIndex->indexLabelCount(), n_labels);
+    EXPECT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+    EXPECT_EQ(tiered_index->labelToInsertJobs.size(), 0);
+    EXPECT_EQ(successful_searches, n);
+    EXPECT_EQ(mock_thread_pool.jobQ.size(), 0);
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, preferAdHocOptimization) {
+    size_t dim = 4;
+
+    SVSParams params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+    };
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    // Create tiered index with buffer limit set to 0.
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+
+    auto svs = tiered_index->backendIndex;
+    auto flat = tiered_index->frontendIndex;
+
+    // Insert 5 vectors to the main index.
+    for (size_t i = 0; i < 5; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(svs, dim, i, i);
+    }
+    // Sanity check. Should choose as SVS.
+    ASSERT_EQ(tiered_index->preferAdHocSearch(5, 5, true), svs->preferAdHocSearch(5, 5, true));
+
+    // Insert 6 vectors to the flat index.
+    for (size_t i = 0; i < 6; i++) {
+        GenerateAndAddVector<TEST_DATA_T>(flat, dim, i, i);
+    }
+    // Sanity check. Should choose as flat as it has more vectors.
+    ASSERT_EQ(tiered_index->preferAdHocSearch(5, 5, true), flat->preferAdHocSearch(5, 5, true));
+
+    // Check for preference of tiered with subset (10) smaller than the tiered index size (11),
+    // but larger than any of the underlying indexes.
+    ASSERT_NO_THROW(tiered_index->preferAdHocSearch(10, 5, false));
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, runGCAPI) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    SVSParams params = {
+        .type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+
+    // Test initialization of the pendingSwapJobsThreshold value.
+    ASSERT_EQ(tiered_index->pendingSwapJobsThreshold, DEFAULT_PENDING_SWAP_JOBS_THRESHOLD);
+
+    // Insert three block of vectors directly to SVS.
+    size_t n = DEFAULT_PENDING_SWAP_JOBS_THRESHOLD * 3;
+    std::srand(10); // create pseudo random generator with any arbitrary seed.
+    for (size_t i = 0; i < n; i++) {
+        TEST_DATA_T vector[dim];
+        for (size_t j = 0; j < dim; j++) {
+            vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+        }
+        VecSimIndex_AddVector(tiered_index->backendIndex, vector, i);
+    }
+
+    // Delete all the vectors and wait for the thread pool to finish running the repair jobs.
+    for (size_t i = 0; i < n; i++) {
+        tiered_index->deleteVector(i);
+    }
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    mock_thread_pool.init_threads();
+    mock_thread_pool.thread_pool_join();
+
+    ASSERT_EQ(tiered_index->indexSize(), n);
+    ASSERT_EQ(tiered_index->backendIndex->indexSize(), n);
+    ASSERT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), n);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 0);
+
+    // Run the GC API call, expect that we will clean the defined threshold number of vectors
+    // each time we call the GC.
+    while (tiered_index->indexSize() > 0) {
+        size_t cur_size = tiered_index->indexSize();
+        VecSimTieredIndex_GC(tiered_index);
+        ASSERT_EQ(tiered_index->indexSize(), cur_size - DEFAULT_PENDING_SWAP_JOBS_THRESHOLD);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, getElementNeighbors) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    size_t n = 0;
+    size_t M = 20;
+    SVSParams params = {
+        .type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2, .M = M};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+    auto *svs_index = this->CastToSVS(tiered_index);
+
+    // Add vectors directly to SVS index until we have at least 2 vectors at level 1.
+    size_t vectors_in_higher_levels = 0;
+    while (vectors_in_higher_levels < 2) {
+        GenerateAndAddVector<TEST_DATA_T>(svs_index, dim, n, n);
+        if (svs_index->getGraphDataByInternalId(n)->toplevel > 0) {
+            vectors_in_higher_levels++;
+        }
+        n++;
+    }
+    // Go over all vectors and validate that the getElementNeighbors debug command returns the
+    // neighbors properly.
+    for (size_t id = 0; id < n; id++) {
+        ElementLevelData &cur = svs_index->getElementLevelData(id, 0);
+        int **neighbors_output;
+        VecSimDebug_GetElementNeighborsInSVSGraph(tiered_index, id, &neighbors_output);
+        auto graph_data = svs_index->getGraphDataByInternalId(id);
+        for (size_t l = 0; l <= graph_data->toplevel; l++) {
+            auto &level_data = svs_index->getElementLevelData(graph_data, l);
+            auto &neighbours = neighbors_output[l];
+            ASSERT_EQ(neighbours[0], level_data.numLinks);
+            for (size_t j = 1; j <= neighbours[0]; j++) {
+                ASSERT_EQ(neighbours[j], level_data.links[j - 1]);
+            }
+        }
+        VecSimDebug_ReleaseElementNeighborsInSVSGraph(neighbors_output);
+    }
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, FitMemoryTest) {
+    size_t dim = 4;
+    SVSParams params = {.dim = dim, .blockSize = DEFAULT_BLOCK_SIZE};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+
+    // Add vector
+    GenerateAndAddVector<TEST_DATA_T>(index->frontendIndex, dim, 0);
+    GenerateAndAddVector<TEST_DATA_T>(index->backendIndex, dim, 0);
+    size_t initial_memory = index->getAllocationSize();
+    index->fitMemory();
+    // Tired backendIndex index doesn't have initial capacity, so adding the first vector triggers
+    // allocation.
+    ASSERT_EQ(index->getAllocationSize(), initial_memory) << "fitMemory() after adding 1 vector";
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, deleteBothAsyncAndInplace) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+
+    SVSParams params = {
+        .type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+
+    // Insert one vector to SVS.
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 0);
+    // Add another vector and remove it. Expect that at SVS index one repair job will be created.
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 1, 1);
+    ASSERT_EQ(tiered_index->deleteLabelFromSVS(1), 1);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 1);
+
+    // The first job should be a repair job of the first inserted node id (0) in level 0.
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 1);
+    ASSERT_EQ(mock_thread_pool.jobQ.front().job->jobType, SVS_REPAIR_NODE_CONNECTIONS_JOB);
+    ASSERT_TRUE(mock_thread_pool.jobQ.front().job->isValid);
+    ASSERT_EQ(((SVSRepairJob *)(mock_thread_pool.jobQ.front().job))->node_id, 0);
+    ASSERT_EQ(((SVSRepairJob *)(mock_thread_pool.jobQ.front().job))->level, 0);
+    ASSERT_EQ(tiered_index->idToRepairJobs.size(), 1);
+    ASSERT_GE(tiered_index->idToRepairJobs.at(0).size(), 1);
+    ASSERT_EQ(tiered_index->idToRepairJobs.at(0)[0]->associatedSwapJobs.size(), 1);
+    ASSERT_EQ(tiered_index->idToRepairJobs.at(0)[0]->associatedSwapJobs[0]->deleted_id, 1);
+
+    // Add one more vector and remove it, expect that the same repair job for 0 would be created
+    // for repairing 0->2.
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 2, 2);
+    ASSERT_EQ(tiered_index->deleteLabelFromSVS(2), 1);
+    ASSERT_TRUE(tiered_index->idToSwapJob.contains(2));
+    ASSERT_EQ(tiered_index->idToRepairJobs.size(), 1);
+    ASSERT_EQ(tiered_index->idToRepairJobs.at(0)[0]->associatedSwapJobs.size(), 2);
+    ASSERT_EQ(tiered_index->idToRepairJobs.at(0)[0]->associatedSwapJobs[1]->deleted_id, 2);
+    ASSERT_EQ(tiered_index->readySwapJobs, 0);
+
+    tiered_index->setWriteMode(VecSim_WriteInPlace);
+    // Delete inplace, expect that the repair job for 0->1 and 0->2 will not be valid anymore.
+    ASSERT_EQ(tiered_index->deleteVector(0), 1);
+    ASSERT_EQ(tiered_index->indexSize(), 2);
+    ASSERT_EQ(((SVSRepairJob *)(mock_thread_pool.jobQ.front().job))->node_id, 0);
+    ASSERT_FALSE(mock_thread_pool.jobQ.front().job->isValid);
+
+    // Also expect that the swap job for 2 will not exist anymore, as 2 swapped with 0
+    ASSERT_EQ(tiered_index->getSVSIndex()->getNumMarkedDeleted(), 2);
+    ASSERT_EQ(tiered_index->idToSwapJob.size(), 2);
+    ASSERT_TRUE(tiered_index->idToSwapJob.contains(0));
+    ASSERT_FALSE(tiered_index->idToSwapJob.contains(2));
+    // Both ids 1 and 0 (previously was 2) are now ready due to the deletion of 0 and its associated
+    // jobs.
+    ASSERT_EQ(tiered_index->readySwapJobs, 2);
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, deleteInplaceAvoidUpdatedMarkedDeleted) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 4;
+    SVSParams params = {
+        .type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+    auto allocator = tiered_index->getAllocator();
+
+    // Insert three vector to SVS, expect a full graph to be created
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 0, 0);
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 1, 1);
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 2, 2);
+
+    // Delete vector with id=0 asynchronously, expect to have a repair job for the other vectors.
+    ASSERT_EQ(tiered_index->deleteVector(0), 1);
+    ASSERT_EQ(tiered_index->idToRepairJobs.size(), 2);
+    ASSERT_EQ(tiered_index->idToRepairJobs.at(1)[0]->associatedSwapJobs.size(), 1);
+    ASSERT_EQ(tiered_index->idToRepairJobs.at(2)[0]->associatedSwapJobs.size(), 1);
+
+    // Execute the repair job for 1->0. Now, 0->1 is unidirectional edge
+    ASSERT_TRUE(mock_thread_pool.jobQ.front().job->isValid);
+    mock_thread_pool.thread_iteration();
+    ASSERT_EQ(tiered_index->idToRepairJobs.size(), 1);
+    ASSERT_EQ(tiered_index->idToRepairJobs.at(2)[0]->associatedSwapJobs.size(), 1);
+
+    // Insert another vector with id=3, that should be connected to both 1 and 2.
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index->backendIndex, dim, 3, -1);
+
+    // Delete in-place id=2, expect that upon repairing inplace 1 due to 1->2, there will *not* be
+    // a new edge 1->0 since 0 is deleted. Also the other repair job 2->0 should be invalidated.
+    // Also, expect that repairing 3 in-place will not create a new edge to marked deleted 0 and
+    // vice versa.
+    tiered_index->setWriteMode(VecSim_WriteInPlace);
+    ASSERT_EQ(tiered_index->deleteVector(2), 1);
+    ASSERT_FALSE(mock_thread_pool.jobQ.front().job->isValid);
+    int **neighbours;
+    ASSERT_EQ(tiered_index->getSVSIndex()->getSVSElementNeighbors(1, &neighbours),
+              VecSimDebugCommandCode_OK);
+    // Expect 1 neighbors at level 0 (id=3) and that 0 is NOT a new neighbor for 1.
+    ASSERT_EQ(neighbours[0][0], 1);
+    ASSERT_EQ(neighbours[0][1], 3);
+    VecSimDebug_ReleaseElementNeighborsInSVSGraph(neighbours);
+
+    ASSERT_EQ(tiered_index->getSVSIndex()->getSVSElementNeighbors(3, &neighbours),
+              VecSimDebugCommandCode_OK);
+    ASSERT_EQ(neighbours[0][0], 1);
+    // Expect 1 neighbors at level 0 (id=1) and that 0 is NOT a new neighbor for 3.
+    ASSERT_EQ(neighbours[0][1], 1);
+    VecSimDebug_ReleaseElementNeighborsInSVSGraph(neighbours);
+
+    auto &level_data = tiered_index->getSVSIndex()->getElementLevelData((idType)0, 0);
+    // Expect 1 neighbors at level 0 (id=1) and that 3 is NOT a new neighbor for 0.
+    ASSERT_EQ(level_data.getNumLinks(), 1);
+    ASSERT_EQ(level_data.getLinkAtPos(0), 1);
+
+    // Expect that id=0 is a ready swap job and execute it.
+    ASSERT_EQ(tiered_index->readySwapJobs, 1);
+    ASSERT_TRUE(tiered_index->idToSwapJob.contains(0));
+    tiered_index->runGC();
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, switchDeleteModes) {
+    // Create TieredSVS index instance with a mock queue.
+    size_t dim = 16;
+    size_t n = 1000;
+    size_t swap_job_threshold = 10;
+    SVSParams params = {
+        .type = TypeParam::get_index_type(),
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+        .blockSize = 100,
+    };
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+
+    auto *tiered_index =
+        this->CreateTieredSVSIndex(svs_params, mock_thread_pool, swap_job_threshold);
+    auto allocator = tiered_index->getAllocator();
+
+    // Launch the BG threads loop that takes jobs from the queue and executes them.
+    mock_thread_pool.init_threads();
+
+    // Create and insert vectors one by one inplace.
+    VecSim_SetWriteMode(VecSim_WriteInPlace);
+    std::srand(10); // create pseudo random generator with any arbitrary seed.
+    for (size_t i = 0; i < n; i++) {
+        TEST_DATA_T vector[dim];
+        for (size_t j = 0; j < dim; j++) {
+            vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+        }
+        VecSimIndex_AddVector(tiered_index, vector, i);
+    }
+    EXPECT_EQ(tiered_index->backendIndex->indexSize(), n);
+
+    // Update vectors while changing the write mode.
+    for (size_t i = 0; i < n; i++) {
+        TEST_DATA_T vector[dim];
+        for (size_t j = 0; j < dim; j++) {
+            vector[j] = std::rand() / (TEST_DATA_T)RAND_MAX;
+        }
+        EXPECT_EQ(tiered_index->addVector(vector, i), 0);
+        if (i % 10 == 0) {
+            // Change mode every 10 vectors.
+            auto next_mode = tiered_index->getWriteMode() == VecSim_WriteInPlace
+                                 ? VecSim_WriteAsync
+                                 : VecSim_WriteInPlace;
+            VecSim_SetWriteMode(next_mode);
+        }
+    }
+
+    mock_thread_pool.thread_pool_join();
+    ASSERT_EQ(tiered_index->frontendIndex->indexSize(), 0);
+    ASSERT_EQ(tiered_index->backendIndex->indexLabelCount(), n);
+    auto state = tiered_index->getSVSIndex()->checkIntegrity();
+    ASSERT_EQ(state.valid_state, 1);
+    ASSERT_EQ(state.connections_to_repair, 0);
+}
+
+*/

--- a/tests/unit/test_svs_tiered.cpp
+++ b/tests/unit/test_svs_tiered.cpp
@@ -64,17 +64,18 @@ protected:
 
 // TEST_DATA_T and TEST_DIST_T are defined in test_utils.h
 
-template <VecSimType type, typename DataType, VecSimQuantBits quantBits>
+template <VecSimType type, typename DataType, VecSimSvsQuantBits quantBits>
 struct SVSIndexType {
     static constexpr VecSimType get_index_type() { return type; }
-    static constexpr VecSimQuantBits get_quant_bits() { return quantBits; }
+    static constexpr VecSimSvsQuantBits get_quant_bits() { return quantBits; }
     typedef DataType data_t;
 };
 
 // clang-format off
-using SVSDataTypeSet = ::testing::Types<SVSIndexType<VecSimType_FLOAT32, float, VecSimQuant_NONE>
-                                    //   ,SVSIndexType<VecSimType_FLOAT32, float, VecSimQuant_8>
-                                    //   ,SVSIndexType<VecSimType_FLOAT32, float, VecSimQuant_4>
+using SVSDataTypeSet = ::testing::Types<SVSIndexType<VecSimType_FLOAT32, float, VecSimSvsQuant_NONE>
+#if HAVE_SVS_LVQ
+                                       ,SVSIndexType<VecSimType_FLOAT32, float, VecSimSvsQuant_8>
+#endif
                                         >;
 // clang-format on
 
@@ -140,7 +141,7 @@ TYPED_TEST(SVSTieredIndexTest, ThreadsReservation) {
     // The number of reserved threads should be equal to requested
     ASSERT_EQ(num_reserved_threads, num_threads - 2);
 
-    // Request and more threads than available
+    // Request more threads than available
     jobs = SVSMultiThreadJob::createJobs(allocator, HNSW_INSERT_VECTOR_JOB, update_job_mock,
                                          tiered_index, num_threads + 2, timeout);
     tiered_index->submitJobs(jobs);
@@ -215,7 +216,7 @@ TYPED_TEST(SVSTieredIndexTest, addVector) {
     ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 1);
     ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 0);
     ASSERT_EQ(tiered_index->GetFlatIndex()->indexCapacity(), DEFAULT_BLOCK_SIZE);
-    ASSERT_EQ(tiered_index->indexCapacity(), DEFAULT_BLOCK_SIZE + 1);
+    ASSERT_EQ(tiered_index->indexCapacity(), DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(tiered_index->GetFlatIndex()->getDistanceFrom_Unsafe(vec_label, vector), 0);
     ASSERT_EQ(mock_thread_pool.jobQ.size(), mock_thread_pool.thread_pool_size);
     // Validate that the job was created properly
@@ -265,7 +266,10 @@ TYPED_TEST(SVSTieredIndexTest, insertJob) {
     ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 1);
     // SVS index should have allocated a single record, while flat index should remove the
     // block.
-    ASSERT_EQ(tiered_index->indexCapacity(), DEFAULT_BLOCK_SIZE);
+    // LVQDataset does not provide a capacity method
+    const size_t expected_capacity =
+        TypeParam::get_quant_bits() > 0 ? tiered_index->indexSize() : DEFAULT_BLOCK_SIZE;
+    ASSERT_EQ(tiered_index->indexCapacity(), expected_capacity);
     ASSERT_EQ(tiered_index->GetFlatIndex()->indexCapacity(), 0);
     ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(vec_label, vector), 0);
 }
@@ -288,7 +292,7 @@ TYPED_TEST(SVSTieredIndexTest, insertJobAsync) {
         GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, i, i);
     }
 
-    mock_thread_pool.thread_pool_join();
+    mock_thread_pool.thread_pool_wait();
     ASSERT_EQ(tiered_index->indexSize(), n);
     ASSERT_EQ(mock_thread_pool.jobQ.size(), 0);
     auto sz_f = tiered_index->GetFlatIndex()->indexSize();
@@ -303,6 +307,7 @@ TYPED_TEST(SVSTieredIndexTest, insertJobAsync) {
             << "Vector label: " << i;
     }
 
+    mock_thread_pool.thread_pool_join();
     // Verify that all vectors were moved to SVS as expected
     sz_f = tiered_index->GetFlatIndex()->indexSize();
     sz_b = tiered_index->GetBackendIndex()->indexSize();

--- a/tests/unit/test_svs_tiered.cpp
+++ b/tests/unit/test_svs_tiered.cpp
@@ -27,6 +27,9 @@ protected:
                                             size_t update_job_threshold = 1024,
                                             size_t flat_buffer_limit = SIZE_MAX) {
         svs_params.algoParams.svsParams.quantBits = index_type_t::get_quant_bits();
+        if (svs_params.algoParams.svsParams.num_threads == 0) {
+            svs_params.algoParams.svsParams.num_threads = mock_thread_pool.thread_pool_size;
+        }
         return TieredIndexParams{
             .jobQueue = &mock_thread_pool.jobQ,
             .jobQueueCtx = mock_thread_pool.ctx,
@@ -84,6 +87,69 @@ template <typename index_type_t>
 class SVSTieredIndexTestBasic : public SVSTieredIndexTest<index_type_t> {};
 TYPED_TEST_SUITE(SVSTieredIndexTestBasic, DataTypeSet);
 
+TYPED_TEST(SVSTieredIndexTest, ThreadsReservation) {
+    std::chrono::milliseconds timeout{1};
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = 4, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock();
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
+
+    // Get the allocator from the tiered index.
+    auto allocator = tiered_index->getAllocator();
+
+    size_t num_reserved_threads = 0;
+
+    auto update_job_mock = [&num_reserved_threads](VecSimIndex * /*unused*/, size_t num_threads) {
+        num_reserved_threads = num_threads;
+    };
+
+    // Request 4 threads but just 1 thread is available
+    auto jobs = SVSMultiThreadJob::createJobs(allocator, HNSW_INSERT_VECTOR_JOB, update_job_mock,
+                                              tiered_index, 4, timeout);
+    ASSERT_EQ(jobs.size(), 4);
+    tiered_index->submitJobs(jobs);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 4);
+    // emulate 1 thread availability
+    mock_thread_pool.thread_iteration();
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), 3);
+    ASSERT_EQ(num_reserved_threads, 1);
+
+    auto num_threads = mock_thread_pool.thread_pool_size;
+    ASSERT_GE(num_threads, 4);
+    mock_thread_pool.init_threads();
+
+    // Request and run exact number of available threads
+    jobs = SVSMultiThreadJob::createJobs(allocator, HNSW_INSERT_VECTOR_JOB, update_job_mock,
+                                         tiered_index, num_threads, timeout);
+    tiered_index->submitJobs(jobs);
+    mock_thread_pool.thread_pool_wait();
+    ASSERT_EQ(num_reserved_threads, num_threads);
+
+    // Request and run 1 thread
+    jobs = SVSMultiThreadJob::createJobs(allocator, HNSW_INSERT_VECTOR_JOB, update_job_mock,
+                                         tiered_index, 1, timeout);
+    tiered_index->submitJobs(jobs);
+    mock_thread_pool.thread_pool_wait();
+    ASSERT_EQ(num_reserved_threads, 1);
+
+    // Request and run less threads than available
+    jobs = SVSMultiThreadJob::createJobs(allocator, HNSW_INSERT_VECTOR_JOB, update_job_mock,
+                                         tiered_index, num_threads - 2, timeout);
+    tiered_index->submitJobs(jobs);
+    mock_thread_pool.thread_pool_wait();
+    // The number of reserved threads should be equal to requested
+    ASSERT_EQ(num_reserved_threads, num_threads - 2);
+
+    // Request and more threads than available
+    jobs = SVSMultiThreadJob::createJobs(allocator, HNSW_INSERT_VECTOR_JOB, update_job_mock,
+                                         tiered_index, num_threads + 2, timeout);
+    tiered_index->submitJobs(jobs);
+    mock_thread_pool.thread_pool_wait();
+    // The number of reserved threads should be equal to the number of available threads
+    ASSERT_EQ(num_reserved_threads, num_threads);
+    mock_thread_pool.thread_pool_join();
+}
+
 TYPED_TEST(SVSTieredIndexTest, CreateIndexInstance) {
     // Create TieredSVS index instance with a mock queue.
     SVSParams params = {.type = TypeParam::get_index_type(), .dim = 4, .metric = VecSimMetric_L2};
@@ -104,7 +170,7 @@ TYPED_TEST(SVSTieredIndexTest, CreateIndexInstance) {
 
     // Submit the index update job.
     tiered_index->scheduleSVSIndexUpdate();
-    ASSERT_EQ(mock_thread_pool.jobQ.size(), 1);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), mock_thread_pool.thread_pool_size);
 
     // Execute the job from the queue and validate that the index was updated properly.
     mock_thread_pool.thread_iteration();
@@ -151,7 +217,7 @@ TYPED_TEST(SVSTieredIndexTest, addVector) {
     ASSERT_EQ(tiered_index->GetFlatIndex()->indexCapacity(), DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(tiered_index->indexCapacity(), DEFAULT_BLOCK_SIZE + 1);
     ASSERT_EQ(tiered_index->GetFlatIndex()->getDistanceFrom_Unsafe(vec_label, vector), 0);
-    ASSERT_EQ(mock_thread_pool.jobQ.size(), 1);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), mock_thread_pool.thread_pool_size);
     // Validate that the job was created properly
     // ASSERT_EQ(tiered_index->labelToInsertJobs.at(vec_label).size(), 1);
     // ASSERT_EQ(tiered_index->labelToInsertJobs.at(vec_label)[0]->label, vec_label);
@@ -163,7 +229,8 @@ TYPED_TEST(SVSTieredIndexTest, addVector) {
     expected_mem += sizeof(vecsim_stl::unordered_map<labelType, idType>::value_type) +
                     sizeof(void *) + sizeof(size_t);
     // Account for the insert job that was created.
-    expected_mem += sizeof(SVSIndexUpdateJob) + sizeof(size_t);
+    expected_mem +=
+        SVSMultiThreadJob::estimateSize(mock_thread_pool.thread_pool_size) + sizeof(size_t);
     auto actual_mem = tiered_index->getAllocationSize();
     ASSERT_GE(expected_mem * 1.02, tiered_index->getAllocationSize());
     ASSERT_LE(expected_mem, tiered_index->getAllocationSize());
@@ -188,8 +255,8 @@ TYPED_TEST(SVSTieredIndexTest, insertJob) {
     ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 1);
 
     // Execute the insert job manually (in a synchronous manner).
-    ASSERT_EQ(mock_thread_pool.jobQ.size(), 1);
-    auto *insertion_job = reinterpret_cast<SVSIndexUpdateJob *>(mock_thread_pool.jobQ.front().job);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), mock_thread_pool.thread_pool_size);
+    auto *insertion_job = mock_thread_pool.jobQ.front().job;
     ASSERT_EQ(insertion_job->jobType, HNSW_INSERT_VECTOR_JOB);
 
     mock_thread_pool.thread_iteration();
@@ -198,7 +265,7 @@ TYPED_TEST(SVSTieredIndexTest, insertJob) {
     ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 1);
     // SVS index should have allocated a single record, while flat index should remove the
     // block.
-    ASSERT_EQ(tiered_index->indexCapacity(), 1 + 1);
+    ASSERT_EQ(tiered_index->indexCapacity(), DEFAULT_BLOCK_SIZE);
     ASSERT_EQ(tiered_index->GetFlatIndex()->indexCapacity(), 0);
     ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(vec_label, vector), 0);
 }
@@ -463,7 +530,10 @@ TYPED_TEST(SVSTieredIndexTest, KNNSearch) {
 TYPED_TEST(SVSTieredIndexTest, deleteVector) {
     // Create TieredSVS index instance with a mock queue.
     size_t dim = 4;
-    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    SVSParams params = {.type = TypeParam::get_index_type(),
+                        .dim = dim,
+                        .metric = VecSimMetric_L2,
+                        .num_threads = 1};
     VecSimParams svs_params = CreateParams(params);
     auto mock_thread_pool = tieredIndexMock();
 
@@ -754,15 +824,14 @@ TYPED_TEST(SVSTieredIndexTest, testSizeEstimation) {
     for (size_t i = 0; i < n; i++) {
         GenerateAndAddVector<TEST_DATA_T>(index, dim, i, i);
     }
-    mock_thread_pool.thread_pool_join();
+    mock_thread_pool.thread_pool_wait();
 
     // Estimate memory delta for filling up the first block and adding another block.
     size_t estimation = VecSimIndex_EstimateElementSize(&params) * bs;
 
     size_t before = index->getAllocationSize();
     GenerateAndAddVector<TEST_DATA_T>(index, dim, bs + n, bs + n);
-    // Run the GC to move last vector to the SVS index.
-    index->runGC();
+    mock_thread_pool.thread_pool_join();
     size_t actual = index->getAllocationSize() - before;
 
     auto tiered_index = this->CastToTieredSVS(index);


### PR DESCRIPTION
## Implemented Tiered version of Scalable Vector Search index (`TieredSVSIndex`)

* Vectors moved to backend in 1 background job as a bulk
* Add basic unit tests for SVS tiered index
* Add Python binding for SVS Tiered index
* Backend index synchronized for deleted vectors

**Main objects this PR modified**
1. New class `TieredSVSIndex`
2. Tiered factory modified to support `TieredSVSIndex`

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

**TODO:**
- [ ] Uncomment and fix unit tests copy-pasted from HNSW-tiered or remove if not relevant.