### PR TITLE
[SVS] Add SVS LeanVec compression support

### DIFF
--- a/cmake/svs.cmake
+++ b/cmake/svs.cmake
@@ -48,7 +48,7 @@ if(USE_SVS)
     endif()
 
     cmake_dependent_option(SVS_SHARED_LIB "Use SVS pre-compiled shared library" ON "USE_SVS AND GLIBC_FOUND" OFF)
-    set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250423.tar.gz" CACHE STRING "SVS URL")
+    set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250505.tar.gz" CACHE STRING "SVS URL")
 
     if(SVS_SHARED_LIB)
         include(FetchContent)

--- a/src/VecSim/algorithms/svs/svs_extensions.h
+++ b/src/VecSim/algorithms/svs/svs_extensions.h
@@ -12,6 +12,7 @@
 
 #if HAVE_SVS_LVQ
 #include SVS_LVQ_HEADER
+#include "svs/extensions/vamana/leanvec.h"
 
 namespace svs_details {
 template <size_t Primary>
@@ -26,7 +27,8 @@ struct LVQSelector<4> {
 } // namespace svs_details
 
 template <typename DataType, size_t QuantBits, size_t ResidualBits>
-struct SVSStorageTraits<DataType, QuantBits, ResidualBits, std::enable_if_t<(QuantBits > 0)>> {
+struct SVSStorageTraits<DataType, QuantBits, ResidualBits, false,
+                        std::enable_if_t<(QuantBits > 0)>> {
     using allocator_type = svs_details::SVSAllocator<std::byte>;
     using blocked_type = svs::data::Blocked<svs::AllocatorHandle<std::byte>>;
     using strategy_type = typename svs_details::LVQSelector<QuantBits>::strategy;
@@ -57,6 +59,75 @@ struct SVSStorageTraits<DataType, QuantBits, ResidualBits, std::enable_if_t<(Qua
     static size_t storage_capacity(const index_storage_type &storage) {
         // LVQDataset does not provide a capacity method
         return storage.size();
+    }
+
+    template <typename Distance, typename E, size_t N>
+    static float compute_distance_by_id(const index_storage_type &storage, const Distance &distance,
+                                        size_t id, std::span<E, N> query) {
+        auto dist_f = svs::index::vamana::extensions::single_search_setup(storage, distance);
+
+        // SVS distance function may require to fix/pre-process one of arguments
+        svs::distance::maybe_fix_argument(dist_f, query);
+
+        // Get the datum from the storage using the storage ID
+        auto datum = storage.get_datum(id);
+        return svs::distance::compute(dist_f, query, datum);
+    }
+};
+
+template <typename DataType, size_t QuantBits, size_t ResidualBits>
+struct SVSStorageTraits<DataType, QuantBits, ResidualBits, true> {
+    using allocator_type = svs_details::SVSAllocator<std::byte>;
+    using blocked_type = svs::data::Blocked<svs::AllocatorHandle<std::byte>>;
+    using index_storage_type = svs::leanvec::LeanDataset<svs::leanvec::UsingLVQ<QuantBits>,
+                                                         svs::leanvec::UsingLVQ<ResidualBits>,
+                                                         svs::Dynamic, svs::Dynamic, blocked_type>;
+
+    static size_t leanvec_dims(size_t dims) { return dims / 2; }
+
+    template <svs::data::ImmutableMemoryDataset Dataset, svs::threads::ThreadPool Pool>
+    static index_storage_type create_storage(const Dataset &data, size_t block_size, Pool &pool,
+                                             std::shared_ptr<VecSimAllocator> allocator) {
+        const auto dims = data.dimensions();
+        auto svs_bs = svs_details::SVSBlockSize(block_size, element_size(dims));
+
+        // allocator_type data_allocator{std::move(allocator)};
+        // blocked_type blocked_alloc{{svs_bs}, data_allocator};
+        allocator_type data_allocator{std::move(allocator)};
+        auto blocked_alloc = svs::make_blocked_allocator_handle({svs_bs}, data_allocator);
+
+        // TODO: Should we pass threadpool?
+        return index_storage_type::reduce(data, std::nullopt, pool, 0,
+                                          svs::lib::MaybeStatic<svs::Dynamic>(leanvec_dims(dims)),
+                                          blocked_alloc);
+    }
+
+    static constexpr size_t element_size(size_t dims, size_t alignment = 0) {
+        return SVSStorageTraits<DataType, QuantBits, 0, false>::element_size(leanvec_dims(dims),
+                                                                             alignment) +
+               SVSStorageTraits<DataType, ResidualBits, 0, false>::element_size(dims, alignment);
+    }
+
+    static size_t storage_capacity(const index_storage_type &storage) {
+        // LeanDataset does not provide a capacity method
+        return storage.size();
+    }
+
+    template <typename Distance, typename E, size_t N>
+    static float compute_distance_by_id(const index_storage_type &storage, const Distance &distance,
+                                        size_t id, std::span<E, N> query) {
+        // SVS distance function wrapper to cover LeanVec cases is a tuple with 3 elements: original
+        // distance, primary distance, secondary distance The last element is the secondary distance
+        // function, which is used for computaion.
+        auto dist_f =
+            std::get<2>(svs::index::vamana::extensions::single_search_setup(storage, distance));
+
+        // SVS distance function may require to fix/pre-process one of arguments
+        svs::distance::maybe_fix_argument(dist_f, query);
+
+        // Get the datum from the second LeavVec storage using the storage ID
+        auto datum = storage.get_secondary(id);
+        return svs::distance::compute(dist_f, query, datum);
     }
 };
 #else

--- a/src/VecSim/algorithms/svs/svs_extensions.h
+++ b/src/VecSim/algorithms/svs/svs_extensions.h
@@ -26,6 +26,7 @@ struct LVQSelector<4> {
 };
 } // namespace svs_details
 
+// LVQDataset traits for SVS
 template <typename DataType, size_t QuantBits, size_t ResidualBits>
 struct SVSStorageTraits<DataType, QuantBits, ResidualBits, false,
                         std::enable_if_t<(QuantBits > 0)>> {
@@ -75,6 +76,7 @@ struct SVSStorageTraits<DataType, QuantBits, ResidualBits, false,
     }
 };
 
+// LeanVec dataset traits for SVS
 template <typename DataType, size_t QuantBits, size_t ResidualBits>
 struct SVSStorageTraits<DataType, QuantBits, ResidualBits, true> {
     using allocator_type = svs_details::SVSAllocator<std::byte>;
@@ -91,8 +93,6 @@ struct SVSStorageTraits<DataType, QuantBits, ResidualBits, true> {
         const auto dims = data.dimensions();
         auto svs_bs = svs_details::SVSBlockSize(block_size, element_size(dims));
 
-        // allocator_type data_allocator{std::move(allocator)};
-        // blocked_type blocked_alloc{{svs_bs}, data_allocator};
         allocator_type data_allocator{std::move(allocator)};
         auto blocked_alloc = svs::make_blocked_allocator_handle({svs_bs}, data_allocator);
 
@@ -125,7 +125,7 @@ struct SVSStorageTraits<DataType, QuantBits, ResidualBits, true> {
         // SVS distance function may require to fix/pre-process one of arguments
         svs::distance::maybe_fix_argument(dist_f, query);
 
-        // Get the datum from the second LeavVec storage using the storage ID
+        // Get the datum from the second LeanVec storage using the storage ID
         auto datum = storage.get_secondary(id);
         return svs::distance::compute(dist_f, query, datum);
     }

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -187,7 +187,8 @@ inline std::pair<VecSimSvsQuantBits, bool> isSVSQuantBitsSupported(VecSimSvsQuan
 }
 } // namespace svs_details
 
-template <typename DataType, size_t QuantBits, size_t ResidualBits, class Enable = void>
+template <typename DataType, size_t QuantBits, size_t ResidualBits, bool IsLeanVec,
+          class Enable = void>
 struct SVSStorageTraits {
     using allocator_type = svs_details::SVSAllocator<DataType>;
     // In SVS, the default allocator is designed for static indices,
@@ -226,6 +227,19 @@ struct SVSStorageTraits {
     }
 
     static size_t storage_capacity(const index_storage_type &storage) { return storage.capacity(); }
+
+    template <typename Distance, typename E, size_t N>
+    static float compute_distance_by_id(const index_storage_type &storage, const Distance &distance,
+                                        size_t id, std::span<E, N> query) {
+        auto dist_f = svs::index::vamana::extensions::single_search_setup(storage, distance);
+
+        // SVS distance function may require to fix/pre-process one of arguments
+        svs::distance::maybe_fix_argument(dist_f, query);
+
+        // Get the datum from the storage using the storage ID
+        auto datum = storage.get_datum(id);
+        return svs::distance::compute(dist_f, query, datum);
+    }
 };
 
 template <typename SVSIdType>

--- a/src/VecSim/index_factories/svs_factory.cpp
+++ b/src/VecSim/index_factories/svs_factory.cpp
@@ -63,9 +63,9 @@ VecSimIndex *NewIndexImpl(const VecSimParams *params, bool is_normalized) {
         return NewIndexImpl<MetricType, DataType, 4, 4, false>(params, is_normalized);
     case VecSimSvsQuant_4x8:
         return NewIndexImpl<MetricType, DataType, 4, 8, false>(params, is_normalized);
-    case VecSimSvsQuant_4x8_leanvec:
+    case VecSimSvsQuant_4x8_LeanVec:
         return NewIndexImpl<MetricType, DataType, 4, 8, true>(params, is_normalized);
-    case VecSimSvsQuant_8x8_leanvec:
+    case VecSimSvsQuant_8x8_LeanVec:
         return NewIndexImpl<MetricType, DataType, 8, 8, true>(params, is_normalized);
     default:
         // If we got here something is wrong.
@@ -128,9 +128,9 @@ size_t QuantizedVectorSize(VecSimSvsQuantBits quant_bits, size_t dims, size_t al
         return QuantizedVectorSize<DataType, 4, 4, false>(dims, alignment);
     case VecSimSvsQuant_4x8:
         return QuantizedVectorSize<DataType, 4, 8, false>(dims, alignment);
-    case VecSimSvsQuant_4x8_leanvec:
+    case VecSimSvsQuant_4x8_LeanVec:
         return QuantizedVectorSize<DataType, 4, 8, true>(dims, alignment);
-    case VecSimSvsQuant_8x8_leanvec:
+    case VecSimSvsQuant_8x8_LeanVec:
         return QuantizedVectorSize<DataType, 8, 8, true>(dims, alignment);
     default:
         // If we got here something is wrong.
@@ -189,7 +189,7 @@ size_t EstimateInitialSize(const SVSParams *params, bool is_normalized) {
     size_t allocations_overhead = VecSimAllocator::getAllocationOverheadSize();
     size_t est = sizeof(VecSimAllocator) + allocations_overhead;
 
-    // Assume all floats have same cases
+    // Assume all non-quant floats have same initial size
     // Assume quantBits>0 cases have same sizes
     est += (params->quantBits == 0)
                ? sizeof(SVSIndex<svs::distance::DistanceL2, float, 0, 0, false>)
@@ -203,7 +203,7 @@ size_t EstimateInitialSize(const SVSParams *params, bool is_normalized) {
 
 // This is a temporary solution to avoid breaking the build when SVS is not available
 // and to allow the code to compile without SVS support.
-// TODO: remove HAVE_SVS when SVS will support all Redis platfoms and compilers
+// TODO: remove HAVE_SVS when SVS will support all Redis platforms and compilers
 #else  // HAVE_SVS
 namespace SVSFactory {
 VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) { return NULL; }

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -138,8 +138,8 @@ typedef enum {
     VecSimSvsQuant_8 = 8,              // 8-bit quantization
     VecSimSvsQuant_4x4 = 4 | (4 << 8), // 4-bit quantization with 4-bit residuals
     VecSimSvsQuant_4x8 = 4 | (8 << 8), // 4-bit quantization with 8-bit residuals
-    VecSimSvsQuant_4x8_leanvec = 4 | (8 << 8) | (1 << 16), // LeanVec 4x4 quantization
-    VecSimSvsQuant_8x8_leanvec = 8 | (8 << 8) | (1 << 16), // LeanVec 8x8 quantization
+    VecSimSvsQuant_4x8_LeanVec = 4 | (8 << 8) | (1 << 16), // LeanVec 4x4 quantization
+    VecSimSvsQuant_8x8_LeanVec = 8 | (8 << 8) | (1 << 16), // LeanVec 8x8 quantization
 } VecSimSvsQuantBits;
 
 typedef struct {

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -133,11 +133,13 @@ typedef struct {
 } BFParams;
 
 typedef enum {
-    VecSimSvsQuant_NONE = 0,            // No quantization.
-    VecSimSvsQuant_8 = 8,               // 8-bit quantization
-    VecSimSvsQuant_4 = 4,               // 4-bit quantization
-    VecSimSvsQuant_4x4 = 4 | (4 << 10), // 4-bit quantization with 4-bit residuals
-    VecSimSvsQuant_4x8 = 4 | (8 << 10)  // 4-bit quantization with 8-bit residuals
+    VecSimSvsQuant_NONE = 0,           // No quantization.
+    VecSimSvsQuant_4 = 4,              // 4-bit quantization
+    VecSimSvsQuant_8 = 8,              // 8-bit quantization
+    VecSimSvsQuant_4x4 = 4 | (4 << 8), // 4-bit quantization with 4-bit residuals
+    VecSimSvsQuant_4x8 = 4 | (8 << 8), // 4-bit quantization with 8-bit residuals
+    VecSimSvsQuant_4x8_leanvec = 4 | (8 << 8) | (1 << 16), // LeanVec 4x4 quantization
+    VecSimSvsQuant_8x8_leanvec = 8 | (8 << 8) | (1 << 16), // LeanVec 8x8 quantization
 } VecSimSvsQuantBits;
 
 typedef struct {

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -138,7 +138,7 @@ typedef enum {
     VecSimSvsQuant_8 = 8,              // 8-bit quantization
     VecSimSvsQuant_4x4 = 4 | (4 << 8), // 4-bit quantization with 4-bit residuals
     VecSimSvsQuant_4x8 = 4 | (8 << 8), // 4-bit quantization with 8-bit residuals
-    VecSimSvsQuant_4x8_LeanVec = 4 | (8 << 8) | (1 << 16), // LeanVec 4x4 quantization
+    VecSimSvsQuant_4x8_LeanVec = 4 | (8 << 8) | (1 << 16), // LeanVec 4x8 quantization
     VecSimSvsQuant_8x8_LeanVec = 8 | (8 << 8) | (1 << 16), // LeanVec 8x8 quantization
 } VecSimSvsQuantBits;
 

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -60,7 +60,7 @@ struct SVSIndexType {
 // clang-format off
 using SVSDataTypeSet = ::testing::Types<SVSIndexType<VecSimType_FLOAT32, float, VecSimSvsQuant_NONE>
                                        ,SVSIndexType<VecSimType_FLOAT32, float, VecSimSvsQuant_8>
-                                       ,SVSIndexType<VecSimType_FLOAT32, float, VecSimSvsQuant_8x8_leanvec>
+                                       ,SVSIndexType<VecSimType_FLOAT32, float, VecSimSvsQuant_8x8_LeanVec>
                                         >;
 // clang-format on
 
@@ -2135,7 +2135,7 @@ TEST(SVSTest, quant_modes) {
 
     for (auto quant_bits :
          {VecSimSvsQuant_NONE, VecSimSvsQuant_8, VecSimSvsQuant_4, VecSimSvsQuant_4x4,
-          VecSimSvsQuant_4x8, VecSimSvsQuant_4x8_leanvec, VecSimSvsQuant_8x8_leanvec}) {
+          VecSimSvsQuant_4x8, VecSimSvsQuant_4x8_LeanVec, VecSimSvsQuant_8x8_LeanVec}) {
         SVSParams params = {
             .type = VecSimType_FLOAT32,
             .dim = dim,
@@ -2152,6 +2152,13 @@ TEST(SVSTest, quant_modes) {
                 GTEST_SKIP() << "SVS LVQ is not supported.";
             }
         }
+
+        // Test initial size estimation
+        // EstimateInitialSize is called after CreateNewIndex because params struct is
+        // changed in CreateNewIndex.
+        size_t estimation = EstimateInitialSize(params);
+        size_t actual = index->getAllocationSize();
+        EXPECT_EQ(estimation, actual);
 
         EXPECT_EQ(VecSimIndex_IndexSize(index), 0);
 

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -60,6 +60,7 @@ struct SVSIndexType {
 // clang-format off
 using SVSDataTypeSet = ::testing::Types<SVSIndexType<VecSimType_FLOAT32, float, VecSimSvsQuant_NONE>
                                        ,SVSIndexType<VecSimType_FLOAT32, float, VecSimSvsQuant_8>
+                                       ,SVSIndexType<VecSimType_FLOAT32, float, VecSimSvsQuant_8x8_leanvec>
                                         >;
 // clang-format on
 
@@ -1390,18 +1391,13 @@ TYPED_TEST(SVSTest, batchIteratorSwapIndices) {
 
 TYPED_TEST(SVSTest, svs_vector_search_test_cosine) {
     const size_t dim = 128;
-    const size_t n = 100;
+    const size_t n = 50;
 
     SVSParams params = {
         .dim = dim,
         .metric = VecSimMetric_Cosine,
         /* SVS-Vamana specifics */
         .alpha = 0.9,
-        .graph_max_degree = 64,
-        .construction_window_size = 20,
-        .max_candidate_pool_size = 1024,
-        .prune_to = 60,
-        .use_search_history = VecSimOption_ENABLE,
     };
 
     VecSimIndex *index = this->CreateNewIndex(params);
@@ -1468,8 +1464,8 @@ TYPED_TEST(SVSTest, svs_vector_search_test_cosine) {
 }
 
 TYPED_TEST(SVSTest, testSizeEstimation) {
-    size_t dim = 128;
-#if HAVE_SVS_LVQ
+    size_t dim = 64;
+
     // SVS block sizes always rounded to a power of 2
     // This why, in case of quantization, actual block size can be differ than requested
     // In addition, block size to be passed to graph and dataset counted in bytes,
@@ -1484,7 +1480,7 @@ TYPED_TEST(SVSTest, testSizeEstimation) {
         const auto lvq_vector_extra = sizeof(svs::quantization::lvq::ScalarBundle);
         dim -= (lvq_vector_extra * 8) / TypeParam::get_quant_bits();
     }
-#endif
+
     size_t n = 0;
     size_t bs = DEFAULT_BLOCK_SIZE;
 
@@ -1515,8 +1511,10 @@ TYPED_TEST(SVSTest, testSizeEstimation) {
     GenerateAndAddVector<TEST_DATA_T>(index, dim, 0);
     actual = index->getAllocationSize() - actual; // get the delta
     ASSERT_GT(actual, 0);
-    ASSERT_GE(estimation * 1.01, actual);
-    ASSERT_LE(estimation * 0.99, actual);
+    // LVQ element estimation accuracy is low
+    double estimation_accuracy = (quantBits != VecSimSvsQuant_NONE) ? 0.1 : 0.01;
+    ASSERT_GE(estimation * (1.0 + estimation_accuracy), actual);
+    ASSERT_LE(estimation * (1.0 - estimation_accuracy), actual);
 
     VecSimIndex_Free(index);
 }

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -1466,21 +1466,23 @@ TYPED_TEST(SVSTest, svs_vector_search_test_cosine) {
 TYPED_TEST(SVSTest, testSizeEstimation) {
     size_t dim = 64;
 
+    auto quantBits = TypeParam::get_quant_bits();
+    // Get the fallback quantization mode
+    quantBits = std::get<0>(svs_details::isSVSQuantBitsSupported(quantBits));
+
+#if HAVE_SVS_LVQ
     // SVS block sizes always rounded to a power of 2
     // This why, in case of quantization, actual block size can be differ than requested
     // In addition, block size to be passed to graph and dataset counted in bytes,
     // converted then to a number of elements.
     // IMHO, would be better to always interpret block size to a number of elements
     // rather than conversion to-from number of bytes
-    auto quantBits = TypeParam::get_quant_bits();
-    // Get the fallback quantization mode
-    quantBits = std::get<0>(svs_details::isSVSQuantBitsSupported(quantBits));
     if (quantBits != VecSimSvsQuant_NONE) {
         // Extra data in LVQ vector
         const auto lvq_vector_extra = sizeof(svs::quantization::lvq::ScalarBundle);
         dim -= (lvq_vector_extra * 8) / TypeParam::get_quant_bits();
     }
-
+#endif
     size_t n = 0;
     size_t bs = DEFAULT_BLOCK_SIZE;
 

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -2169,9 +2169,9 @@ TEST(SVSTest, quant_modes) {
 
         EXPECT_EQ(VecSimIndex_IndexSize(index), 0);
 
-        std::vector<float[dim]> v(n);
+        std::vector<std::array<float, dim>> v(n);
         for (size_t i = 0; i < n; i++) {
-            GenerateVector<float>(v[i], dim, i);
+            GenerateVector<float>(v[i].data(), dim, i);
         }
 
         std::vector<size_t> ids(n);
@@ -2187,7 +2187,8 @@ TEST(SVSTest, quant_modes) {
         actual = index->getAllocationSize() - actual; // get the delta
         ASSERT_GT(actual, 0);
         // LVQ element size estimation accuracy is low
-        double estimation_accuracy = (quant_bits != VecSimSvsQuant_NONE) ? 0.11 : 0.01;
+        auto quant_bits_fallback = std::get<0>(svs_details::isSVSQuantBitsSupported(quant_bits));
+        double estimation_accuracy = (quant_bits_fallback != VecSimSvsQuant_NONE) ? 0.11 : 0.01;
         ASSERT_GE(estimation * (1.0 + estimation_accuracy), actual);
         ASSERT_LE(estimation * (1.0 - estimation_accuracy), actual);
 


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR introduces SVS LeanVec index compression integration to VecSim `SVSIndex`.

**Which issues this PR fixes**
1. No issues


**Main objects this PR modified**
1. Added SVS LeanVec compression support:
    - New template parameter `IsLeanVec` for `SVSIndex` class in *svs.h*
    - New `SVSStorageTraits` specialization for `IsLeanVec=true` in *svs_extensions.h*
    - `SVSStorageTraits` interface extended by `compute_distance_by_id()` used in `SVSIndex::getDistanceFrom_Unsafe()`
    - Added new LeanVec options to `VecSimSvsQuantBits` enum in *vec_sim_common.h*
    - Reflect new LeanVec options in *svs_factory.h*
    - Added new test to `test_svs.cpp` which constructs `SVSIndex` with different kind of compression/quantization.

**Mark if applicable**

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes
