### PR TITLE
Using statically-linked SVS shared library

### DIFF
--- a/cmake/svs.cmake
+++ b/cmake/svs.cmake
@@ -58,7 +58,7 @@ endif()
 
 # Configure SVS build
 cmake_dependent_option(SVS_SHARED_LIB "Use SVS pre-compiled shared library" ON "SVS_SUPPORTED AND MKL_FOUND" OFF)
-set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.7/svs-shared-library-0.0.7-avx2.tar.gz" CACHE STRING "SVS URL")
+set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.7/svs-shared-library-0.0.7-avx2-static.tar.gz" CACHE STRING "SVS URL")
 
 if(USE_SVS)
     add_compile_definitions("HAVE_SVS=1")


### PR DESCRIPTION
**Describe the changes in the pull request**

Minor revision to SVS shared library url in https://github.com/RedisAI/VectorSimilarity/pull/658 to pull statically-linked MKL version for validation.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
