### PR TITLE
Solve issues with mutexes while running tests on MacOS M1 

### DIFF
--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -462,6 +462,7 @@ public:
                                         VecSimQueryParams *query_params) override {
 
         py::array query(input);
+        py::gil_scoped_release py_gil;
         // Passing indexGuardPtr by value, so that the refCount of the mutex
         auto del = [indexGuardPtr = this->indexGuard](VecSimBatchIterator *pyBatchIter) {
             VecSimBatchIterator_Free(pyBatchIter);

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -236,8 +236,10 @@ public:
 
 class PyHNSWLibIndex : public PyVecSimIndex {
 private:
-    std::shared_ptr<std::shared_mutex> indexGuard; // to protect parallel operations on the index.
-    template <typename search_param_t>             // size_t/double for KNN/range queries.
+    std::shared_ptr<std::shared_mutex>
+        indexGuard; // to protect parallel operations on the index. Make sure to release the GIL
+                    // while locking the mutex.
+    template <typename search_param_t> // size_t/double for KNN/range queries.
     using QueryFunc =
         std::function<VecSimQueryReply *(const char *, search_param_t, VecSimQueryParams *)>;
 


### PR DESCRIPTION
**Describe the changes in the pull request**

2 issues are handled in this PR:

1- An `abort` was identified while running a test related to `PyBatchIterator`. The abort happened when the test was being shutdown. The error comes from the `deleter`passed to the `PyBatchIterator` `shared_ptr` which captures the `PyIndex`by reference. The problem is that there is no guarantee that the `PyIndex`lifetime will survive the `Iterator`. In that deleter a `mutex` is released (which could be in an invalid state). The solution is to have the `mutex`be wrapped in a shared_ptr that will share the ownership with the `PyBatchIterator` deleter as it captures it by value (incrementing its reference count).

2- Deadlock found on `tests/flow/test_hnsw_parallel.py::test_parallel_insert_batch_search`:

- Thread #N-1 has the `indexGuard` locked in shared mode, and tries to recover the GIL in the getNextResult
- Thread #N tries to acquire `indexGuard` exclusively, while N-1 has the indexGuard in shared mode. (WAIT)
- Thread #N+1 is another iterator that want `indexGuard` in shared mode (It goes in the queue) but cannot get it in shared mode (I guess is System dependant if they would schedule a reader to bypass the writer ) potential starvation. Thread N+1 has the GIL.

This is solved by releasing the GIL in `Thread N+1` before asking for `indexGuard`.
