### PR TITLE
[SVS] Update SVS Index defaults

### DIFF
--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -78,7 +78,7 @@ using SVSAllocator = VecsimSTLAllocator<T>;
 
 template <typename T, typename U>
 static T getOrDefault(T v, U def) {
-    return v ? v : static_cast<T>(def);
+    return v != T{} ? v : static_cast<T>(def);
 }
 
 static svs::index::vamana::VamanaBuildParameters

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -81,7 +81,7 @@ static T getOrDefault(T v, U def) {
     return v != T{} ? v : static_cast<T>(def);
 }
 
-static svs::index::vamana::VamanaBuildParameters
+inline svs::index::vamana::VamanaBuildParameters
 makeVamanaBuildParameters(const SVSParams &params) {
     // clang-format off
     // evaluate optimal default parameters; current assumption:

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -76,6 +76,48 @@ inline double toVecSimDistance<svs::distance::DistanceCosineSimilarity>(float v)
 template <typename T>
 using SVSAllocator = VecsimSTLAllocator<T>;
 
+template <typename T, typename U>
+static T getOrDefault(T v, U def) {
+    return v ? v : static_cast<T>(def);
+}
+
+static svs::index::vamana::VamanaBuildParameters
+makeVamanaBuildParameters(const SVSParams &params) {
+    // clang-format off
+    // evaluate optimal default parameters; current assumption:
+    // * alpha (1.2 or 0.95) depends on metric: L2: > 1.0, IP, Cosine: < 1.0
+    //      In the Vamana algorithm implementation in SVS, the choice of alpha value
+    //      depends on the type of similarity measure used. For L2, which minimizes distance,
+    //      an alpha value greater than 1 is needed, typically around 1.2.
+    //      For Inner Product and Cosine, which maximize similarity or distance,
+    //      the alpha value should be less than 1, usually 0.9 or 0.95 works.
+    // * construction_window_size (200): similar to HNSW_EF_CONSTRUCTION
+    // * graph_max_degree (32): similar to HNSW_M * 2
+    // * max_candidate_pool_size (600): =~ construction_window_size * 3
+    // * prune_to (28): < graph_max_degree, optimal = graph_max_degree - 4
+    //      The prune_to parameter is a performance feature designed to enhance build time
+    //      by setting a small difference between this value and the maximum graph degree.
+    //      This acts as a threshold for how much pruning can reduce the number of neighbors.
+    //      Typically, a small gap of 4 or 8 is sufficient to improve build time
+    //      without compromising the quality of the graph.
+    // * use_search_history (true): now: is enabled if not disabled explicitly
+    //                              future: default value based on other index parameters
+    const auto construction_window_size = getOrDefault(params.construction_window_size, 200);
+    const auto graph_max_degree = getOrDefault(params.graph_max_degree, 32);
+
+    // More info about VamanaBuildParameters can be found there:
+    // https://intel.github.io/ScalableVectorSearch/python/vamana.html#svs.VamanaBuildParameters
+    return svs::index::vamana::VamanaBuildParameters{
+        getOrDefault(params.alpha, (params.metric == VecSimMetric_L2 ? 1.2f : 0.95f)),
+        graph_max_degree,
+        construction_window_size,
+        getOrDefault(params.max_candidate_pool_size, construction_window_size * 3),
+        getOrDefault(params.prune_to, graph_max_degree - 4),
+        params.use_search_history != VecSimOption_DISABLE
+    };
+    // clang-format on
+}
+
 // Join default SVS search parameters with VecSim query runtime parameters
 inline svs::index::vamana::VamanaSearchParameters
 joinSearchParams(svs::index::vamana::VamanaSearchParameters &&sp,

--- a/src/VecSim/index_factories/svs_factory.cpp
+++ b/src/VecSim/index_factories/svs_factory.cpp
@@ -182,8 +182,9 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
 
 size_t EstimateElementSize(const SVSParams *params) {
     using graph_idx_type = uint32_t;
-    const auto graph_node_size =
-        SVSGraphBuilder<graph_idx_type>::element_size(params->graph_max_degree);
+    // Assuming that the graph_max_degree can be unset in params.
+    const auto graph_max_degree = svs_details::makeVamanaBuildParameters(*params).graph_max_degree;
+    const auto graph_node_size = SVSGraphBuilder<graph_idx_type>::element_size(graph_max_degree);
     const auto vector_size = QuantizedVectorSize(params->type, params->quantBits, params->dim);
 
     return vector_size + graph_node_size;


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR updates SVS Index parameters defaults according to rules:

> These should be the defaults values:
> - alpha=1.2 for L2 and 0.95 for IP and cosine
> - construction_window_size = 200
> - graph_max_degree = 32
> - max_candidate_pool_size = 3 * construction_window_size
> - prune_to = graph_max_degree - 4
> - use_search_history = True
> 

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. SVS Vamna Index


**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
