### PR TITLE
SVS with ISA dispatcher, Logging, and Static lib update

### DIFF
--- a/cmake/svs.cmake
+++ b/cmake/svs.cmake
@@ -50,9 +50,9 @@ if(USE_SVS)
 
     cmake_dependent_option(SVS_SHARED_LIB "Use SVS pre-compiled shared library" ON "USE_SVS AND GLIBC_FOUND AND SVS_LVQ_SUPPORTED" OFF)
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM")
-        set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250623-clang18.tar.gz" CACHE STRING "SVS URL")
+        set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250626-clang.tar.gz" CACHE STRING "SVS URL")
     else()
-        set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250613-320.tar.gz" CACHE STRING "SVS URL")
+        set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250626.tar.gz" CACHE STRING "SVS URL")
     endif()
 
     if(SVS_SHARED_LIB)

--- a/cmake/svs.cmake
+++ b/cmake/svs.cmake
@@ -49,7 +49,7 @@ if(USE_SVS)
     endif()
 
     cmake_dependent_option(SVS_SHARED_LIB "Use SVS pre-compiled shared library" ON "USE_SVS AND GLIBC_FOUND AND SVS_LVQ_SUPPORTED" OFF)
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM")
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250626-clang.tar.gz" CACHE STRING "SVS URL")
     else()
         set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250626.tar.gz" CACHE STRING "SVS URL")

--- a/src/VecSim/CMakeLists.txt
+++ b/src/VecSim/CMakeLists.txt
@@ -46,8 +46,8 @@ target_link_libraries(VectorSimilarity VectorSimilaritySpaces)
 
 if (TARGET svs::svs)
     target_link_libraries(VectorSimilarity svs::svs)
-    if(TARGET svs::svs_shared_library)
-        target_link_libraries(VectorSimilarity svs::svs_shared_library)
+    if(TARGET svs::svs_static_library)
+        target_link_libraries(VectorSimilarity svs::svs_static_library)
     endif()
 endif()
 

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -274,7 +274,7 @@ struct SVSGraphBuilder {
         auto prefetch_parameters =
             svs::index::vamana::extensions::estimate_prefetch_parameters(data);
         auto builder = svs::index::vamana::VamanaBuilder(
-            graph, data, std::move(distance), parameters, threadpool, prefetch_parameters);
+            graph, data, std::move(distance), parameters, threadpool, prefetch_parameters, logger);
 
         // Specific to the Vamana algorithm:
         // It builds in two rounds, one with alpha=1 and the second time with the user/config

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -2538,7 +2538,7 @@ TEST(SVSTest, quant_modes) {
         ASSERT_GT(actual, 0);
         // LVQ element size estimation accuracy is low
         auto quant_bits_fallback = std::get<0>(svs_details::isSVSQuantBitsSupported(quant_bits));
-        double estimation_accuracy = (quant_bits_fallback != VecSimSvsQuant_NONE) ? 0.11 : 0.01;
+        double estimation_accuracy = (quant_bits_fallback != VecSimSvsQuant_NONE) ? 0.12 : 0.01;
         ASSERT_GE(estimation * (1.0 + estimation_accuracy), actual);
         ASSERT_LE(estimation * (1.0 - estimation_accuracy), actual);
 


### PR DESCRIPTION

**Describe the changes in the pull request**

This PR fixes ISA dispatcher issues and update logging information in SVS. This PR also replaces SVS shared library with static library. 


**Which issues this PR fixes**
1. ISA dispatcher: Now the `inf->nan` issue is solved on SVS side. The ISA dispatcher also runs on non-AVX arch without issues. This change requires slightly extra size on SVS index so the test size estimation is updated.
2. Logging: SVS made a change so that SVS will print out building parameters during index construction at VecSim Verbose logging level. It requires feeding logger to VamanaBuilder.
3. Static Library: This PR uses SVS static library as requested.


**Main objects this PR modified**
1. Add logger parameter in `svs::index::vamana::VamanaBuilder`
2. Change `estimation_accuracy` in SVSTest::quant_modes from `0.11` to `0.12`
3. Update SVS version and use static library.

**Mark if applicable**

- [x] This PR introduces SVS integration changes
- [x] This PR introduces SVS test changes
- [x] This PR introduces SVS shared library changes