### PR TITLE
Fix support of old compiler versions

### DIFF
--- a/src/VecSim/spaces/IP_space.cpp
+++ b/src/VecSim/spaces/IP_space.cpp
@@ -38,7 +38,7 @@ dist_func_t<float> IP_FP32_GetDistFunc(size_t dim, unsigned char *alignment, con
     }
 
     dist_func_t<float> ret_dist_func = FP32_InnerProduct;
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 #ifdef CPU_FEATURES_ARCH_AARCH64
 
 #ifdef OPT_SVE2
@@ -97,7 +97,7 @@ dist_func_t<double> IP_FP64_GetDistFunc(size_t dim, unsigned char *alignment,
     }
 
     dist_func_t<double> ret_dist_func = FP64_InnerProduct;
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef OPT_SVE2
@@ -158,7 +158,7 @@ dist_func_t<float> IP_BF16_GetDistFunc(size_t dim, unsigned char *alignment, con
     if (!is_little_endian()) {
         return BF16_InnerProduct_BigEndian;
     }
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #if defined(CPU_FEATURES_ARCH_AARCH64)
 #ifdef OPT_SVE_BF16
@@ -216,7 +216,7 @@ dist_func_t<float> IP_FP16_GetDistFunc(size_t dim, unsigned char *alignment, con
     if (alignment == nullptr) {
         alignment = &dummy_alignment;
     }
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
     dist_func_t<float> ret_dist_func = FP16_InnerProduct;
 
@@ -278,7 +278,7 @@ dist_func_t<float> IP_INT8_GetDistFunc(size_t dim, unsigned char *alignment, con
 
     dist_func_t<float> ret_dist_func = INT8_InnerProduct;
 
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef OPT_SVE2
@@ -328,7 +328,7 @@ dist_func_t<float> Cosine_INT8_GetDistFunc(size_t dim, unsigned char *alignment,
 
     dist_func_t<float> ret_dist_func = INT8_Cosine;
 
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef OPT_SVE2
@@ -380,7 +380,7 @@ dist_func_t<float> IP_UINT8_GetDistFunc(size_t dim, unsigned char *alignment,
 
     dist_func_t<float> ret_dist_func = UINT8_InnerProduct;
 
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef OPT_SVE2
@@ -428,7 +428,7 @@ dist_func_t<float> Cosine_UINT8_GetDistFunc(size_t dim, unsigned char *alignment
 
     dist_func_t<float> ret_dist_func = UINT8_Cosine;
 
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef OPT_SVE2

--- a/src/VecSim/spaces/L2_space.cpp
+++ b/src/VecSim/spaces/L2_space.cpp
@@ -39,7 +39,7 @@ dist_func_t<float> L2_FP32_GetDistFunc(size_t dim, unsigned char *alignment, con
 
     dist_func_t<float> ret_dist_func = FP32_L2Sqr;
 
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef OPT_SVE2
     if (features.sve2) {
@@ -97,7 +97,7 @@ dist_func_t<double> L2_FP64_GetDistFunc(size_t dim, unsigned char *alignment,
     }
 
     dist_func_t<double> ret_dist_func = FP64_L2Sqr;
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef OPT_SVE2
@@ -157,7 +157,7 @@ dist_func_t<float> L2_BF16_GetDistFunc(size_t dim, unsigned char *alignment, con
     if (!is_little_endian()) {
         return BF16_L2Sqr_BigEndian;
     }
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #if defined(CPU_FEATURES_ARCH_AARCH64)
 #ifdef OPT_SVE_BF16
@@ -207,7 +207,7 @@ dist_func_t<float> L2_FP16_GetDistFunc(size_t dim, unsigned char *alignment, con
     if (alignment == nullptr) {
         alignment = &dummy_alignment;
     }
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
     dist_func_t<float> ret_dist_func = FP16_L2Sqr;
 
@@ -269,7 +269,7 @@ dist_func_t<float> L2_INT8_GetDistFunc(size_t dim, unsigned char *alignment, con
 
     dist_func_t<float> ret_dist_func = INT8_L2Sqr;
 
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef OPT_SVE2
@@ -317,7 +317,7 @@ dist_func_t<float> L2_UINT8_GetDistFunc(size_t dim, unsigned char *alignment,
 
     dist_func_t<float> ret_dist_func = UINT8_L2Sqr;
     // Optimizations assume at least 32 uint8. If we have less, we use the naive implementation.
-    auto features = getCpuOptimizationFeatures(arch_opt);
+    [[maybe_unused]] auto features = getCpuOptimizationFeatures(arch_opt);
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef OPT_SVE2


### PR DESCRIPTION
**Describe the changes in the pull request**

Mark all CPU feature variables as `maybe_unused` so we won't get a warning about them if the compiler does not support certain features and does not include any optimizations for some type.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
