### PR TITLE
Fix undefined behavior in U/INT8 in L2_SVE [MOD-9080]

### DIFF
--- a/src/VecSim/spaces/L2/L2_SVE_INT8.h
+++ b/src/VecSim/spaces/L2/L2_SVE_INT8.h
@@ -78,7 +78,7 @@ float INT8_L2SqrSIMD_SVE(const void *pVect1v, const void *pVect2v, size_t dimens
         svint8_t v2_i8 = svld1_s8(pg, pVect2 + offset); // Load int8 vectors from pVect2
 
         // The result of svabd can be reinterpreted as uint8
-        svuint8_t abs_diff = svreinterpret_u8_s8(svabd_s8_x(pg, v1_i8, v2_i8));
+        svuint8_t abs_diff = svreinterpret_u8_s8(svabd_s8_x(all, v1_i8, v2_i8));
 
         // Can sum with taking into account pg because svld1 will set inactive lanes to 0
         sum3 = svdot_u32(sum3, abs_diff, abs_diff);

--- a/src/VecSim/spaces/L2/L2_SVE_UINT8.h
+++ b/src/VecSim/spaces/L2/L2_SVE_UINT8.h
@@ -76,8 +76,9 @@ float UINT8_L2SqrSIMD_SVE(const void *pVect1v, const void *pVect2v, size_t dimen
         svuint8_t v1_ui8 = svld1_u8(pg, pVect1 + offset); // Load uint8 vectors from pVect1
         svuint8_t v2_ui8 = svld1_u8(pg, pVect2 + offset); // Load uint8 vectors from pVect2
 
-        svuint8_t abs_diff = svabd_u8_x(pg, v1_ui8, v2_ui8);
+        svuint8_t abs_diff = svabd_u8_x(all, v1_ui8, v2_ui8);
 
+        // Can sum with taking into account pg because svld1 will set inactive lanes to 0
         sum3 = svdot_u32(sum3, abs_diff, abs_diff);
     }
 


### PR DESCRIPTION
Previously, we sum onto sum3 without active lanes selection because svld1 load zeros onto inactive lanes,
 but in abs_diff we use svabd_s8_x and the same pg so the inactive lanes will be arbitrary rather than 0, which is a mistake.
 This PR changes the lanes in svabd from pg to all.