### PR TITLE
remove flags

### DIFF
--- a/src/VecSim/CMakeLists.txt
+++ b/src/VecSim/CMakeLists.txt
@@ -12,10 +12,7 @@ set(HEADER_LIST "${headers}")
 include_directories(../)
 
 set(SVS_CXX_STANDARD 20)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++20 -march=native -mtune=native")
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++20")
 
 add_subdirectory(spaces)
 


### PR DESCRIPTION

This PR removes the following global compiler flags from the CMake configuration:

```cmake
-march=native -mtune=native
```

These flags were originally introduced in [[#598](https://github.com/RedisAI/VectorSimilarity/pull/598)](https://github.com/RedisAI/VectorSimilarity/pull/598) to enable high-performance execution of the SVS dependency by leveraging the build machine's full CPU capabilities.

However, applying `-march=native` and `-mtune=native` **globally** causes several issues:

* **Cross-device compatibility:** hese flags enforce optimizations based on the build machine's architecture, making the resulting binaries potentially incompatible with machines of different architectures.
* **Conflicts with file-specific flags:** Some files require specific architecture features. For example, ARM files using intrinsics like `vdotq_s32` are explicitly compiled with `-march=armv8.2-a+dotprod.` Despite this, the presence of `-mtune=native` breaks the build. Removing it resolves the issue. This may be a bug in how GCC chains `-mtune=native` in combination with specific `-march=` overrides, as discussed here https://bugs.gentoo.org/884549.

* **Inconsistent optimization strategy:** In `VecSim`, architecture-specific optimizations are selected dynamically at **runtime** using a dispatcher based on the actual CPU running the binary. This pattern is also being extended for SVS in [[intel/SVS PR #113](https://github.com/intel/ScalableVectorSearch/pull/113)](https://github.com/intel/ScalableVectorSearch/pull/113).

### Summary

We are removing `-march=native` and `-mtune=native` from the global CMake configuration to:

* They lock in optimizations for the build machine’s CPU, breaking portability.
* They interfere with files requiring explicit `-march` values.
* They are incompatible with our runtime architecture selection strategy.

This change ensures that:

* The global build remains architecture-agnostic and portable.
* File-specific or runtime-selected optimizations can be applied safely where needed.

