### PR TITLE
Generalize Micro-benchmarks  [MOD-10160] 

### DIFF
--- a/tests/benchmark/benchmarks.sh
+++ b/tests/benchmark/benchmarks.sh
@@ -83,7 +83,7 @@ elif [ "$BM_TYPE" = "bm-batch-iter-uint8-multi" ] ; then
 
 # Updated index benchmarks
 elif [ "$BM_TYPE" = "bm-updated-fp32-single" ] ; then
-    echo bm_updated_index_single_fp32
+    echo updated_index_single_fp32
 
 # Spaces benchmarks
 elif [ "$BM_TYPE" = "bm-spaces" ] ; then

--- a/tests/benchmark/benchmarks.sh
+++ b/tests/benchmark/benchmarks.sh
@@ -83,7 +83,7 @@ elif [ "$BM_TYPE" = "bm-batch-iter-uint8-multi" ] ; then
 
 # Updated index benchmarks
 elif [ "$BM_TYPE" = "bm-updated-fp32-single" ] ; then
-    echo updated_index_single_fp32
+    echo bm_updated_index_single_fp32
 
 # Spaces benchmarks
 elif [ "$BM_TYPE" = "bm-spaces" ] ; then

--- a/tests/benchmark/bm_batch_iterator.h
+++ b/tests/benchmark/bm_batch_iterator.h
@@ -44,8 +44,8 @@ void BM_BatchIterator<index_type_t>::RunBatchedSearch_HNSW(
     benchmark::State &st, std::atomic_int &correct, size_t iter, size_t num_batches,
     size_t batch_size, size_t &total_res_num, size_t batch_increase_factor, size_t index_memory,
     double &memory_delta) {
-    VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(
-        INDICES.at(VecSimAlgo_HNSWLIB), QUERIES[iter % N_QUERIES].data(), nullptr);
+    VecSimBatchIterator *batchIterator =
+        VecSimBatchIterator_New(INDICES.at(INDEX_HNSW), QUERIES[iter % N_QUERIES].data(), nullptr);
     VecSimQueryReply *accumulated_results[num_batches];
     size_t batch_num = 0;
     total_res_num = 0;
@@ -62,13 +62,13 @@ void BM_BatchIterator<index_type_t>::RunBatchedSearch_HNSW(
     }
     st.PauseTiming();
     // Update the memory delta as a result of using the batch iterator.
-    size_t curr_memory = VecSimIndex_StatsInfo(INDICES.at(VecSimAlgo_HNSWLIB)).memory;
+    size_t curr_memory = VecSimIndex_StatsInfo(INDICES.at(INDEX_HNSW)).memory;
     memory_delta += (double)(curr_memory - index_memory);
     VecSimBatchIterator_Free(batchIterator);
 
     // Measure recall - compare every result that was collected in some batch to the BF results.
-    auto bf_results = VecSimIndex_TopKQuery(
-        INDICES[VecSimAlgo_BF], QUERIES[iter % N_QUERIES].data(), total_res_num, nullptr, BY_SCORE);
+    auto bf_results = VecSimIndex_TopKQuery(INDICES.at(INDEX_BF), QUERIES[iter % N_QUERIES].data(),
+                                            total_res_num, nullptr, BY_SCORE);
     for (size_t i = 0; i < batch_num; i++) {
         auto hnsw_results = accumulated_results[i];
         BM_VecSimGeneral::MeasureRecall(hnsw_results, bf_results, correct);
@@ -83,12 +83,12 @@ void BM_BatchIterator<index_type_t>::BF_FixedBatchSize(benchmark::State &st) {
     size_t batch_size = st.range(0);
     size_t num_batches = st.range(1);
     size_t iter = 0;
-    size_t index_memory = VecSimIndex_StatsInfo(INDICES[VecSimAlgo_BF]).memory;
+    size_t index_memory = VecSimIndex_StatsInfo(INDICES.at(INDEX_BF)).memory;
     double memory_delta = 0.0;
 
     for (auto _ : st) {
         VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(
-            INDICES[VecSimAlgo_BF], QUERIES[iter % N_QUERIES].data(), nullptr);
+            INDICES.at(INDEX_BF), QUERIES[iter % N_QUERIES].data(), nullptr);
         size_t batches_counter = 0;
         while (VecSimBatchIterator_HasNext(batchIterator)) {
             VecSimQueryReply *res = VecSimBatchIterator_Next(batchIterator, batch_size, BY_ID);
@@ -98,7 +98,7 @@ void BM_BatchIterator<index_type_t>::BF_FixedBatchSize(benchmark::State &st) {
                 break;
             }
         }
-        size_t curr_memory = VecSimIndex_StatsInfo(INDICES[VecSimAlgo_BF]).memory;
+        size_t curr_memory = VecSimIndex_StatsInfo(INDICES.at(INDEX_BF)).memory;
         memory_delta += (double)(curr_memory - index_memory);
         VecSimBatchIterator_Free(batchIterator);
         iter++;
@@ -113,7 +113,7 @@ void BM_BatchIterator<index_type_t>::BF_VariableBatchSize(benchmark::State &st) 
     size_t iter = 0;
     for (auto _ : st) {
         VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(
-            INDICES[VecSimAlgo_BF], QUERIES[iter % N_QUERIES].data(), nullptr);
+            INDICES.at(INDEX_BF), QUERIES[iter % N_QUERIES].data(), nullptr);
         size_t batches_counter = 0;
         while (VecSimBatchIterator_HasNext(batchIterator)) {
             VecSimQueryReply *res = VecSimBatchIterator_Next(batchIterator, batch_size, BY_ID);
@@ -137,7 +137,7 @@ void BM_BatchIterator<index_type_t>::BF_BatchesToAdhocBF(benchmark::State &st) {
     size_t iter = 0;
     for (auto _ : st) {
         VecSimBatchIterator *batchIterator = VecSimBatchIterator_New(
-            INDICES[VecSimAlgo_BF], QUERIES[iter % N_QUERIES].data(), nullptr);
+            INDICES.at(INDEX_BF), QUERIES[iter % N_QUERIES].data(), nullptr);
         size_t batches_counter = 0;
         while (VecSimBatchIterator_HasNext(batchIterator)) {
             if (batches_counter == num_batches) {
@@ -151,7 +151,7 @@ void BM_BatchIterator<index_type_t>::BF_BatchesToAdhocBF(benchmark::State &st) {
         VecSimBatchIterator_Free(batchIterator);
         // Switch to ad-hoc BF
         for (size_t i = 0; i < N_VECTORS; i += step) {
-            VecSimIndex_GetDistanceFrom_Unsafe(INDICES[VecSimAlgo_BF], i,
+            VecSimIndex_GetDistanceFrom_Unsafe(INDICES.at(INDEX_BF), i,
                                                QUERIES[iter % N_QUERIES].data());
         }
         iter++;
@@ -166,7 +166,7 @@ void BM_BatchIterator<index_type_t>::HNSW_FixedBatchSize(benchmark::State &st) {
     size_t total_res_num = num_batches * batch_size;
     size_t iter = 0;
     std::atomic_int correct = 0;
-    size_t index_memory = VecSimIndex_StatsInfo(INDICES[VecSimAlgo_HNSWLIB]).memory;
+    size_t index_memory = VecSimIndex_StatsInfo(INDICES.at(INDEX_HNSW)).memory;
     double memory_delta = 0.0;
 
     for (auto _ : st) {
@@ -185,7 +185,7 @@ void BM_BatchIterator<index_type_t>::HNSW_VariableBatchSize(benchmark::State &st
     size_t total_res_num;
     size_t iter = 0;
     std::atomic_int correct = 0;
-    size_t index_memory = VecSimIndex_StatsInfo(INDICES[VecSimAlgo_HNSWLIB]).memory;
+    size_t index_memory = VecSimIndex_StatsInfo(INDICES.at(INDEX_HNSW)).memory;
     double memory_delta = 0.0;
 
     for (auto _ : st) {
@@ -204,7 +204,7 @@ void BM_BatchIterator<index_type_t>::HNSW_BatchesToAdhocBF(benchmark::State &st)
     size_t total_res_num;
     size_t iter = 0;
     std::atomic_int correct = 0;
-    size_t index_memory = VecSimIndex_StatsInfo(INDICES[VecSimAlgo_HNSWLIB]).memory;
+    size_t index_memory = VecSimIndex_StatsInfo(INDICES.at(INDEX_HNSW)).memory;
     double memory_delta = 0.0;
 
     for (auto _ : st) {
@@ -212,7 +212,7 @@ void BM_BatchIterator<index_type_t>::HNSW_BatchesToAdhocBF(benchmark::State &st)
                               memory_delta);
         // Switch to ad-hoc BF
         for (size_t i = 0; i < N_VECTORS; i += step) {
-            VecSimIndex_GetDistanceFrom_Unsafe(INDICES[VecSimAlgo_HNSWLIB], i,
+            VecSimIndex_GetDistanceFrom_Unsafe(INDICES.at(INDEX_HNSW), i,
                                                QUERIES[iter % N_QUERIES].data());
         }
         iter++;

--- a/tests/benchmark/bm_common.h
+++ b/tests/benchmark/bm_common.h
@@ -38,9 +38,7 @@ public:
     static void TopK_Tiered(benchmark::State &st, unsigned short index_offset = 0);
 
     // Does nothing but returning the index memory.
-    static void Memory_FLAT(benchmark::State &st, unsigned short index_offset = 0);
-    static void Memory_HNSW(benchmark::State &st, unsigned short index_offset = 0);
-    static void Memory_Tiered(benchmark::State &st, unsigned short index_offset = 0);
+    static void Memory(benchmark::State &st, IndexTypeIndex index_type);
 };
 
 template <typename index_type_t>
@@ -66,30 +64,10 @@ void BM_VecSimCommon<index_type_t>::RunTopK_HNSW(benchmark::State &st, size_t ef
 }
 
 template <typename index_type_t>
-void BM_VecSimCommon<index_type_t>::Memory_FLAT(benchmark::State &st, unsigned short index_offset) {
-    auto index = INDICES.at(INDEX_BF + index_offset);
+void BM_VecSimCommon<index_type_t>::Memory(benchmark::State &st, IndexTypeIndex index_type) {
+    auto index = INDICES.at(index_type);
     index->fitMemory();
 
-    for (auto _ : st) {
-        // Do nothing...
-    }
-    st.counters["memory"] = (double)VecSimIndex_StatsInfo(index).memory;
-}
-template <typename index_type_t>
-void BM_VecSimCommon<index_type_t>::Memory_HNSW(benchmark::State &st, unsigned short index_offset) {
-    auto index = INDICES.at(INDEX_HNSW + index_offset);
-    index->fitMemory();
-
-    for (auto _ : st) {
-        // Do nothing...
-    }
-    st.counters["memory"] = (double)VecSimIndex_StatsInfo(index).memory;
-}
-template <typename index_type_t>
-void BM_VecSimCommon<index_type_t>::Memory_Tiered(benchmark::State &st,
-                                                  unsigned short index_offset) {
-    auto index = INDICES.at(INDEX_TIERED_HNSW + index_offset);
-    index->fitMemory();
     for (auto _ : st) {
         // Do nothing...
     }

--- a/tests/benchmark/bm_common.h
+++ b/tests/benchmark/bm_common.h
@@ -48,12 +48,12 @@ void BM_VecSimCommon<index_type_t>::RunTopK_HNSW(benchmark::State &st, size_t ef
     HNSWRuntimeParams hnswRuntimeParams = {.efRuntime = ef};
     auto query_params = BM_VecSimGeneral::CreateQueryParams(hnswRuntimeParams);
     auto hnsw_results =
-        VecSimIndex_TopKQuery(INDICES.at(is_tiered ? INDEX_TIERED_HNSW : INDEX_HNSW + index_offset),
+        VecSimIndex_TopKQuery(GET_INDEX(is_tiered ? INDEX_TIERED_HNSW : INDEX_HNSW + index_offset),
                               QUERIES[iter % N_QUERIES].data(), k, &query_params, BY_SCORE);
     st.PauseTiming();
 
     // Measure recall:
-    auto bf_results = VecSimIndex_TopKQuery(INDICES.at(INDEX_BF + index_offset),
+    auto bf_results = VecSimIndex_TopKQuery(GET_INDEX(INDEX_BF + index_offset),
                                             QUERIES[iter % N_QUERIES].data(), k, nullptr, BY_SCORE);
 
     BM_VecSimGeneral::MeasureRecall(hnsw_results, bf_results, correct);
@@ -65,7 +65,7 @@ void BM_VecSimCommon<index_type_t>::RunTopK_HNSW(benchmark::State &st, size_t ef
 
 template <typename index_type_t>
 void BM_VecSimCommon<index_type_t>::Memory(benchmark::State &st, IndexTypeIndex index_type) {
-    auto index = INDICES.at(index_type);
+    auto index = GET_INDEX(index_type);
     index->fitMemory();
 
     for (auto _ : st) {
@@ -81,7 +81,7 @@ void BM_VecSimCommon<index_type_t>::TopK_BF(benchmark::State &st, unsigned short
     size_t k = st.range(0);
     size_t iter = 0;
     for (auto _ : st) {
-        VecSimIndex_TopKQuery(INDICES.at(INDEX_BF + index_offset), QUERIES[iter % N_QUERIES].data(),
+        VecSimIndex_TopKQuery(GET_INDEX(INDEX_BF + index_offset), QUERIES[iter % N_QUERIES].data(),
                               k, nullptr, BY_SCORE);
         iter++;
     }
@@ -106,8 +106,8 @@ void BM_VecSimCommon<index_type_t>::TopK_Tiered(benchmark::State &st, unsigned s
     size_t k = st.range(1);
     std::atomic_int correct = 0;
     std::atomic_int iter = 0;
-    auto *tiered_index =
-        dynamic_cast<TieredHNSWIndex<data_t, dist_t> *>(INDICES.at(INDEX_TIERED_HNSW));
+    auto tiered_index =
+        dynamic_cast<TieredHNSWIndex<data_t, dist_t> *>(GET_INDEX(INDEX_TIERED_HNSW));
     size_t total_iters = 50;
     VecSimQueryReply *all_results[total_iters];
 
@@ -116,7 +116,7 @@ void BM_VecSimCommon<index_type_t>::TopK_Tiered(benchmark::State &st, unsigned s
         HNSWRuntimeParams hnswRuntimeParams = {.efRuntime = search_job->ef};
         auto query_params = BM_VecSimGeneral::CreateQueryParams(hnswRuntimeParams);
         size_t cur_iter = search_job->iter;
-        auto hnsw_results = VecSimIndex_TopKQuery(INDICES.at(INDEX_TIERED_HNSW),
+        auto hnsw_results = VecSimIndex_TopKQuery(GET_INDEX(INDEX_TIERED_HNSW),
                                                   QUERIES[cur_iter % N_QUERIES].data(),
                                                   search_job->k, &query_params, BY_SCORE);
         search_job->all_results[cur_iter] = hnsw_results;
@@ -136,7 +136,7 @@ void BM_VecSimCommon<index_type_t>::TopK_Tiered(benchmark::State &st, unsigned s
     // Measure recall
     for (iter = 0; iter < total_iters; iter++) {
         auto bf_results =
-            VecSimIndex_TopKQuery(INDICES.at(INDEX_BF + index_offset),
+            VecSimIndex_TopKQuery(GET_INDEX(INDEX_BF + index_offset),
                                   QUERIES[iter % N_QUERIES].data(), k, nullptr, BY_SCORE);
         BM_VecSimGeneral::MeasureRecall(all_results[iter], bf_results, correct);
 

--- a/tests/benchmark/bm_common.h
+++ b/tests/benchmark/bm_common.h
@@ -23,6 +23,8 @@ public:
     BM_VecSimCommon() = default;
     ~BM_VecSimCommon() = default;
 
+    // index_offset: Offset added to base index types to access variants (0=original, 1=updated)
+
     static void RunTopK_HNSW(benchmark::State &st, size_t ef, size_t iter, size_t k,
                              std::atomic_int &correct, unsigned short index_offset = 0,
                              bool is_tiered = false);

--- a/tests/benchmark/bm_definitions.h
+++ b/tests/benchmark/bm_definitions.h
@@ -21,6 +21,29 @@ struct IndexType {
     typedef DistType dist_t;
 };
 
+enum IndexTypeIndex {
+    INDEX_BF = 0,
+    INDEX_BF_UPDATED,
+    INDEX_HNSW,
+    INDEX_HNSW_UPDATED,
+    INDEX_TIERED_HNSW,
+    INDEX_SVS,
+    INDEX_TIERED_SVS,
+    INDEX_SVS_QUANTIZED,
+    NUMBER_OF_INDEX_TYPES
+};
+
+enum IndexTypeFlags {
+    INDEX_TYPE_BF = 1 << 0,
+    INDEX_TYPE_BF_UPDATED = 1 << 1,
+    INDEX_TYPE_HNSW = 1 << 2,
+    INDEX_TYPE_HNSW_UPDATED = 1 << 3,
+    INDEX_TYPE_TIERED_HNSW = 1 << 4,
+    INDEX_TYPE_SVS = 1 << 5,
+    INDEX_TYPE_TIERED_SVS = 1 << 6,
+    INDEX_TYPE_SVS_QUANTIZED = 1 << 7
+};
+
 using fp32_index_t = IndexType<VecSimType_FLOAT32, float, float>;
 using fp64_index_t = IndexType<VecSimType_FLOAT64, double, double>;
 using bf16_index_t = IndexType<VecSimType_BFLOAT16, vecsim_types::bfloat16, float>;

--- a/tests/benchmark/bm_definitions.h
+++ b/tests/benchmark/bm_definitions.h
@@ -41,14 +41,14 @@ enum IndexTypeIndex {
 // stored in a 32-bit mask (uint32_t)
 // Note: Bit positions currently match IndexTypeIndex values but this is not required by the code
 enum IndexTypeFlags {
-    INDEX_TYPE_BF = 1 << 0,
-    INDEX_TYPE_BF_UPDATED = 1 << 1,
-    INDEX_TYPE_HNSW = 1 << 2,
-    INDEX_TYPE_HNSW_UPDATED = 1 << 3,
-    INDEX_TYPE_TIERED_HNSW = 1 << 4,
-    INDEX_TYPE_SVS = 1 << 5,
-    INDEX_TYPE_TIERED_SVS = 1 << 6,
-    INDEX_TYPE_SVS_COMPRESSED = 1 << 7
+    INDEX_MASK_BF = 1 << 0,
+    INDEX_MASK_BF_UPDATED = 1 << 1,
+    INDEX_MASK_HNSW = 1 << 2,
+    INDEX_MASK_HNSW_UPDATED = 1 << 3,
+    INDEX_MASK_TIERED_HNSW = 1 << 4,
+    INDEX_MASK_SVS = 1 << 5,
+    INDEX_MASK_TIERED_SVS = 1 << 6,
+    INDEX_MASK_SVS_COMPRESSED = 1 << 7
 };
 
 // Smart pointer wrapper for VecSimIndex with configurable ownership

--- a/tests/benchmark/bm_definitions.h
+++ b/tests/benchmark/bm_definitions.h
@@ -39,6 +39,7 @@ enum IndexTypeIndex {
 // Bit flags for selectively enabling index types in benchmarks via
 // BM_VecSimGeneral::enabled_index_types bitmask Limited to 32 index types because IndexTypeFlags is
 // stored in a 32-bit mask (uint32_t)
+// Note: Bit positions currently match IndexTypeIndex values but this is not required by the code
 enum IndexTypeFlags {
     INDEX_TYPE_BF = 1 << 0,
     INDEX_TYPE_BF_UPDATED = 1 << 1,
@@ -47,7 +48,7 @@ enum IndexTypeFlags {
     INDEX_TYPE_TIERED_HNSW = 1 << 4,
     INDEX_TYPE_SVS = 1 << 5,
     INDEX_TYPE_TIERED_SVS = 1 << 6,
-    INDEX_TYPE_SVS_QUANTIZED = 1 << 7
+    INDEX_TYPE_SVS_COMPRESSED = 1 << 7
 };
 
 using fp32_index_t = IndexType<VecSimType_FLOAT32, float, float>;

--- a/tests/benchmark/bm_definitions.h
+++ b/tests/benchmark/bm_definitions.h
@@ -21,6 +21,9 @@ struct IndexType {
     typedef DistType dist_t;
 };
 
+// Array indices for accessing different index types in the indices array
+// Note: Updated variants are offset by 1 from their base types (e.g., INDEX_BF_UPDATED = INDEX_BF +
+// 1)
 enum IndexTypeIndex {
     INDEX_BF = 0,
     INDEX_BF_UPDATED,
@@ -33,6 +36,9 @@ enum IndexTypeIndex {
     NUMBER_OF_INDEX_TYPES
 };
 
+// Bit flags for selectively enabling index types in benchmarks via
+// BM_VecSimGeneral::enabled_index_types bitmask Limited to 32 index types because IndexTypeFlags is
+// stored in a 32-bit mask (uint32_t)
 enum IndexTypeFlags {
     INDEX_TYPE_BF = 1 << 0,
     INDEX_TYPE_BF_UPDATED = 1 << 1,

--- a/tests/benchmark/bm_definitions.h
+++ b/tests/benchmark/bm_definitions.h
@@ -33,7 +33,7 @@ enum IndexTypeIndex {
     INDEX_SVS,
     INDEX_TIERED_SVS,
     INDEX_SVS_QUANTIZED,
-    NUMBER_OF_INDEX_TYPES
+    NUMBER_OF_INDEX_TYPES // Keep last
 };
 
 // Bit flags for selectively enabling index types in benchmarks via
@@ -109,3 +109,7 @@ using uint8_index_t = IndexType<VecSimType_UINT8, uint8_t, float>;
 #define N_VECTORS BM_VecSimGeneral::n_vectors
 #define DIM       BM_VecSimGeneral::dim
 #define IS_MULTI  BM_VecSimGeneral::is_multi
+
+constexpr uint32_t DEFAULT_BM_INDEXES_MASK = IndexTypeFlags::INDEX_MASK_BF |
+                                             IndexTypeFlags::INDEX_MASK_HNSW |
+                                             IndexTypeFlags::INDEX_MASK_TIERED_HNSW;

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
@@ -32,8 +32,8 @@ BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(
 // AddLabel
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL, bf16_index_t)
 (benchmark::State &st) { AddLabel(st); }
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_BF);
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_HNSWLIB);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_BF);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_HNSW);
 
 // DeleteLabel Registration. Definition is placed in the .cpp file.
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, BF));
@@ -65,14 +65,14 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), bf16_ind
 REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), bf16_index_t);
 
 // Tiered HNSW add/delete benchmarks
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_TIERED_HNSW);
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, Tiered));
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, bf16_index_t)
 (benchmark::State &st) { AddLabel_AsyncIngest(st); }
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
-    ->UNIT_AND_ITERATIONS->Arg(VecSimAlgo_TIERED)
-    ->ArgName("VecSimAlgo_TIERED");
+    ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
+    ->ArgName("INDEX_TIERED_HNSW");
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, bf16_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_bf16.h
@@ -16,17 +16,17 @@ the file.
 
 // Memory BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT), bf16_index_t)
-(benchmark::State &st) { Memory_FLAT(st); }
+(benchmark::State &st) { Memory(st, INDEX_BF); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT))->Iterations(1);
 
 // Memory HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW), bf16_index_t)
-(benchmark::State &st) { Memory_HNSW(st); }
+(benchmark::State &st) { Memory(st, INDEX_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW))->Iterations(1);
 
 // Memory Tiered
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered), bf16_index_t)
-(benchmark::State &st) { Memory_Tiered(st); }
+(benchmark::State &st) { Memory(st, INDEX_TIERED_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(1);
 
 // AddLabel

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
@@ -32,8 +32,8 @@ BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(
 // AddLabel
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL, fp16_index_t)
 (benchmark::State &st) { AddLabel(st); }
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_BF);
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_HNSWLIB);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_BF);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_HNSW);
 
 // DeleteLabel Registration. Definition is placed in the .cpp file.
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, BF));
@@ -65,14 +65,14 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp16_ind
 REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), fp16_index_t);
 
 // Tiered HNSW add/delete benchmarks
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_TIERED_HNSW);
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, Tiered));
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, fp16_index_t)
 (benchmark::State &st) { AddLabel_AsyncIngest(st); }
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
-    ->UNIT_AND_ITERATIONS->Arg(VecSimAlgo_TIERED)
-    ->ArgName("VecSimAlgo_TIERED");
+    ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
+    ->ArgName("INDEX_TIERED_HNSW");
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, fp16_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp16.h
@@ -16,17 +16,17 @@ the file.
 
 // Memory BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT), fp16_index_t)
-(benchmark::State &st) { Memory_FLAT(st); }
+(benchmark::State &st) { Memory(st, INDEX_BF); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT))->Iterations(1);
 
 // Memory HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW), fp16_index_t)
-(benchmark::State &st) { Memory_HNSW(st); }
+(benchmark::State &st) { Memory(st, INDEX_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW))->Iterations(1);
 
 // Memory Tiered
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered), fp16_index_t)
-(benchmark::State &st) { Memory_Tiered(st); }
+(benchmark::State &st) { Memory(st, INDEX_TIERED_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(1);
 
 // AddLabel

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
@@ -73,7 +73,6 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, fp32_index_t)
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
     ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
     ->ArgName("INDEX_TIERED_HNSW");
-;
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, fp32_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
@@ -32,8 +32,8 @@ BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(
 // AddLabel
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL, fp32_index_t)
 (benchmark::State &st) { AddLabel(st); }
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_BF);
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_HNSWLIB);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_BF);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_HNSW);
 
 // DeleteLabel Registration. Definition is placed in the .cpp file.
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, BF));
@@ -65,14 +65,15 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp32_ind
 REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), fp32_index_t);
 
 // Tiered HNSW add/delete benchmarks
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_TIERED_HNSW);
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, Tiered));
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, fp32_index_t)
 (benchmark::State &st) { AddLabel_AsyncIngest(st); }
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
-    ->UNIT_AND_ITERATIONS->Arg(VecSimAlgo_TIERED)
-    ->ArgName("VecSimAlgo_TIERED");
+    ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
+    ->ArgName("INDEX_TIERED_HNSW");
+;
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, fp32_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp32.h
@@ -16,17 +16,17 @@ the file.
 
 // Memory BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT), fp32_index_t)
-(benchmark::State &st) { Memory_FLAT(st); }
+(benchmark::State &st) { Memory(st, INDEX_BF); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT))->Iterations(1);
 
 // Memory HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW), fp32_index_t)
-(benchmark::State &st) { Memory_HNSW(st); }
+(benchmark::State &st) { Memory(st, INDEX_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW))->Iterations(1);
 
 // Memory Tiered
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered), fp32_index_t)
-(benchmark::State &st) { Memory_Tiered(st); }
+(benchmark::State &st) { Memory(st, INDEX_TIERED_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(1);
 
 // AddLabel

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
@@ -32,8 +32,8 @@ BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(
 // AddLabel
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL, fp64_index_t)
 (benchmark::State &st) { AddLabel(st); }
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_BF);
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_HNSWLIB);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_BF);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_HNSW);
 
 // DeleteLabel Registration. Definition is placed in the .cpp file.
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, BF));
@@ -65,14 +65,15 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), fp64_ind
 REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), fp64_index_t);
 
 // Tiered HNSW add/delete benchmarks
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_TIERED_HNSW);
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, Tiered));
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, fp64_index_t)
 (benchmark::State &st) { AddLabel_AsyncIngest(st); }
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
-    ->UNIT_AND_ITERATIONS->Arg(VecSimAlgo_TIERED)
-    ->ArgName("VecSimAlgo_TIERED");
+    ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
+    ->ArgName("INDEX_TIERED_HNSW");
+;
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, fp64_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
@@ -16,17 +16,17 @@ the file.
 
 // Memory BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT), fp64_index_t)
-(benchmark::State &st) { Memory_FLAT(st); }
+(benchmark::State &st) { Memory(st, INDEX_BF); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT))->Iterations(1);
 
 // Memory HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW), fp64_index_t)
-(benchmark::State &st) { Memory_HNSW(st); }
+(benchmark::State &st) { Memory(st, INDEX_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW))->Iterations(1);
 
 // Memory Tiered
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered), fp64_index_t)
-(benchmark::State &st) { Memory_Tiered(st); }
+(benchmark::State &st) { Memory(st, INDEX_TIERED_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(1);
 
 // AddLabel

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_fp64.h
@@ -73,7 +73,6 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, fp64_index_t)
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
     ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
     ->ArgName("INDEX_TIERED_HNSW");
-;
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, fp64_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
@@ -73,7 +73,6 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, int8_index_t)
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
     ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
     ->ArgName("INDEX_TIERED_HNSW");
-;
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, int8_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
@@ -16,17 +16,17 @@ the file.
 
 // Memory BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT), int8_index_t)
-(benchmark::State &st) { Memory_FLAT(st); }
+(benchmark::State &st) { Memory(st, INDEX_BF); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT))->Iterations(1);
 
 // Memory HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW), int8_index_t)
-(benchmark::State &st) { Memory_HNSW(st); }
+(benchmark::State &st) { Memory(st, INDEX_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW))->Iterations(1);
 
 // Memory Tiered
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered), int8_index_t)
-(benchmark::State &st) { Memory_Tiered(st); }
+(benchmark::State &st) { Memory(st, INDEX_TIERED_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(1);
 
 // AddLabel

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_int8.h
@@ -32,8 +32,8 @@ BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(
 // AddLabel
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL, int8_index_t)
 (benchmark::State &st) { AddLabel(st); }
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_BF);
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_HNSWLIB);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_BF);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_HNSW);
 
 // DeleteLabel Registration. Definition is placed in the .cpp file.
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, BF));
@@ -65,14 +65,15 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), int8_ind
 REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), int8_index_t);
 
 // Tiered HNSW add/delete benchmarks
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_TIERED_HNSW);
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, Tiered));
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, int8_index_t)
 (benchmark::State &st) { AddLabel_AsyncIngest(st); }
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
-    ->UNIT_AND_ITERATIONS->Arg(VecSimAlgo_TIERED)
-    ->ArgName("VecSimAlgo_TIERED");
+    ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
+    ->ArgName("INDEX_TIERED_HNSW");
+;
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, int8_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_uint8.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_uint8.h
@@ -32,8 +32,8 @@ BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(
 // AddLabel
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL, uint8_index_t)
 (benchmark::State &st) { AddLabel(st); }
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_BF);
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_HNSWLIB);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_BF);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_HNSW);
 
 // DeleteLabel Registration. Definition is placed in the .cpp file.
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, BF));
@@ -65,14 +65,15 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC_NAME(Range, HNSW), uint8_in
 REGISTER_Range_HNSW(BM_FUNC_NAME(Range, HNSW), uint8_index_t);
 
 // Tiered HNSW add/delete benchmarks
-REGISTER_AddLabel(BM_ADD_LABEL, VecSimAlgo_TIERED);
+REGISTER_AddLabel(BM_ADD_LABEL, INDEX_TIERED_HNSW);
 REGISTER_DeleteLabel(BM_FUNC_NAME(DeleteLabel, Tiered));
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, uint8_index_t)
 (benchmark::State &st) { AddLabel_AsyncIngest(st); }
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
-    ->UNIT_AND_ITERATIONS->Arg(VecSimAlgo_TIERED)
-    ->ArgName("VecSimAlgo_TIERED");
+    ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
+    ->ArgName("INDEX_TIERED_HNSW");
+;
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, uint8_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_uint8.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_uint8.h
@@ -16,17 +16,17 @@ the file.
 
 // Memory BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT), uint8_index_t)
-(benchmark::State &st) { Memory_FLAT(st); }
+(benchmark::State &st) { Memory(st, INDEX_BF); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, FLAT))->Iterations(1);
 
 // Memory HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW), uint8_index_t)
-(benchmark::State &st) { Memory_HNSW(st); }
+(benchmark::State &st) { Memory(st, INDEX_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, HNSW))->Iterations(1);
 
 // Memory Tiered
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered), uint8_index_t)
-(benchmark::State &st) { Memory_Tiered(st); }
+(benchmark::State &st) { Memory(st, INDEX_TIERED_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_FUNC_NAME(Memory, Tiered))->Iterations(1);
 
 // AddLabel

--- a/tests/benchmark/bm_initialization/bm_basics_initialize_uint8.h
+++ b/tests/benchmark/bm_initialization/bm_basics_initialize_uint8.h
@@ -73,7 +73,6 @@ BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC, uint8_index_t)
 BENCHMARK_REGISTER_F(BM_VecSimBasics, BM_ADD_LABEL_ASYNC)
     ->UNIT_AND_ITERATIONS->Arg(INDEX_TIERED_HNSW)
     ->ArgName("INDEX_TIERED_HNSW");
-;
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_DELETE_LABEL_ASYNC, uint8_index_t)
 (benchmark::State &st) { DeleteLabel_AsyncRepair(st); }

--- a/tests/benchmark/bm_initialization/bm_updated_initialize_fp32.h
+++ b/tests/benchmark/bm_initialization/bm_updated_initialize_fp32.h
@@ -16,22 +16,22 @@ the file.
 ***************************************/
 // Memory BF before
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_BEFORE_FUNC_NAME(Memory, FLAT), fp32_index_t)
-(benchmark::State &st) { Memory_FLAT(st); }
+(benchmark::State &st) { Memory(st, INDEX_BF); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_BEFORE_FUNC_NAME(Memory, FLAT))->Iterations(1);
 
 // Updated memory BF
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimUpdatedIndex, BM_UPDATED_FUNC_NAME(Memory, FLAT), fp32_index_t)
-(benchmark::State &st) { Memory_FLAT(st, updated_index_offset); }
+(benchmark::State &st) { Memory(st, INDEX_BF_UPDATED); }
 BENCHMARK_REGISTER_F(BM_VecSimUpdatedIndex, BM_UPDATED_FUNC_NAME(Memory, FLAT))->Iterations(1);
 
 // Memory HNSW before
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimCommon, BM_BEFORE_FUNC_NAME(Memory, HNSW), fp32_index_t)
-(benchmark::State &st) { Memory_HNSW(st); }
+(benchmark::State &st) { Memory(st, INDEX_HNSW); }
 BENCHMARK_REGISTER_F(BM_VecSimCommon, BM_BEFORE_FUNC_NAME(Memory, HNSW))->Iterations(1);
 
 // Updated memory HNSW
 BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimUpdatedIndex, BM_UPDATED_FUNC_NAME(Memory, HNSW), fp32_index_t)
-(benchmark::State &st) { Memory_HNSW(st, updated_index_offset); }
+(benchmark::State &st) { Memory(st, INDEX_HNSW_UPDATED); }
 BENCHMARK_REGISTER_F(BM_VecSimUpdatedIndex, BM_UPDATED_FUNC_NAME(Memory, HNSW))->Iterations(1);
 
 // TopK BF

--- a/tests/benchmark/bm_updated_index.h
+++ b/tests/benchmark/bm_updated_index.h
@@ -28,31 +28,21 @@ public:
     // Offset to access updated index variants in indices array (e.g., INDEX_BF + 1 =
     // INDEX_BF_UPDATED)
     const static unsigned short updated_index_offset = 1;
-    // The constructor is called after we have already registered the tests residing in
-    // BM_VecSimCommon, (and not in this class) so `ref_count` is not zero at the first time
-    // BM_VecSimUpdatedIndex Ctor is called, and we can't rely on it to decide whether we should
-    // initialize the indices or not. This is why we use the `is_initialized` flag. Also, we keep
-    // the value of ref_count at the moment of initialization in first_updatedBM_ref_count to free
-    // the indices when ref_count is decreased to this value. Reminder: ref_count is updated in
-    // BM_VecSimIndex ctor (and dtor).
+
+    // Tracks initialization state for updated indices to ensure one-time initialization
+    // Independent from BM_VecSimGeneral base class initialization since updated indices have
+    // different setup
     static bool is_initialized;
 
-    static size_t first_updatedBM_ref_count;
     BM_VecSimUpdatedIndex() {
         if (!is_initialized) {
             // Initialize the updated indexes as well, if this is the first instance.
             Initialize();
             is_initialized = true;
-            first_updatedBM_ref_count = REF_COUNT;
         }
     }
 
-    ~BM_VecSimUpdatedIndex() {
-        if (REF_COUNT == first_updatedBM_ref_count) {
-            VecSimIndex_Free(INDICES[INDEX_BF + updated_index_offset]);
-            VecSimIndex_Free(INDICES[INDEX_HNSW + updated_index_offset]);
-        }
-    }
+    ~BM_VecSimUpdatedIndex() = default;
 
 private:
     static const char *updated_hnsw_index_file;
@@ -63,50 +53,46 @@ template <typename index_type_t>
 bool BM_VecSimUpdatedIndex<index_type_t>::is_initialized = false;
 
 template <typename index_type_t>
-size_t BM_VecSimUpdatedIndex<index_type_t>::first_updatedBM_ref_count = 0;
-
-template <typename index_type_t>
 void BM_VecSimUpdatedIndex<index_type_t>::Initialize() {
-
     VecSimType type = index_type_t::get_index_type();
 
     if (BM_VecSimGeneral::enabled_index_types & IndexTypeFlags::INDEX_TYPE_BF) {
         BFParams bf_params = {
             .type = type, .dim = DIM, .metric = VecSimMetric_Cosine, .multi = IS_MULTI};
-        // This index will be inserted after the basic indices at indices[VecSimAlfo_BF +
-        // update_offset]
-        INDICES.at(INDEX_BF + updated_index_offset) =
-            BM_VecSimIndex<index_type_t>::CreateNewIndex(bf_params);
+
+        INDICES[INDEX_BF + updated_index_offset] =
+            IndexPtr(BM_VecSimIndex<index_type_t>::CreateNewIndex(bf_params));
 
         // Initially, load all the vectors to the updated bf index (before we override it).
         for (size_t i = 0; i < N_VECTORS; ++i) {
             const char *blob = BM_VecSimIndex<index_type_t>::GetHNSWDataByInternalId(i);
-            size_t label = BM_VecSimIndex<index_type_t>::CastToHNSW(INDICES.at(INDEX_HNSW))
+            size_t label = BM_VecSimIndex<index_type_t>::CastToHNSW(GET_INDEX(INDEX_HNSW))
                                ->getExternalLabel(i);
-            VecSimIndex_AddVector(INDICES.at(INDEX_BF + updated_index_offset), blob, label);
+            VecSimIndex_AddVector(GET_INDEX(INDEX_BF + updated_index_offset), blob, label);
         }
     }
 
     if (BM_VecSimGeneral::enabled_index_types & IndexTypeFlags::INDEX_TYPE_HNSW) {
         // Generate index from file.
-        // This index will be inserted after the basic indices at indices[VecSimAlgo_HNSWLIB +
-        // update_offset]
-        INDICES.at(INDEX_HNSW + updated_index_offset) = (HNSWFactory::NewIndex(
+        // This index will be inserted after the basic indices at INDICES[INDEX_HNSW +
+        // updated_index_offset]
+        INDICES[INDEX_HNSW + updated_index_offset] = IndexPtr(HNSWFactory::NewIndex(
             BM_VecSimIndex<index_type_t>::AttachRootPath(updated_hnsw_index_file)));
 
-        if (!BM_VecSimIndex<index_type_t>::CastToHNSW(INDICES.at(INDEX_HNSW + updated_index_offset))
+        if (!BM_VecSimIndex<index_type_t>::CastToHNSW(GET_INDEX(INDEX_HNSW + updated_index_offset))
                  ->checkIntegrity()
                  .valid_state) {
             throw std::runtime_error("The loaded HNSW index is corrupted. Exiting...");
         }
+
         // Add the same vectors to the *updated* FLAT index (override the previous vectors).
         for (size_t i = 0; i < N_VECTORS; ++i) {
             const char *blob =
                 BM_VecSimIndex<index_type_t>::GetHNSWDataByInternalId(i, updated_index_offset);
             size_t label = BM_VecSimIndex<index_type_t>::CastToHNSW(
-                               INDICES.at(INDEX_HNSW + updated_index_offset))
+                               GET_INDEX(INDEX_HNSW + updated_index_offset))
                                ->getExternalLabel(i);
-            VecSimIndex_AddVector(INDICES.at(INDEX_BF + updated_index_offset), blob, label);
+            VecSimIndex_AddVector(GET_INDEX(INDEX_BF + updated_index_offset), blob, label);
         }
     }
 }

--- a/tests/benchmark/bm_updated_index.h
+++ b/tests/benchmark/bm_updated_index.h
@@ -25,7 +25,7 @@
 template <typename index_type_t>
 class BM_VecSimUpdatedIndex : public BM_VecSimCommon<index_type_t> {
 public:
-    const static unsigned short updated_index_offset = 3;
+    const static unsigned short updated_index_offset = 1;
     // The constructor is called after we have already registered the tests residing in
     // BM_VecSimCommon, (and not in this class) so `ref_count` is not zero at the first time
     // BM_VecSimUpdatedIndex Ctor is called, and we can't rely on it to decide whether we should
@@ -47,8 +47,8 @@ public:
 
     ~BM_VecSimUpdatedIndex() {
         if (REF_COUNT == first_updatedBM_ref_count) {
-            VecSimIndex_Free(INDICES[VecSimAlgo_BF + updated_index_offset]);
-            VecSimIndex_Free(INDICES[VecSimAlgo_HNSWLIB + updated_index_offset]);
+            VecSimIndex_Free(INDICES[INDEX_BF + updated_index_offset]);
+            VecSimIndex_Free(INDICES[INDEX_HNSW + updated_index_offset]);
         }
     }
 
@@ -68,38 +68,43 @@ void BM_VecSimUpdatedIndex<index_type_t>::Initialize() {
 
     VecSimType type = index_type_t::get_index_type();
 
-    BFParams bf_params = {
-        .type = type, .dim = DIM, .metric = VecSimMetric_Cosine, .multi = IS_MULTI};
-    // This index will be inserted after the basic indices at indices[VecSimAlfo_BF + update_offset]
-    INDICES.push_back(BM_VecSimIndex<index_type_t>::CreateNewIndex(bf_params));
+    if (BM_VecSimGeneral::enabled_index_types & IndexTypeFlags::INDEX_TYPE_BF) {
+        BFParams bf_params = {
+            .type = type, .dim = DIM, .metric = VecSimMetric_Cosine, .multi = IS_MULTI};
+        // This index will be inserted after the basic indices at indices[VecSimAlfo_BF +
+        // update_offset]
+        INDICES.at(INDEX_BF + updated_index_offset) =
+            BM_VecSimIndex<index_type_t>::CreateNewIndex(bf_params);
 
-    // Initially, load all the vectors to the updated bf index (before we override it).
-    for (size_t i = 0; i < N_VECTORS; ++i) {
-        const char *blob = BM_VecSimIndex<index_type_t>::GetHNSWDataByInternalId(i);
-        size_t label = BM_VecSimIndex<index_type_t>::CastToHNSW(INDICES[VecSimAlgo_HNSWLIB])
-                           ->getExternalLabel(i);
-        VecSimIndex_AddVector(INDICES[VecSimAlgo_BF + updated_index_offset], blob, label);
+        // Initially, load all the vectors to the updated bf index (before we override it).
+        for (size_t i = 0; i < N_VECTORS; ++i) {
+            const char *blob = BM_VecSimIndex<index_type_t>::GetHNSWDataByInternalId(i);
+            size_t label = BM_VecSimIndex<index_type_t>::CastToHNSW(INDICES.at(INDEX_HNSW))
+                               ->getExternalLabel(i);
+            VecSimIndex_AddVector(INDICES.at(INDEX_BF + updated_index_offset), blob, label);
+        }
     }
 
-    // Generate index from file.
-    // This index will be inserted after the basic indices at indices[VecSimAlgo_HNSWLIB +
-    // update_offset]
-    INDICES.push_back(HNSWFactory::NewIndex(
-        BM_VecSimIndex<index_type_t>::AttachRootPath(updated_hnsw_index_file)));
+    if (BM_VecSimGeneral::enabled_index_types & IndexTypeFlags::INDEX_TYPE_HNSW) {
+        // Generate index from file.
+        // This index will be inserted after the basic indices at indices[VecSimAlgo_HNSWLIB +
+        // update_offset]
+        INDICES.at(INDEX_HNSW + updated_index_offset) = (HNSWFactory::NewIndex(
+            BM_VecSimIndex<index_type_t>::AttachRootPath(updated_hnsw_index_file)));
 
-    if (!BM_VecSimIndex<index_type_t>::CastToHNSW(
-             INDICES[VecSimAlgo_HNSWLIB + updated_index_offset])
-             ->checkIntegrity()
-             .valid_state) {
-        throw std::runtime_error("The loaded HNSW index is corrupted. Exiting...");
-    }
-    // Add the same vectors to the *updated* FLAT index (override the previous vectors).
-    for (size_t i = 0; i < N_VECTORS; ++i) {
-        const char *blob =
-            BM_VecSimIndex<index_type_t>::GetHNSWDataByInternalId(i, updated_index_offset);
-        size_t label = BM_VecSimIndex<index_type_t>::CastToHNSW(
-                           INDICES[VecSimAlgo_HNSWLIB + updated_index_offset])
-                           ->getExternalLabel(i);
-        VecSimIndex_AddVector(INDICES[VecSimAlgo_BF + updated_index_offset], blob, label);
+        if (!BM_VecSimIndex<index_type_t>::CastToHNSW(INDICES.at(INDEX_HNSW + updated_index_offset))
+                 ->checkIntegrity()
+                 .valid_state) {
+            throw std::runtime_error("The loaded HNSW index is corrupted. Exiting...");
+        }
+        // Add the same vectors to the *updated* FLAT index (override the previous vectors).
+        for (size_t i = 0; i < N_VECTORS; ++i) {
+            const char *blob =
+                BM_VecSimIndex<index_type_t>::GetHNSWDataByInternalId(i, updated_index_offset);
+            size_t label = BM_VecSimIndex<index_type_t>::CastToHNSW(
+                               INDICES.at(INDEX_HNSW + updated_index_offset))
+                               ->getExternalLabel(i);
+            VecSimIndex_AddVector(INDICES.at(INDEX_BF + updated_index_offset), blob, label);
+        }
     }
 }

--- a/tests/benchmark/bm_updated_index.h
+++ b/tests/benchmark/bm_updated_index.h
@@ -25,6 +25,8 @@
 template <typename index_type_t>
 class BM_VecSimUpdatedIndex : public BM_VecSimCommon<index_type_t> {
 public:
+    // Offset to access updated index variants in indices array (e.g., INDEX_BF + 1 =
+    // INDEX_BF_UPDATED)
     const static unsigned short updated_index_offset = 1;
     // The constructor is called after we have already registered the tests residing in
     // BM_VecSimCommon, (and not in this class) so `ref_count` is not zero at the first time

--- a/tests/benchmark/bm_vecsim_basics.h
+++ b/tests/benchmark/bm_vecsim_basics.h
@@ -50,7 +50,7 @@ private:
 template <typename index_type_t>
 void BM_VecSimBasics<index_type_t>::AddLabel(benchmark::State &st) {
 
-    auto index = INDICES.at(st.range(0));
+    auto index = GET_INDEX(st.range(0));
     size_t index_size = N_VECTORS;
     size_t initial_label_count = index->indexLabelCount();
 
@@ -88,15 +88,14 @@ void BM_VecSimBasics<index_type_t>::AddLabel(benchmark::State &st) {
     for (size_t label = initial_label_count; label < new_label_count; label++) {
         // If index is tiered HNSW, remove directly from the underline HNSW.
         VecSimIndex_DeleteVector(
-            INDICES.at(st.range(0) == INDEX_TIERED_HNSW ? INDEX_HNSW : st.range(0)), label);
+            GET_INDEX(st.range(0) == INDEX_TIERED_HNSW ? INDEX_HNSW : st.range(0)), label);
     }
     assert(VecSimIndex_IndexSize(index) == N_VECTORS);
 }
 
 template <typename index_type_t>
 void BM_VecSimBasics<index_type_t>::AddLabel_AsyncIngest(benchmark::State &st) {
-
-    auto index = INDICES.at(st.range(0));
+    auto index = GET_INDEX(st.range(0));
     size_t index_size = N_VECTORS;
     size_t initial_label_count = index->indexLabelCount();
 
@@ -137,7 +136,7 @@ void BM_VecSimBasics<index_type_t>::AddLabel_AsyncIngest(benchmark::State &st) {
     size_t new_label_count = index->indexLabelCount();
     // Remove directly inplace from the underline HNSW index.
     for (size_t label_ = initial_label_count; label_ < new_label_count; label_++) {
-        VecSimIndex_DeleteVector(INDICES.at(INDEX_HNSW), label_);
+        VecSimIndex_DeleteVector(GET_INDEX(INDEX_HNSW), label_);
     }
 
     assert(VecSimIndex_IndexSize(index) == N_VECTORS);
@@ -195,7 +194,7 @@ void BM_VecSimBasics<index_type_t>::DeleteLabel_AsyncRepair(benchmark::State &st
     // Remove a different vector in every execution.
     size_t label_to_remove = 0;
     auto *tiered_index =
-        dynamic_cast<TieredHNSWIndex<data_t, dist_t> *>(INDICES.at(INDEX_TIERED_HNSW));
+        dynamic_cast<TieredHNSWIndex<data_t, dist_t> *>(GET_INDEX(INDEX_TIERED_HNSW));
 
     tiered_index->fitMemory();
     double memory_before = tiered_index->getAllocationSize();
@@ -257,7 +256,7 @@ void BM_VecSimBasics<index_type_t>::Range_BF(benchmark::State &st) {
     size_t total_res = 0;
 
     for (auto _ : st) {
-        auto res = VecSimIndex_RangeQuery(INDICES.at(INDEX_BF), QUERIES[iter % N_QUERIES].data(),
+        auto res = VecSimIndex_RangeQuery(GET_INDEX(INDEX_BF), QUERIES[iter % N_QUERIES].data(),
                                           radius, nullptr, BY_ID);
         total_res += VecSimQueryReply_Len(res);
         iter++;
@@ -277,13 +276,13 @@ void BM_VecSimBasics<index_type_t>::Range_HNSW(benchmark::State &st) {
 
     for (auto _ : st) {
         auto hnsw_results = VecSimIndex_RangeQuery(
-            INDICES.at(INDEX_HNSW), QUERIES[iter % N_QUERIES].data(), radius, &query_params, BY_ID);
+            GET_INDEX(INDEX_HNSW), QUERIES[iter % N_QUERIES].data(), radius, &query_params, BY_ID);
         st.PauseTiming();
         total_res += VecSimQueryReply_Len(hnsw_results);
 
         // Measure recall:
         auto bf_results = VecSimIndex_RangeQuery(
-            INDICES.at(INDEX_BF), QUERIES[iter % N_QUERIES].data(), radius, nullptr, BY_ID);
+            GET_INDEX(INDEX_BF), QUERIES[iter % N_QUERIES].data(), radius, nullptr, BY_ID);
         total_res_bf += VecSimQueryReply_Len(bf_results);
 
         VecSimQueryReply_Free(bf_results);
@@ -340,8 +339,8 @@ void BM_VecSimBasics<index_type_t>::Range_HNSW(benchmark::State &st) {
 #define DEFINE_DELETE_LABEL(BM_FUNC, INDEX_TYPE, INDEX_NAME, DATA_TYPE, DIST_TYPE, VecSimAlgo)     \
     BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimBasics, BM_FUNC, INDEX_TYPE)(benchmark::State & st) {     \
         DeleteLabel<INDEX_NAME<DATA_TYPE, DIST_TYPE>>(                                             \
-            dynamic_cast<INDEX_NAME<DATA_TYPE, DIST_TYPE> *>(                                      \
-                BM_VecSimIndex<INDEX_TYPE>::indices[VecSimAlgo]),                                  \
+            BM_VecSimIndex<INDEX_TYPE>::get_typed_index<INDEX_NAME<DATA_TYPE, DIST_TYPE>>(         \
+                VecSimAlgo),                                                                       \
             st);                                                                                   \
     }
 #define REGISTER_DeleteLabel(BM_FUNC)                                                              \

--- a/tests/benchmark/bm_vecsim_basics.h
+++ b/tests/benchmark/bm_vecsim_basics.h
@@ -50,7 +50,7 @@ private:
 template <typename index_type_t>
 void BM_VecSimBasics<index_type_t>::AddLabel(benchmark::State &st) {
 
-    auto index = INDICES[st.range(0)];
+    auto index = INDICES.at(st.range(0));
     size_t index_size = N_VECTORS;
     size_t initial_label_count = index->indexLabelCount();
 
@@ -88,7 +88,7 @@ void BM_VecSimBasics<index_type_t>::AddLabel(benchmark::State &st) {
     for (size_t label = initial_label_count; label < new_label_count; label++) {
         // If index is tiered HNSW, remove directly from the underline HNSW.
         VecSimIndex_DeleteVector(
-            INDICES[st.range(0) == VecSimAlgo_TIERED ? VecSimAlgo_HNSWLIB : st.range(0)], label);
+            INDICES.at(st.range(0) == INDEX_TIERED_HNSW ? INDEX_HNSW : st.range(0)), label);
     }
     assert(VecSimIndex_IndexSize(index) == N_VECTORS);
 }
@@ -96,7 +96,7 @@ void BM_VecSimBasics<index_type_t>::AddLabel(benchmark::State &st) {
 template <typename index_type_t>
 void BM_VecSimBasics<index_type_t>::AddLabel_AsyncIngest(benchmark::State &st) {
 
-    auto index = INDICES[st.range(0)];
+    auto index = INDICES.at(st.range(0));
     size_t index_size = N_VECTORS;
     size_t initial_label_count = index->indexLabelCount();
 
@@ -137,7 +137,7 @@ void BM_VecSimBasics<index_type_t>::AddLabel_AsyncIngest(benchmark::State &st) {
     size_t new_label_count = index->indexLabelCount();
     // Remove directly inplace from the underline HNSW index.
     for (size_t label_ = initial_label_count; label_ < new_label_count; label_++) {
-        VecSimIndex_DeleteVector(INDICES[VecSimAlgo_HNSWLIB], label_);
+        VecSimIndex_DeleteVector(INDICES.at(INDEX_HNSW), label_);
     }
 
     assert(VecSimIndex_IndexSize(index) == N_VECTORS);
@@ -195,7 +195,7 @@ void BM_VecSimBasics<index_type_t>::DeleteLabel_AsyncRepair(benchmark::State &st
     // Remove a different vector in every execution.
     size_t label_to_remove = 0;
     auto *tiered_index =
-        dynamic_cast<TieredHNSWIndex<data_t, dist_t> *>(INDICES[VecSimAlgo_TIERED]);
+        dynamic_cast<TieredHNSWIndex<data_t, dist_t> *>(INDICES.at(INDEX_TIERED_HNSW));
 
     tiered_index->fitMemory();
     double memory_before = tiered_index->getAllocationSize();
@@ -257,7 +257,7 @@ void BM_VecSimBasics<index_type_t>::Range_BF(benchmark::State &st) {
     size_t total_res = 0;
 
     for (auto _ : st) {
-        auto res = VecSimIndex_RangeQuery(INDICES[VecSimAlgo_BF], QUERIES[iter % N_QUERIES].data(),
+        auto res = VecSimIndex_RangeQuery(INDICES.at(INDEX_BF), QUERIES[iter % N_QUERIES].data(),
                                           radius, nullptr, BY_ID);
         total_res += VecSimQueryReply_Len(res);
         iter++;
@@ -276,15 +276,14 @@ void BM_VecSimBasics<index_type_t>::Range_HNSW(benchmark::State &st) {
     auto query_params = BM_VecSimGeneral::CreateQueryParams(hnswRuntimeParams);
 
     for (auto _ : st) {
-        auto hnsw_results =
-            VecSimIndex_RangeQuery(INDICES[VecSimAlgo_HNSWLIB], QUERIES[iter % N_QUERIES].data(),
-                                   radius, &query_params, BY_ID);
+        auto hnsw_results = VecSimIndex_RangeQuery(
+            INDICES.at(INDEX_HNSW), QUERIES[iter % N_QUERIES].data(), radius, &query_params, BY_ID);
         st.PauseTiming();
         total_res += VecSimQueryReply_Len(hnsw_results);
 
         // Measure recall:
         auto bf_results = VecSimIndex_RangeQuery(
-            INDICES[VecSimAlgo_BF], QUERIES[iter % N_QUERIES].data(), radius, nullptr, BY_ID);
+            INDICES.at(INDEX_BF), QUERIES[iter % N_QUERIES].data(), radius, nullptr, BY_ID);
         total_res_bf += VecSimQueryReply_Len(bf_results);
 
         VecSimQueryReply_Free(bf_results);

--- a/tests/benchmark/bm_vecsim_general.cpp
+++ b/tests/benchmark/bm_vecsim_general.cpp
@@ -27,3 +27,5 @@ void BM_VecSimGeneral::MeasureRecall(VecSimQueryReply *hnsw_results, VecSimQuery
     }
     VecSimQueryReply_IteratorFree(hnsw_it);
 }
+
+tieredIndexMock *BM_VecSimGeneral::mock_thread_pool = nullptr;

--- a/tests/benchmark/bm_vecsim_general.h
+++ b/tests/benchmark/bm_vecsim_general.h
@@ -45,14 +45,17 @@ protected:
     static bool is_multi;
     // Bitmask controlling which index types to include in benchmarks (uses IndexTypeFlags)
     static uint32_t enabled_index_types;
-    static tieredIndexMock mock_thread_pool;
+    static tieredIndexMock *mock_thread_pool;
 
     static size_t n_queries;
     static const char *hnsw_index_file;
     static const char *test_queries_file;
 
     BM_VecSimGeneral() = default;
-    virtual ~BM_VecSimGeneral() = default;
+    virtual ~BM_VecSimGeneral() {
+        if (mock_thread_pool)
+            delete mock_thread_pool;
+    };
 
     // Updates @correct according to the number of search results in @hnsw_results
     // that appear also in the flat algorithm results list.

--- a/tests/benchmark/bm_vecsim_general.h
+++ b/tests/benchmark/bm_vecsim_general.h
@@ -43,6 +43,7 @@ protected:
     static size_t n_vectors;
 
     static bool is_multi;
+    // Bitmask controlling which index types to include in benchmarks (uses IndexTypeFlags)
     static uint32_t enabled_index_types;
     static tieredIndexMock mock_thread_pool;
 

--- a/tests/benchmark/bm_vecsim_general.h
+++ b/tests/benchmark/bm_vecsim_general.h
@@ -53,8 +53,10 @@ protected:
 
     BM_VecSimGeneral() = default;
     virtual ~BM_VecSimGeneral() {
-        if (mock_thread_pool)
+        if (mock_thread_pool) {
             delete mock_thread_pool;
+            mock_thread_pool = nullptr;
+        }
     };
 
     // Updates @correct according to the number of search results in @hnsw_results

--- a/tests/benchmark/bm_vecsim_general.h
+++ b/tests/benchmark/bm_vecsim_general.h
@@ -43,6 +43,7 @@ protected:
     static size_t n_vectors;
 
     static bool is_multi;
+    static uint32_t enabled_index_types;
     static tieredIndexMock mock_thread_pool;
 
     static size_t n_queries;

--- a/tests/benchmark/bm_vecsim_index.h
+++ b/tests/benchmark/bm_vecsim_index.h
@@ -24,7 +24,7 @@ public:
 
     static std::vector<std::vector<data_t>> queries;
 
-    static std::vector<VecSimIndex *> indices;
+    static std::array<VecSimIndex *, NUMBER_OF_INDEX_TYPES> indices;
 
     BM_VecSimIndex();
 
@@ -35,7 +35,7 @@ protected:
         return dynamic_cast<HNSWIndex<data_t, dist_t> *>(index);
     }
     static inline const char *GetHNSWDataByInternalId(size_t id, unsigned short index_offset = 0) {
-        return CastToHNSW(indices[VecSimAlgo_HNSWLIB + index_offset])->getDataByInternalId(id);
+        return CastToHNSW(indices[INDEX_HNSW + index_offset])->getDataByInternalId(id);
     }
 
 private:
@@ -67,28 +67,28 @@ template <>
 std::vector<std::vector<uint8_t>> BM_VecSimIndex<uint8_index_t>::queries{};
 
 template <>
-std::vector<VecSimIndex *> BM_VecSimIndex<fp32_index_t>::indices{};
+std::array<VecSimIndex *, NUMBER_OF_INDEX_TYPES> BM_VecSimIndex<fp32_index_t>::indices{nullptr};
 
 template <>
-std::vector<VecSimIndex *> BM_VecSimIndex<fp64_index_t>::indices{};
+std::array<VecSimIndex *, NUMBER_OF_INDEX_TYPES> BM_VecSimIndex<fp64_index_t>::indices{nullptr};
 
 template <>
-std::vector<VecSimIndex *> BM_VecSimIndex<bf16_index_t>::indices{};
+std::array<VecSimIndex *, NUMBER_OF_INDEX_TYPES> BM_VecSimIndex<bf16_index_t>::indices{nullptr};
 
 template <>
-std::vector<VecSimIndex *> BM_VecSimIndex<fp16_index_t>::indices{};
+std::array<VecSimIndex *, NUMBER_OF_INDEX_TYPES> BM_VecSimIndex<fp16_index_t>::indices{nullptr};
 
 template <>
-std::vector<VecSimIndex *> BM_VecSimIndex<int8_index_t>::indices{};
+std::array<VecSimIndex *, NUMBER_OF_INDEX_TYPES> BM_VecSimIndex<int8_index_t>::indices{nullptr};
 
 template <>
-std::vector<VecSimIndex *> BM_VecSimIndex<uint8_index_t>::indices{};
+std::array<VecSimIndex *, NUMBER_OF_INDEX_TYPES> BM_VecSimIndex<uint8_index_t>::indices{nullptr};
 
 template <typename index_type_t>
 BM_VecSimIndex<index_type_t>::~BM_VecSimIndex() {
     ref_count--;
     if (ref_count == 0) {
-        VecSimIndex_Free(indices[VecSimAlgo_BF]);
+        VecSimIndex_Free(indices[INDEX_BF]);
         /* Note that VecSimAlgo_HNSW will be destroyed as part of the tiered index release, and
          * the VecSimAlgo_Tiered index ptr will be deleted when the mock thread pool ctx object is
          * destroyed.
@@ -107,55 +107,59 @@ BM_VecSimIndex<index_type_t>::BM_VecSimIndex() {
 
 template <typename index_type_t>
 void BM_VecSimIndex<index_type_t>::Initialize() {
-
     VecSimType type = index_type_t::get_index_type();
     // dim, block_size, M, EF_C, n_vectors, is_multi, n_queries, hnsw_index_file and
     // test_queries_file are BM_VecSimGeneral static data members that are defined for a specific
     // index type benchmarks.
-    BFParams bf_params = {.type = type,
-                          .dim = dim,
-                          .metric = VecSimMetric_Cosine,
-                          .multi = is_multi,
-                          .blockSize = block_size};
+    if (enabled_index_types & IndexTypeFlags::INDEX_TYPE_BF) {
+        BFParams bf_params = {.type = type,
+                              .dim = dim,
+                              .metric = VecSimMetric_Cosine,
+                              .multi = is_multi,
+                              .blockSize = block_size};
+        indices[INDEX_BF] = CreateNewIndex(bf_params);
+    }
+    if (enabled_index_types & IndexTypeFlags::INDEX_TYPE_HNSW) {
+        // Initialize and load HNSW index for DBPedia data set.
+        indices[INDEX_HNSW] = HNSWFactory::NewIndex(AttachRootPath(hnsw_index_file));
 
-    indices.push_back(CreateNewIndex(bf_params));
+        auto *hnsw_index = CastToHNSW(indices[INDEX_HNSW]);
+        size_t ef_r = 10;
+        hnsw_index->setEf(ef_r);
+        // Create tiered index from the loaded HNSW index.
+        if (enabled_index_types & IndexTypeFlags::INDEX_TYPE_TIERED_HNSW) {
+            auto &mock_thread_pool = BM_VecSimGeneral::mock_thread_pool;
+            TieredIndexParams tiered_params = {
+                .jobQueue = &BM_VecSimGeneral::mock_thread_pool.jobQ,
+                .jobQueueCtx = mock_thread_pool.ctx,
+                .submitCb = tieredIndexMock::submit_callback,
+                .flatBufferLimit = block_size,
+                .primaryIndexParams = nullptr,
+                .specificParams = {TieredHNSWParams{.swapJobThreshold = 0}}};
 
-    // Initialize and load HNSW index for DBPedia data set.
-    indices.push_back(HNSWFactory::NewIndex(AttachRootPath(hnsw_index_file)));
+            auto *tiered_index = TieredFactory::TieredHNSWFactory::NewIndex<data_t, dist_t>(
+                &tiered_params, hnsw_index);
+            mock_thread_pool.ctx->index_strong_ref.reset(tiered_index);
 
-    auto *hnsw_index = CastToHNSW(indices[VecSimAlgo_HNSWLIB]);
-    size_t ef_r = 10;
-    hnsw_index->setEf(ef_r);
+            indices[INDEX_TIERED_HNSW] = tiered_index;
 
-    // Create tiered index from the loaded HNSW index.
-    auto &mock_thread_pool = BM_VecSimGeneral::mock_thread_pool;
-    TieredIndexParams tiered_params = {.jobQueue = &BM_VecSimGeneral::mock_thread_pool.jobQ,
-                                       .jobQueueCtx = mock_thread_pool.ctx,
-                                       .submitCb = tieredIndexMock::submit_callback,
-                                       .flatBufferLimit = block_size,
-                                       .primaryIndexParams = nullptr,
-                                       .specificParams = {TieredHNSWParams{.swapJobThreshold = 0}}};
+            // Launch the BG threads loop that takes jobs from the queue and executes them.
+            mock_thread_pool.init_threads();
+        }
+    }
 
-    auto *tiered_index =
-        TieredFactory::TieredHNSWFactory::NewIndex<data_t, dist_t>(&tiered_params, hnsw_index);
-    mock_thread_pool.ctx->index_strong_ref.reset(tiered_index);
-
-    indices.push_back(tiered_index);
-
-    // Launch the BG threads loop that takes jobs from the queue and executes them.
-    mock_thread_pool.init_threads();
-
-    // Add the same vectors to Flat index.
-    for (size_t i = 0; i < n_vectors; ++i) {
-        const char *blob = GetHNSWDataByInternalId(i);
-        // Fot multi value indices, the internal id is not necessarily equal the label.
-        size_t label = CastToHNSW(indices[VecSimAlgo_HNSWLIB])->getExternalLabel(i);
-        VecSimIndex_AddVector(indices[VecSimAlgo_BF], blob, label);
+    if (indices[INDEX_HNSW] && indices[INDEX_BF]) {
+        // Add the same vectors to Flat index.
+        for (size_t i = 0; i < n_vectors; ++i) {
+            const char *blob = GetHNSWDataByInternalId(i);
+            // Fot multi value indices, the internal id is not necessarily equal the label.
+            size_t label = CastToHNSW(indices[INDEX_HNSW])->getExternalLabel(i);
+            VecSimIndex_AddVector(indices[INDEX_BF], blob, label);
+        }
     }
 
     // Load the test query vectors form file. Index file path is relative to repository root dir.
     loadTestVectors(AttachRootPath(test_queries_file), type);
-
     VecSim_SetLogCallbackFunction(nullptr);
 }
 

--- a/tests/benchmark/bm_vecsim_index.h
+++ b/tests/benchmark/bm_vecsim_index.h
@@ -24,6 +24,9 @@ public:
 
     static std::vector<std::vector<data_t>> queries;
 
+    // Static array holding all index instances, indexed by IndexTypeIndex values
+    // Elements are initialized to nullptr and populated in Initialize() method
+    // Only indices corresponding to BM_VecSimGeneral::enabled_index_types bitmask will be non-null
     static std::array<VecSimIndex *, NUMBER_OF_INDEX_TYPES> indices;
 
     BM_VecSimIndex();

--- a/tests/benchmark/run_files/bm_basics_multi_bf16.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_bf16.cpp
@@ -8,16 +8,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1111025;
 size_t BM_VecSimGeneral::dim = 512;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/fashion_images_multi_value-cosine-dim512-M64-efc512-bf16.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_multi_bf16.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_bf16.cpp
@@ -8,6 +8,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1111025;
@@ -27,11 +30,11 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       CONCAT_WITH_UNDERSCORE_ARCH(DeleteLabel_Async, Multi)
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), bf16_index_t, BruteForceIndex_Multi,
-                    vecsim_types::bfloat16, float, VecSimAlgo_BF)
+                    vecsim_types::bfloat16, float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), bf16_index_t, HNSWIndex_Multi,
-                    vecsim_types::bfloat16, float, VecSimAlgo_HNSWLIB)
+                    vecsim_types::bfloat16, float, INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), bf16_index_t, TieredHNSWIndex,
-                    vecsim_types::bfloat16, float, VecSimAlgo_TIERED)
+                    vecsim_types::bfloat16, float, INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_bf16.h"
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_multi_fp16.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_fp16.cpp
@@ -8,6 +8,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1111025;
@@ -27,11 +30,11 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       CONCAT_WITH_UNDERSCORE_ARCH(DeleteLabel_Async, Multi)
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), fp16_index_t, BruteForceIndex_Multi,
-                    vecsim_types::float16, float, VecSimAlgo_BF)
+                    vecsim_types::float16, float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), fp16_index_t, HNSWIndex_Multi,
-                    vecsim_types::float16, float, VecSimAlgo_HNSWLIB)
+                    vecsim_types::float16, float, INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), fp16_index_t, TieredHNSWIndex,
-                    vecsim_types::float16, float, VecSimAlgo_TIERED)
+                    vecsim_types::float16, float, INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_fp16.h"
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_multi_fp16.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_fp16.cpp
@@ -8,16 +8,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1111025;
 size_t BM_VecSimGeneral::dim = 512;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/fashion_images_multi_value-cosine-dim512-M64-efc512-fp16.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_multi_fp32.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_fp32.cpp
@@ -7,16 +7,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1111025;
 size_t BM_VecSimGeneral::dim = 512;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/fashion_images_multi_value-cosine-dim512-M64-efc512.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_multi_fp32.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_fp32.cpp
@@ -7,6 +7,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1111025;
@@ -26,11 +29,11 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       CONCAT_WITH_UNDERSCORE_ARCH(DeleteLabel_Async, Multi)
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), fp32_index_t, BruteForceIndex_Multi, float,
-                    float, VecSimAlgo_BF)
+                    float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), fp32_index_t, HNSWIndex_Multi, float, float,
-                    VecSimAlgo_HNSWLIB)
+                    INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), fp32_index_t, TieredHNSWIndex, float, float,
-                    VecSimAlgo_TIERED)
+                    INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_fp32.h"
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_multi_fp64.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_fp64.cpp
@@ -7,16 +7,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1111025;
 size_t BM_VecSimGeneral::dim = 512;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/fashion_images_multi_value-cosine-dim512-M64-efc512-fp64.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_multi_fp64.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_fp64.cpp
@@ -7,6 +7,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1111025;
@@ -26,11 +29,11 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       CONCAT_WITH_UNDERSCORE_ARCH(DeleteLabel_Async, Multi)
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), fp64_index_t, BruteForceIndex_Multi, double,
-                    double, VecSimAlgo_BF)
+                    double, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), fp64_index_t, HNSWIndex_Multi, double, double,
-                    VecSimAlgo_HNSWLIB)
+                    INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), fp64_index_t, TieredHNSWIndex, double,
-                    double, VecSimAlgo_TIERED)
+                    double, INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_fp64.h"
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_multi_int8.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_int8.cpp
@@ -7,16 +7,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
 size_t BM_VecSimGeneral::dim = 1024;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/wipedia_multi-cosine-dim1024-M64-efc512-int8.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_multi_int8.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_int8.cpp
@@ -7,6 +7,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -26,11 +29,11 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       DeleteLabel_Async_Multi
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), int8_index_t, BruteForceIndex_Multi, int8_t,
-                    float, VecSimAlgo_BF)
+                    float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), int8_index_t, HNSWIndex_Multi, int8_t, float,
-                    VecSimAlgo_HNSWLIB)
+                    INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), int8_index_t, TieredHNSWIndex, int8_t, float,
-                    VecSimAlgo_TIERED)
+                    INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_int8.h"
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_multi_uint8.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_uint8.cpp
@@ -7,6 +7,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -26,11 +29,11 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       DeleteLabel_Async_Multi
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), uint8_index_t, BruteForceIndex_Multi, uint8_t,
-                    float, VecSimAlgo_BF)
+                    float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), uint8_index_t, HNSWIndex_Multi, uint8_t, float,
-                    VecSimAlgo_HNSWLIB)
+                    INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), uint8_index_t, TieredHNSWIndex, uint8_t,
-                    float, VecSimAlgo_TIERED)
+                    float, INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_uint8.h"
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_multi_uint8.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_uint8.cpp
@@ -7,16 +7,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
 size_t BM_VecSimGeneral::dim = 1024;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/wipedia_multi_uint8-cosine-dim1024-M64-efc512-uint8.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_multi_uint8.cpp
+++ b/tests/benchmark/run_files/bm_basics_multi_uint8.cpp
@@ -7,9 +7,7 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
-                                                 IndexTypeFlags::INDEX_MASK_HNSW |
-                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = DEFAULT_BM_INDEXES_MASK;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_basics_single_bf16.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_bf16.cpp
@@ -8,9 +8,7 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
-                                                 IndexTypeFlags::INDEX_MASK_HNSW |
-                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = DEFAULT_BM_INDEXES_MASK;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_basics_single_bf16.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_bf16.cpp
@@ -8,16 +8,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
 size_t BM_VecSimGeneral::dim = 768;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/dbpedia-cosine-dim768-M64-efc512-bf16.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_single_bf16.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_bf16.cpp
@@ -8,6 +8,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -27,10 +30,10 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       CONCAT_WITH_UNDERSCORE_ARCH(DeleteLabel, Async, Single)
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), bf16_index_t, BruteForceIndex_Single,
-                    vecsim_types::bfloat16, float, VecSimAlgo_BF)
+                    vecsim_types::bfloat16, float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), bf16_index_t, HNSWIndex_Single,
-                    vecsim_types::bfloat16, float, VecSimAlgo_HNSWLIB)
+                    vecsim_types::bfloat16, float, INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), bf16_index_t, TieredHNSWIndex,
-                    vecsim_types::bfloat16, float, VecSimAlgo_TIERED)
+                    vecsim_types::bfloat16, float, INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_bf16.h"
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_single_fp16.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_fp16.cpp
@@ -8,9 +8,7 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
-                                                 IndexTypeFlags::INDEX_MASK_HNSW |
-                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = DEFAULT_BM_INDEXES_MASK;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_basics_single_fp16.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_fp16.cpp
@@ -8,6 +8,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -27,10 +30,10 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       CONCAT_WITH_UNDERSCORE_ARCH(DeleteLabel, Async, Single)
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), fp16_index_t, BruteForceIndex_Single,
-                    vecsim_types::float16, float, VecSimAlgo_BF)
+                    vecsim_types::float16, float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), fp16_index_t, HNSWIndex_Single,
-                    vecsim_types::float16, float, VecSimAlgo_HNSWLIB)
+                    vecsim_types::float16, float, INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), fp16_index_t, TieredHNSWIndex,
-                    vecsim_types::float16, float, VecSimAlgo_TIERED)
+                    vecsim_types::float16, float, INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_fp16.h"
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_single_fp16.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_fp16.cpp
@@ -8,16 +8,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
 size_t BM_VecSimGeneral::dim = 768;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/dbpedia-cosine-dim768-M64-efc512-fp16.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_single_fp32.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_fp32.cpp
@@ -7,9 +7,7 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
-                                                 IndexTypeFlags::INDEX_MASK_HNSW |
-                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = DEFAULT_BM_INDEXES_MASK;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_basics_single_fp32.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_fp32.cpp
@@ -7,6 +7,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -26,10 +29,10 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       CONCAT_WITH_UNDERSCORE_ARCH(DeleteLabel_Async, Single)
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), fp32_index_t, BruteForceIndex_Single, float,
-                    float, VecSimAlgo_BF)
+                    float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), fp32_index_t, HNSWIndex_Single, float, float,
-                    VecSimAlgo_HNSWLIB)
+                    INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), fp32_index_t, TieredHNSWIndex, float, float,
-                    VecSimAlgo_TIERED)
+                    INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_fp32.h"
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_single_fp32.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_fp32.cpp
@@ -7,16 +7,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
 size_t BM_VecSimGeneral::dim = 768;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/dbpedia-cosine-dim768-M64-efc512.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_single_fp64.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_fp64.cpp
@@ -7,16 +7,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
 size_t BM_VecSimGeneral::dim = 768;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/dbpedia-cosine-dim768-M64-efc512-fp64.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_single_fp64.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_fp64.cpp
@@ -7,9 +7,7 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
-                                                 IndexTypeFlags::INDEX_MASK_HNSW |
-                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = DEFAULT_BM_INDEXES_MASK;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_basics_single_fp64.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_fp64.cpp
@@ -7,6 +7,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -26,10 +29,10 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       CONCAT_WITH_UNDERSCORE_ARCH(DeleteLabel, Async, Single)
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), fp64_index_t, BruteForceIndex_Single, double,
-                    double, VecSimAlgo_BF)
+                    double, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), fp64_index_t, HNSWIndex_Single, double, double,
-                    VecSimAlgo_HNSWLIB)
+                    INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), fp64_index_t, TieredHNSWIndex, double,
-                    double, VecSimAlgo_TIERED)
+                    double, INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_fp64.h"
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_single_int8.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_int8.cpp
@@ -7,6 +7,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -26,11 +29,11 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       CONCAT_WITH_UNDERSCORE_ARCH(DeleteLabel, Async, Single)
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), int8_index_t, BruteForceIndex_Single, int8_t,
-                    float, VecSimAlgo_BF)
+                    float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), int8_index_t, HNSWIndex_Single, int8_t, float,
-                    VecSimAlgo_HNSWLIB)
+                    INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), int8_index_t, TieredHNSWIndex, int8_t, float,
-                    VecSimAlgo_TIERED)
+                    INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_int8.h"
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_basics_single_int8.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_int8.cpp
@@ -7,16 +7,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
 size_t BM_VecSimGeneral::dim = 1024;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/wipedia_single-cosine-dim1024-M64-efc512-int8.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_single_uint8.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_uint8.cpp
@@ -7,16 +7,15 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
 size_t BM_VecSimGeneral::dim = 1024;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/wipedia_single_uint8-cosine-dim1024-M64-efc512-uint8.hnsw_v3";

--- a/tests/benchmark/run_files/bm_basics_single_uint8.cpp
+++ b/tests/benchmark/run_files/bm_basics_single_uint8.cpp
@@ -7,6 +7,9 @@
 ***************************************/
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -26,11 +29,11 @@ const char *BM_VecSimGeneral::test_queries_file =
 #define BM_DELETE_LABEL_ASYNC       DeleteLabel_Async_Single
 
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, BF), uint8_index_t, BruteForceIndex_Single, uint8_t,
-                    float, VecSimAlgo_BF)
+                    float, INDEX_BF)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, HNSW), uint8_index_t, HNSWIndex_Single, uint8_t,
-                    float, VecSimAlgo_HNSWLIB)
+                    float, INDEX_HNSW)
 DEFINE_DELETE_LABEL(BM_FUNC_NAME(DeleteLabel, Tiered), uint8_index_t, TieredHNSWIndex, uint8_t,
-                    float, VecSimAlgo_TIERED)
+                    float, INDEX_TIERED_HNSW)
 #include "benchmark/bm_initialization/bm_basics_initialize_uint8.h"
 
 BENCHMARK_MAIN();

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_bf16.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_bf16.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1111025;
@@ -12,7 +12,6 @@ size_t BM_VecSimGeneral::dim = 512;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/fashion_images_multi_value-cosine-dim512-M64-efc512-bf16.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_bf16.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_bf16.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1111025;

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_fp16.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_fp16.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1111025;
@@ -12,7 +12,6 @@ size_t BM_VecSimGeneral::dim = 512;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/fashion_images_multi_value-cosine-dim512-M64-efc512-fp16.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_fp16.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_fp16.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1111025;

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_fp32.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_fp32.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1111025;
@@ -12,7 +12,6 @@ size_t BM_VecSimGeneral::dim = 512;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/fashion_images_multi_value-cosine-dim512-M64-efc512.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_fp32.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_fp32.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1111025;

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_fp64.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_fp64.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1111025;
@@ -12,7 +12,6 @@ size_t BM_VecSimGeneral::dim = 512;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/fashion_images_multi_value-cosine-dim512-M64-efc512-fp64.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_fp64.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_fp64.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1111025;

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_int8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_int8.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -11,7 +11,6 @@ size_t BM_VecSimGeneral::dim = 1024;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/wipedia_multi-cosine-dim1024-M64-efc512-int8.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_int8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_int8.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_uint8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_uint8.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -11,7 +11,6 @@ size_t BM_VecSimGeneral::dim = 1024;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/wipedia_multi_uint8-cosine-dim1024-M64-efc512-uint8.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_uint8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_uint8.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_multi_uint8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_multi_uint8.cpp
@@ -1,9 +1,7 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = true;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
-                                                 IndexTypeFlags::INDEX_MASK_HNSW |
-                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = DEFAULT_BM_INDEXES_MASK;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_single_bf16.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_bf16.cpp
@@ -1,9 +1,7 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
-                                                 IndexTypeFlags::INDEX_MASK_HNSW |
-                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = DEFAULT_BM_INDEXES_MASK;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_single_bf16.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_bf16.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_single_bf16.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_bf16.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -12,7 +12,6 @@ size_t BM_VecSimGeneral::dim = 768;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/dbpedia-cosine-dim768-M64-efc512-bf16.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_single_fp16.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_fp16.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_single_fp16.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_fp16.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -12,7 +12,6 @@ size_t BM_VecSimGeneral::dim = 768;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/dbpedia-cosine-dim768-M64-efc512-fp16.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_single_fp32.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_fp32.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -12,7 +12,6 @@ size_t BM_VecSimGeneral::dim = 768;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/dbpedia-cosine-dim768-M64-efc512.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_single_fp32.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_fp32.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_single_fp64.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_fp64.cpp
@@ -1,9 +1,7 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
-                                                 IndexTypeFlags::INDEX_MASK_HNSW |
-                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = DEFAULT_BM_INDEXES_MASK;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_single_fp64.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_fp64.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_single_fp64.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_fp64.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 // Global benchmark data
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -12,7 +12,6 @@ size_t BM_VecSimGeneral::dim = 768;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/dbpedia-cosine-dim768-M64-efc512-fp64.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_single_int8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_int8.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_single_int8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_int8.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -11,7 +11,6 @@ size_t BM_VecSimGeneral::dim = 1024;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/wipedia_single-cosine-dim1024-M64-efc512-int8.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_single_uint8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_uint8.cpp
@@ -1,9 +1,7 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
-                                                 IndexTypeFlags::INDEX_MASK_HNSW |
-                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = DEFAULT_BM_INDEXES_MASK;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_batch_iterator_single_uint8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_uint8.cpp
@@ -1,9 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
-uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
-                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
-                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_MASK_BF |
+                                                 IndexTypeFlags::INDEX_MASK_HNSW |
+                                                 IndexTypeFlags::INDEX_MASK_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;
@@ -11,7 +11,6 @@ size_t BM_VecSimGeneral::dim = 1024;
 size_t BM_VecSimGeneral::M = 64;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::block_size = 1024;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/wipedia_single_uint8-cosine-dim1024-M64-efc512-uint8.hnsw_v3";

--- a/tests/benchmark/run_files/bm_batch_iterator_single_uint8.cpp
+++ b/tests/benchmark/run_files/bm_batch_iterator_single_uint8.cpp
@@ -1,6 +1,9 @@
 #include "benchmark/bm_batch_iterator.h"
 
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types = IndexTypeFlags::INDEX_TYPE_BF |
+                                                 IndexTypeFlags::INDEX_TYPE_HNSW |
+                                                 IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::n_vectors = 1000000;

--- a/tests/benchmark/run_files/bm_updated_index_single_fp32.cpp
+++ b/tests/benchmark/run_files/bm_updated_index_single_fp32.cpp
@@ -5,15 +5,14 @@
 ***************************************/
 bool BM_VecSimGeneral::is_multi = false;
 uint32_t BM_VecSimGeneral::enabled_index_types =
-    IndexTypeFlags::INDEX_TYPE_BF | IndexTypeFlags::INDEX_TYPE_HNSW |
-    IndexTypeFlags::INDEX_TYPE_HNSW_UPDATED | IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
+    IndexTypeFlags::INDEX_MASK_BF | IndexTypeFlags::INDEX_MASK_HNSW |
+    IndexTypeFlags::INDEX_MASK_HNSW_UPDATED | IndexTypeFlags::INDEX_MASK_BF_UPDATED;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::dim = 768;
 size_t BM_VecSimGeneral::M = 65;
 size_t BM_VecSimGeneral::EF_C = 512;
 size_t BM_VecSimGeneral::n_vectors = 500000;
-tieredIndexMock BM_VecSimGeneral::mock_thread_pool{};
 
 const char *BM_VecSimGeneral::hnsw_index_file =
     "tests/benchmark/data/dbpedia-cosine-dim768-M65-efc512-n500k.hnsw_v3";

--- a/tests/benchmark/run_files/bm_updated_index_single_fp32.cpp
+++ b/tests/benchmark/run_files/bm_updated_index_single_fp32.cpp
@@ -4,6 +4,9 @@
   Basic tests for updated single value index.
 ***************************************/
 bool BM_VecSimGeneral::is_multi = false;
+uint32_t BM_VecSimGeneral::enabled_index_types =
+    IndexTypeFlags::INDEX_TYPE_BF | IndexTypeFlags::INDEX_TYPE_HNSW |
+    IndexTypeFlags::INDEX_TYPE_HNSW_UPDATED | IndexTypeFlags::INDEX_TYPE_TIERED_HNSW;
 
 size_t BM_VecSimGeneral::n_queries = 10000;
 size_t BM_VecSimGeneral::dim = 768;


### PR DESCRIPTION
This PR introduces a significant refactor to the benchmarking framework.
The primary goal of this refactor is to lay the groundwork for expanding the benchmarks to support additional index types. 
To achieve this, the benchmark classes have been generalized to ensure that only the required indices are initialized, as defined by their corresponding `.cpp` files in the `run_files` folder.

## Key Changes
### Generalization of Benchmark Classes:
- Introduced `IndexTypeIndex` enums and `IndexTypeFlags` bitmask to dynamically control which indices are initialized. This ensures that only the indices required by a specific benchmark are loaded, reducing unnecessary resource allocation.
- **Benchmarks now dynamically initialize only the indices defined** in their corresponding `.cpp` files in the `run_files` folder.
- `BM_VecSimGeneral` now **holds a pointer** to `tieredIndexMock` instead of an instance. Previously, the default constructor of `tieredIndexMock` always initialized it and its context, even when not required for all benchmark cases. By using a pointer, it is now initialized to nullptr by default and created only when a tiered index is required.

### Index Memory Management

- The `ref_count` mechanism has been removed from `bm_vecsim_index.h` and `first_updatedBM_ref_count` from `bm_updated_index.h.`
  - Their purposes were:
    - Ensuring **one-time initialization** of indices.
    - **Tracking references to release** indices.
  - They were replaced by:
    - An `is_initialized` flag to ensure one-time initialization.
    - The `IndexPtr` class for safe ownership and automatic cleanup of indices.


### Code cleanups
- Consolidated memory-related benchmark functions into a single Memory function, replacing redundant functions like `Memory_FLAT`, `Memory_HNSW,` and `Memory_Tiered.`

### Dynamic Index Access:
- Replaced hardcoded references like `INDICES[VecSimAlgo_BF]` with the `GET_INDEX` method for flexible and dynamic index retrieval. 




