### PR TITLE
[0.6] [MOD-9303] Update GoogleTest tag to support CMake 4.0 compatibility

### DIFF
--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 brew update
 brew install make
+brew install coreutils
 source install_cmake.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if(VECSIM_BUILD_TESTS)
 
 	FetchContent_Declare(
 		googletest
-		URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
+		URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
 	)
 
 	# For Windows: Prevent overriding the parent project's compiler/linker settings


### PR DESCRIPTION
Backport #630 to 0.6
* use googletest  1.16.0

* install coreutils on mac