### PR TITLE
[MOD-9302] Refactor SVS preprocessing and remove unused preprocessQueryInPlace

### DIFF
--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -215,8 +215,8 @@ protected:
         memcpy(processed_blob.get(), original_data, data_size);
         // Preprocess each vector in place
         for (size_t i = 0; i < n; i++) {
-            this->preprocessQueryInPlace(static_cast<DataType *>(processed_blob.get()) +
-                                         i * this->dim);
+            this->preprocessStorageInPlace(static_cast<DataType *>(processed_blob.get()) +
+                                           i * this->dim);
         }
         return processed_blob;
     }

--- a/src/VecSim/index_factories/components/components_factory.h
+++ b/src/VecSim/index_factories/components/components_factory.h
@@ -14,53 +14,6 @@
 #include "VecSim/index_factories/components/preprocessors_factory.h"
 #include "VecSim/spaces/computer/calculator.h"
 
-/**
- * @brief Creates parameters for a preprocessors container based on the given metric, dimension,
- *        normalization flag, and alignment.
- *
- * @tparam DataType The data type of the vector elements (e.g., float, int).
- * @param metric The similarity metric to be used (e.g., Cosine, Inner Product).
- * @param dim The dimensionality of the vectors.
- * @param is_normalized A flag indicating whether the vectors are already normalized.
- * @param alignment The alignment requirement for the data.
- * @return A PreprocessorsContainerParams object containing the processed parameters:
- *         - metric: The adjusted metric based on the input and normalization flag.
- *         - dim: The dimensionality of the vectors.
- *         - alignment: The alignment requirement for the data.
- *         - processed_bytes_count: The size of the processed data blob in bytes.
- *
- * @details
- * If the metric is Cosine and the data type is integral, the processed bytes count may include
- * additional space for normalization. If the vectors are already
- * normalized (is_normalized == true), the metric is adjusted to Inner Product (IP) to skip
- * redundant normalization during preprocessing.
- */
-template <typename DataType>
-PreprocessorsContainerParams CreatePreprocessorsContainerParams(VecSimMetric metric, size_t dim,
-                                                                bool is_normalized,
-                                                                unsigned char alignment) {
-    // By default the processed blob size is the same as the original blob size.
-    size_t processed_bytes_count = dim * sizeof(DataType);
-
-    VecSimMetric pp_metric = metric;
-    if (metric == VecSimMetric_Cosine) {
-        // if metric is cosine and DataType is integral, the processed_bytes_count includes the
-        // norm appended to the vector.
-        if (std::is_integral<DataType>::value) {
-            processed_bytes_count += sizeof(float);
-        }
-        // if is_normalized == true, we will enforce skipping normalizing vector and query blobs by
-        // setting the metric to IP.
-        if (is_normalized) {
-            pp_metric = VecSimMetric_IP;
-        }
-    }
-    return {.metric = pp_metric,
-            .dim = dim,
-            .alignment = alignment,
-            .processed_bytes_count = processed_bytes_count};
-}
-
 template <typename DataType, typename DistType>
 IndexComponents<DataType, DistType>
 CreateIndexComponents(std::shared_ptr<VecSimAllocator> allocator, VecSimMetric metric, size_t dim,
@@ -71,9 +24,8 @@ CreateIndexComponents(std::shared_ptr<VecSimAllocator> allocator, VecSimMetric m
     // Currently we have only one distance calculator implementation
     auto indexCalculator = new (allocator) DistanceCalculatorCommon<DistType>(allocator, distFunc);
 
-    PreprocessorsContainerParams ppParams =
-        CreatePreprocessorsContainerParams<DataType>(metric, dim, is_normalized, alignment);
-    auto preprocessors = CreatePreprocessorsContainer<DataType>(allocator, ppParams);
+    auto preprocessors =
+        CreatePreprocessorsContainer<DataType>(allocator, metric, dim, is_normalized, alignment);
 
     return {indexCalculator, preprocessors};
 }

--- a/src/VecSim/index_factories/components/preprocessors_factory.h
+++ b/src/VecSim/index_factories/components/preprocessors_factory.h
@@ -18,6 +18,53 @@ struct PreprocessorsContainerParams {
     size_t processed_bytes_count;
 };
 
+/**
+ * @brief Creates parameters for a preprocessors container based on the given metric, dimension,
+ *        normalization flag, and alignment.
+ *
+ * @tparam DataType The data type of the vector elements (e.g., float, int).
+ * @param metric The similarity metric to be used (e.g., Cosine, Inner Product).
+ * @param dim The dimensionality of the vectors.
+ * @param is_normalized A flag indicating whether the vectors are already normalized.
+ * @param alignment The alignment requirement for the data.
+ * @return A PreprocessorsContainerParams object containing the processed parameters:
+ *         - metric: The adjusted metric based on the input and normalization flag.
+ *         - dim: The dimensionality of the vectors.
+ *         - alignment: The alignment requirement for the data.
+ *         - processed_bytes_count: The size of the processed data blob in bytes.
+ *
+ * @details
+ * If the metric is Cosine and the data type is integral, the processed bytes count may include
+ * additional space for normalization. If the vectors are already
+ * normalized (is_normalized == true), the metric is adjusted to Inner Product (IP) to skip
+ * redundant normalization during preprocessing.
+ */
+template <typename DataType>
+PreprocessorsContainerParams CreatePreprocessorsContainerParams(VecSimMetric metric, size_t dim,
+                                                                bool is_normalized,
+                                                                unsigned char alignment) {
+    // By default the processed blob size is the same as the original blob size.
+    size_t processed_bytes_count = dim * sizeof(DataType);
+
+    VecSimMetric pp_metric = metric;
+    if (metric == VecSimMetric_Cosine) {
+        // if metric is cosine and DataType is integral, the processed_bytes_count includes the
+        // norm appended to the vector.
+        if (std::is_integral<DataType>::value) {
+            processed_bytes_count += sizeof(float);
+        }
+        // if is_normalized == true, we will enforce skipping normalizing vector and query blobs by
+        // setting the metric to IP.
+        if (is_normalized) {
+            pp_metric = VecSimMetric_IP;
+        }
+    }
+    return {.metric = pp_metric,
+            .dim = dim,
+            .alignment = alignment,
+            .processed_bytes_count = processed_bytes_count};
+}
+
 template <typename DataType>
 PreprocessorsContainerAbstract *
 CreatePreprocessorsContainer(std::shared_ptr<VecSimAllocator> allocator,
@@ -35,6 +82,16 @@ CreatePreprocessorsContainer(std::shared_ptr<VecSimAllocator> allocator,
     }
 
     return new (allocator) PreprocessorsContainerAbstract(allocator, params.alignment);
+}
+
+template <typename DataType>
+PreprocessorsContainerAbstract *
+CreatePreprocessorsContainer(std::shared_ptr<VecSimAllocator> allocator, VecSimMetric metric,
+                             size_t dim, bool is_normalized, unsigned char alignment) {
+
+    PreprocessorsContainerParams ppParams =
+        CreatePreprocessorsContainerParams<DataType>(metric, dim, is_normalized, alignment);
+    return CreatePreprocessorsContainer<DataType>(allocator, ppParams);
 }
 
 template <typename DataType>

--- a/src/VecSim/spaces/computer/preprocessor_container.cpp
+++ b/src/VecSim/spaces/computer/preprocessor_container.cpp
@@ -26,9 +26,6 @@ MemoryUtils::unique_blob PreprocessorsContainerAbstract::preprocessQuery(const v
     return maybeCopyToAlignedMem(original_blob, input_blob_size, force_copy);
 }
 
-void PreprocessorsContainerAbstract::preprocessQueryInPlace(void *blob,
-                                                            size_t input_blob_size) const {}
-
 void PreprocessorsContainerAbstract::preprocessStorageInPlace(void *blob,
                                                               size_t input_blob_size) const {}
 

--- a/src/VecSim/spaces/computer/preprocessor_container.h
+++ b/src/VecSim/spaces/computer/preprocessor_container.h
@@ -33,7 +33,6 @@ public:
                                                      size_t input_blob_size,
                                                      bool force_copy = false) const;
 
-    virtual void preprocessQueryInPlace(void *blob, size_t input_blob_size) const;
     virtual void preprocessStorageInPlace(void *blob, size_t input_blob_size) const;
 
     unsigned char getAlignment() const { return alignment; }
@@ -89,8 +88,6 @@ public:
 
     MemoryUtils::unique_blob preprocessQuery(const void *original_blob, size_t input_blob_size,
                                              bool force_copy = false) const override;
-
-    void preprocessQueryInPlace(void *blob, size_t input_blob_size) const override;
 
     void preprocessStorageInPlace(void *blob, size_t input_blob_size) const override;
 
@@ -231,18 +228,6 @@ MemoryUtils::unique_blob MultiPreprocessorsContainer<DataType, n_preprocessors>:
     return query_blob
                ? std::move(this->wrapAllocated(query_blob))
                : std::move(this->maybeCopyToAlignedMem(original_blob, input_blob_size, force_copy));
-}
-
-template <typename DataType, size_t n_preprocessors>
-void MultiPreprocessorsContainer<DataType, n_preprocessors>::preprocessQueryInPlace(
-    void *blob, size_t input_blob_size) const {
-
-    for (auto pp : preprocessors) {
-        if (!pp)
-            break;
-        // modifies the memory in place
-        pp->preprocessQueryInPlace(blob, input_blob_size, this->alignment);
-    }
 }
 
 template <typename DataType, size_t n_preprocessors>

--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -29,8 +29,6 @@ public:
                                       size_t &input_blob_size) const = 0;
     virtual void preprocessQuery(const void *original_blob, void *&query_blob,
                                  size_t &input_blob_size, unsigned char alignment) const = 0;
-    virtual void preprocessQueryInPlace(void *original_blob, size_t input_blob_size,
-                                        unsigned char alignment) const = 0;
     virtual void preprocessStorageInPlace(void *original_blob, size_t input_blob_size) const = 0;
 };
 
@@ -108,13 +106,6 @@ public:
         }
         normalize_func(blob, this->dim);
         input_blob_size = processed_bytes_count;
-    }
-
-    void preprocessQueryInPlace(void *blob, size_t input_blob_size,
-                                unsigned char alignment) const override {
-        assert(blob);
-        assert(input_blob_size == this->processed_bytes_count);
-        normalize_func(blob, this->dim);
     }
 
     void preprocessStorageInPlace(void *blob, size_t input_blob_size) const override {

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -160,13 +160,6 @@ public:
     MemoryUtils::unique_blob preprocessForStorage(const void *original_blob) const;
 
     /**
-     * @brief Preprocess a blob for query in place.
-     *
-     * @param blob will be directly modified, not copied.
-     */
-    void preprocessQueryInPlace(void *blob) const;
-
-    /**
      * @brief Preprocess a blob for storage in place.
      *
      * @param blob will be directly modified, not copied.
@@ -337,11 +330,6 @@ template <typename DataType, typename DistType>
 MemoryUtils::unique_blob
 VecSimIndexAbstract<DataType, DistType>::preprocessForStorage(const void *original_blob) const {
     return this->preprocessors->preprocessForStorage(original_blob, this->dataSize);
-}
-
-template <typename DataType, typename DistType>
-void VecSimIndexAbstract<DataType, DistType>::preprocessQueryInPlace(void *blob) const {
-    this->preprocessors->preprocessQueryInPlace(blob, this->dataSize);
 }
 
 template <typename DataType, typename DistType>

--- a/tests/unit/test_components.cpp
+++ b/tests/unit/test_components.cpp
@@ -81,8 +81,6 @@ public:
         }
         static_cast<DataType *>(blob)[0] += value_to_add_storage;
     }
-    void preprocessQueryInPlace(void *blob, size_t input_blob_size,
-                                unsigned char alignment) const override {}
 
     void preprocessStorageInPlace(void *blob, size_t input_blob_size) const override {
         assert(blob);
@@ -120,10 +118,7 @@ public:
                               size_t &input_blob_size) const override {
         /* do nothing*/
     }
-    void preprocessQueryInPlace(void *blob, size_t input_blob_size,
-                                unsigned char alignment) const override {
-        static_cast<DataType *>(blob)[0] += value_to_add_query;
-    }
+
     void preprocessStorageInPlace(void *blob, size_t input_blob_size) const override {}
     void preprocessQuery(const void *original_blob, void *&blob, size_t &input_blob_size,
                          unsigned char alignment) const override {
@@ -174,8 +169,6 @@ public:
         }
         static_cast<DataType *>(blob)[0] += value_to_add_storage;
     }
-    void preprocessQueryInPlace(void *blob, size_t input_blob_size,
-                                unsigned char alignment) const override {}
 
     void preprocessStorageInPlace(void *blob, size_t input_blob_size) const override {}
     void preprocessQuery(const void *original_blob, void *&blob, size_t &input_blob_size,
@@ -254,14 +247,6 @@ public:
                               size_t &input_blob_size) const override {
 
         this->preprocessGeneral(original_blob, blob, input_blob_size);
-    }
-    void preprocessQueryInPlace(void *blob, size_t input_blob_size,
-                                unsigned char alignment) const override {
-        // only supported if the blob in already large enough
-        assert(input_blob_size >= processed_bytes_count);
-        // set excess bytes to 0
-        memset((char *)blob + processed_bytes_count, excess_value,
-               input_blob_size - processed_bytes_count);
     }
 
     void preprocessStorageInPlace(void *blob, size_t input_blob_size) const override {

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -4232,12 +4232,6 @@ public:
             static_cast<DataType *>(blob)[i] *= 2;
         }
     }
-    void preprocessQueryInPlace(void *blob, size_t input_blob_size,
-                                unsigned char alignment) const override {
-        for (size_t i = 0; i < dim; i++) {
-            static_cast<DataType *>(blob)[i] *= 2;
-        }
-    }
 
     void preprocessStorageInPlace(void *blob, size_t input_blob_size) const override {
         for (size_t i = 0; i < dim; i++) {


### PR DESCRIPTION
## Core Changes
### SVS Index 
- Modified SVS index creation to use` indexCalculator = NULL` in `svs_factory.cpp`
- Replaced `preprocessQueryInPlace` with new `preprocessStorageInPlace` API in `preprocessForBatchStorage`

### API Cleanup
- Removed: `preprocessQueryInPlace` API (unused functionality)
- Added: New `CreatePreprocessorsContainer` overload to skip `CreatePreprocessorsContainerParams`
- Moved: `CreatePreprocessorsContainerParams` from components factory to `preprocessors_factory.h`