### PR TITLE
Support SVS search buffer capacity and LeanVec dimension parameters

### DIFF
--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -72,7 +72,15 @@ protected:
 
     // Index search parameters
     size_t search_window_size;
+    size_t search_buffer_capacity;
+    // LeanVec dataset dimension
+    // This parameter allows to tune LeanVec dimension if LeanVec is enabled
+    size_t leanvec_dim;
     double epsilon;
+
+    // Check if the dataset is Two-level LVQ
+    // This allows to tune default window capacity during search
+    bool is_two_level_lvq;
 
     // SVS thread pool
     VecSimSVSThreadPool threadpool_;
@@ -126,7 +134,7 @@ protected:
 
         // Construct SVS index initial storage with compression if needed
         auto data = storage_traits_t::create_storage(points, this->blockSize, threadpool_handle,
-                                                     this->getAllocator());
+                                                     this->getAllocator(), this->leanvec_dim);
         // Compute the entry point.
         auto entry_point =
             svs::index::vamana::extensions::compute_entry_point(data, threadpool_handle);
@@ -153,7 +161,7 @@ protected:
 
         // Configure default search parameters
         auto sp = impl_->get_search_parameters();
-        sp.buffer_config({this->search_window_size});
+        sp.buffer_config({this->search_window_size, this->search_buffer_capacity});
         impl_->set_search_parameters(sp);
         impl_->reset_performance_parameters();
     }
@@ -278,6 +286,18 @@ protected:
         }
     }
 
+    bool isTwoLevelLVQ(const VecSimSvsQuantBits& qbits) {
+        switch (qbits) {
+            case VecSimSvsQuant_4x4:
+            case VecSimSvsQuant_4x8:
+            case VecSimSvsQuant_4x8_LeanVec:
+            case VecSimSvsQuant_8x8_LeanVec:
+              return true;
+            default:
+              return false;
+        }
+    }
+
 public:
     SVSIndex(const SVSParams &params, const AbstractIndexInitParams &abstractInitParams,
              const index_component_t &components, bool force_preprocessing)
@@ -285,7 +305,10 @@ public:
           changes_num{0}, buildParams{svs_details::makeVamanaBuildParameters(params)},
           search_window_size{svs_details::getOrDefault(params.search_window_size,
                                                        SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE)},
+          search_buffer_capacity{svs_details::getOrDefault(params.search_buffer_capacity, search_window_size)},
+          leanvec_dim{svs_details::getOrDefault(params.leanvec_dim, SVS_VAMANA_DEFAULT_LEANVEC_DIM)},
           epsilon{svs_details::getOrDefault(params.epsilon, SVS_VAMANA_DEFAULT_EPSILON)},
+          is_two_level_lvq{isTwoLevelLVQ(params.quantBits)},
           threadpool_{std::max(size_t{SVS_VAMANA_DEFAULT_NUM_THREADS}, params.num_threads)},
           impl_{nullptr} {
         logger_ = makeLogger();
@@ -340,6 +363,8 @@ public:
                           .numThreads = this->getNumThreads(),
                           .numberOfMarkedDeletedNodes = this->changes_num,
                           .searchWindowSize = this->search_window_size,
+                          .searchBufferCapacity = this->search_buffer_capacity,
+                          .leanvecDim = this->leanvec_dim,
                           .epsilon = this->epsilon};
         return info;
     }
@@ -416,7 +441,7 @@ public:
         auto query = svs::data::ConstSimpleDataView<DataType>{
             static_cast<const DataType *>(processed_query), 1, this->dim};
         auto result = svs::QueryResult<size_t>{query.size(), k};
-        auto sp = svs_details::joinSearchParams(impl_->get_search_parameters(), queryParams);
+        auto sp = svs_details::joinSearchParams(impl_->get_search_parameters(), queryParams, is_two_level_lvq);
 
         auto timeoutCtx = queryParams ? queryParams->timeoutCtx : nullptr;
         auto cancel = [timeoutCtx]() { return VECSIM_TIMEOUT(timeoutCtx); };
@@ -461,7 +486,7 @@ public:
                                          this->dim};
 
         // Base search parameters for the SVS iterator schedule.
-        auto sp = svs_details::joinSearchParams(impl_->get_search_parameters(), queryParams);
+        auto sp = svs_details::joinSearchParams(impl_->get_search_parameters(), queryParams, is_two_level_lvq);
         // SVS BatchIterator handles the search in batches
         // The batch size is set to the index search window size by default
         const size_t batch_size = sp.buffer_config_.get_search_window_size();
@@ -524,7 +549,7 @@ public:
                 NullSVS_BatchIterator(queryBlobCopyPtr, queryParams, this->getAllocator());
         } else {
             return new (this->getAllocator()) SVS_BatchIterator<impl_type, data_type>(
-                queryBlobCopyPtr, impl_.get(), queryParams, this->getAllocator());
+                queryBlobCopyPtr, impl_.get(), queryParams, this->getAllocator(), is_two_level_lvq);
         }
     }
 

--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -286,15 +286,15 @@ protected:
         }
     }
 
-    bool isTwoLevelLVQ(const VecSimSvsQuantBits& qbits) {
+    bool isTwoLevelLVQ(const VecSimSvsQuantBits &qbits) {
         switch (qbits) {
-            case VecSimSvsQuant_4x4:
-            case VecSimSvsQuant_4x8:
-            case VecSimSvsQuant_4x8_LeanVec:
-            case VecSimSvsQuant_8x8_LeanVec:
-              return true;
-            default:
-              return false;
+        case VecSimSvsQuant_4x4:
+        case VecSimSvsQuant_4x8:
+        case VecSimSvsQuant_4x8_LeanVec:
+        case VecSimSvsQuant_8x8_LeanVec:
+            return true;
+        default:
+            return false;
         }
     }
 
@@ -305,8 +305,10 @@ public:
           changes_num{0}, buildParams{svs_details::makeVamanaBuildParameters(params)},
           search_window_size{svs_details::getOrDefault(params.search_window_size,
                                                        SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE)},
-          search_buffer_capacity{svs_details::getOrDefault(params.search_buffer_capacity, search_window_size)},
-          leanvec_dim{svs_details::getOrDefault(params.leanvec_dim, SVS_VAMANA_DEFAULT_LEANVEC_DIM)},
+          search_buffer_capacity{
+              svs_details::getOrDefault(params.search_buffer_capacity, search_window_size)},
+          leanvec_dim{
+              svs_details::getOrDefault(params.leanvec_dim, SVS_VAMANA_DEFAULT_LEANVEC_DIM)},
           epsilon{svs_details::getOrDefault(params.epsilon, SVS_VAMANA_DEFAULT_EPSILON)},
           is_two_level_lvq{isTwoLevelLVQ(params.quantBits)},
           threadpool_{std::max(size_t{SVS_VAMANA_DEFAULT_NUM_THREADS}, params.num_threads)},
@@ -441,7 +443,8 @@ public:
         auto query = svs::data::ConstSimpleDataView<DataType>{
             static_cast<const DataType *>(processed_query), 1, this->dim};
         auto result = svs::QueryResult<size_t>{query.size(), k};
-        auto sp = svs_details::joinSearchParams(impl_->get_search_parameters(), queryParams, is_two_level_lvq);
+        auto sp = svs_details::joinSearchParams(impl_->get_search_parameters(), queryParams,
+                                                is_two_level_lvq);
 
         auto timeoutCtx = queryParams ? queryParams->timeoutCtx : nullptr;
         auto cancel = [timeoutCtx]() { return VECSIM_TIMEOUT(timeoutCtx); };
@@ -486,7 +489,8 @@ public:
                                          this->dim};
 
         // Base search parameters for the SVS iterator schedule.
-        auto sp = svs_details::joinSearchParams(impl_->get_search_parameters(), queryParams, is_two_level_lvq);
+        auto sp = svs_details::joinSearchParams(impl_->get_search_parameters(), queryParams,
+                                                is_two_level_lvq);
         // SVS BatchIterator handles the search in batches
         // The batch size is set to the index search window size by default
         const size_t batch_size = sp.buffer_config_.get_search_window_size();

--- a/src/VecSim/algorithms/svs/svs_batch_iterator.h
+++ b/src/VecSim/algorithms/svs/svs_batch_iterator.h
@@ -78,7 +78,8 @@ public:
           impl_{std::make_unique<impl_type>(index->make_batch_iterator(
               std::span{static_cast<const DataType *>(query_vector), dim}))},
           curr_it{impl_->begin()} {
-        auto sp = svs_details::joinSearchParams(index->get_search_parameters(), queryParams, is_two_level_lvq);
+        auto sp = svs_details::joinSearchParams(index->get_search_parameters(), queryParams,
+                                                is_two_level_lvq);
         batch_size = queryParams && queryParams->batchSize
                          ? queryParams->batchSize
                          : sp.buffer_config_.get_search_window_size();

--- a/src/VecSim/algorithms/svs/svs_batch_iterator.h
+++ b/src/VecSim/algorithms/svs/svs_batch_iterator.h
@@ -71,14 +71,14 @@ private:
 
 public:
     SVS_BatchIterator(void *query_vector, const Index *index, const VecSimQueryParams *queryParams,
-                      std::shared_ptr<VecSimAllocator> allocator)
+                      std::shared_ptr<VecSimAllocator> allocator, bool is_two_level_lvq)
         : VecSimBatchIterator{query_vector, queryParams ? queryParams->timeoutCtx : nullptr,
                               std::move(allocator)},
           done{false}, dim{index->dimensions()}, index_{index},
           impl_{std::make_unique<impl_type>(index->make_batch_iterator(
               std::span{static_cast<const DataType *>(query_vector), dim}))},
           curr_it{impl_->begin()} {
-        auto sp = svs_details::joinSearchParams(index->get_search_parameters(), queryParams);
+        auto sp = svs_details::joinSearchParams(index->get_search_parameters(), queryParams, is_two_level_lvq);
         batch_size = queryParams && queryParams->batchSize
                          ? queryParams->batchSize
                          : sp.buffer_config_.get_search_window_size();

--- a/src/VecSim/algorithms/svs/svs_extensions.h
+++ b/src/VecSim/algorithms/svs/svs_extensions.h
@@ -31,7 +31,8 @@ struct SVSStorageTraits<DataType, 1, 0, false> {
 
     template <svs::data::ImmutableMemoryDataset Dataset, svs::threads::ThreadPool Pool>
     static index_storage_type create_storage(const Dataset &data, size_t block_size, Pool &pool,
-                                             std::shared_ptr<VecSimAllocator> allocator, size_t /*leanvec_dim*/) {
+                                             std::shared_ptr<VecSimAllocator> allocator,
+                                             size_t /*leanvec_dim*/) {
         const auto dim = data.dimensions();
         auto svs_bs = svs_details::SVSBlockSize(block_size, element_size(dim));
 
@@ -41,7 +42,8 @@ struct SVSStorageTraits<DataType, 1, 0, false> {
         return index_storage_type::compress(data, pool, blocked_alloc);
     }
 
-    static constexpr size_t element_size(size_t dims, size_t alignment = 0, size_t /*leanvec_dim*/ = 0) {
+    static constexpr size_t element_size(size_t dims, size_t alignment = 0,
+                                         size_t /*leanvec_dim*/ = 0) {
         return dims * sizeof(element_type);
     }
 
@@ -107,7 +109,8 @@ struct SVSStorageTraits<DataType, QuantBits, ResidualBits, false,
 
     template <svs::data::ImmutableMemoryDataset Dataset, svs::threads::ThreadPool Pool>
     static index_storage_type create_storage(const Dataset &data, size_t block_size, Pool &pool,
-                                             std::shared_ptr<VecSimAllocator> allocator, size_t /*leanvec_dim*/) {
+                                             std::shared_ptr<VecSimAllocator> allocator,
+                                             size_t /*leanvec_dim*/) {
         const auto dim = data.dimensions();
         auto svs_bs = svs_details::SVSBlockSize(block_size, element_size(dim));
 
@@ -117,7 +120,8 @@ struct SVSStorageTraits<DataType, QuantBits, ResidualBits, false,
         return index_storage_type::compress(data, pool, 0, blocked_alloc);
     }
 
-    static constexpr size_t element_size(size_t dims, size_t alignment = 0, size_t /*leanvec_dim*/ = 0) {
+    static constexpr size_t element_size(size_t dims, size_t alignment = 0,
+                                         size_t /*leanvec_dim*/ = 0) {
         using primary_type = typename index_storage_type::primary_type;
         using layout_type = typename primary_type::helper_type;
         using layout_dims_type = svs::lib::MaybeStatic<index_storage_type::extent>;
@@ -154,7 +158,7 @@ struct SVSStorageTraits<DataType, QuantBits, ResidualBits, true> {
                                                          svs::Dynamic, svs::Dynamic, blocked_type>;
 
     static size_t check_leanvec_dim(size_t dims, size_t leanvec_dim) {
-        if(leanvec_dim == 0) {
+        if (leanvec_dim == 0) {
             return dims / 2; /* default LeanVec dimension */
         }
         return leanvec_dim;
@@ -175,21 +179,24 @@ struct SVSStorageTraits<DataType, QuantBits, ResidualBits, true> {
 
     template <svs::data::ImmutableMemoryDataset Dataset, svs::threads::ThreadPool Pool>
     static index_storage_type create_storage(const Dataset &data, size_t block_size, Pool &pool,
-                                             std::shared_ptr<VecSimAllocator> allocator, size_t leanvec_dim) {
+                                             std::shared_ptr<VecSimAllocator> allocator,
+                                             size_t leanvec_dim) {
         const auto dims = data.dimensions();
         auto svs_bs = svs_details::SVSBlockSize(block_size, element_size(dims));
 
         allocator_type data_allocator{std::move(allocator)};
         auto blocked_alloc = svs::make_blocked_allocator_handle({svs_bs}, data_allocator);
 
-        return index_storage_type::reduce(data, std::nullopt, pool, 0,
-                                          svs::lib::MaybeStatic<svs::Dynamic>(check_leanvec_dim(dims, leanvec_dim)),
-                                          blocked_alloc);
+        return index_storage_type::reduce(
+            data, std::nullopt, pool, 0,
+            svs::lib::MaybeStatic<svs::Dynamic>(check_leanvec_dim(dims, leanvec_dim)),
+            blocked_alloc);
     }
 
-    static constexpr size_t element_size(size_t dims, size_t alignment = 0, size_t leanvec_dim = 0) {
-        return SVSStorageTraits<DataType, QuantBits, 0, false>::element_size(check_leanvec_dim(dims, leanvec_dim),
-                                                                             alignment) +
+    static constexpr size_t element_size(size_t dims, size_t alignment = 0,
+                                         size_t leanvec_dim = 0) {
+        return SVSStorageTraits<DataType, QuantBits, 0, false>::element_size(
+                   check_leanvec_dim(dims, leanvec_dim), alignment) +
                SVSStorageTraits<DataType, ResidualBits, 0, false>::element_size(dims, alignment);
     }
 

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -129,18 +129,16 @@ joinSearchParams(svs::index::vamana::VamanaSearchParameters &&sp,
     size_t sbc = sp.buffer_config_.get_total_capacity();
     if (rt_params.windowSize > 0) {
         sws = rt_params.windowSize;
-        if(rt_params.bufferCapacity > 0) {
+        if (rt_params.bufferCapacity > 0) {
             sbc = rt_params.bufferCapacity;
-        }
-        else {
-          if(!is_two_level_lvq) {
-              // set windowSize as default
-              sbc = rt_params.windowSize;
-          }
-          else {
-              // set windowSize * 1.5 as default for Two-level LVQ
-              sbc = static_cast<size_t>(rt_params.windowSize * 1.5);
-          }
+        } else {
+            if (!is_two_level_lvq) {
+                // set windowSize as default
+                sbc = rt_params.windowSize;
+            } else {
+                // set windowSize * 1.5 as default for Two-level LVQ
+                sbc = static_cast<size_t>(rt_params.windowSize * 1.5);
+            }
         }
     }
     sp.buffer_config({sws, sbc});
@@ -220,7 +218,8 @@ struct SVSStorageTraits {
 
     template <svs::data::ImmutableMemoryDataset Dataset, svs::threads::ThreadPool Pool>
     static index_storage_type create_storage(const Dataset &data, size_t block_size, Pool &pool,
-                                             std::shared_ptr<VecSimAllocator> allocator, size_t /* leanvec_dim */) {
+                                             std::shared_ptr<VecSimAllocator> allocator,
+                                             size_t /* leanvec_dim */) {
         const auto dim = data.dimensions();
         const auto size = data.size();
         // SVS storage element size and block size can be differ than VecSim
@@ -240,7 +239,8 @@ struct SVSStorageTraits {
     }
 
     // SVS storage element size can be differ than VecSim DataSize
-    static constexpr size_t element_size(size_t dims, size_t /*alignment*/ = 0, size_t /*leanvec_dim*/ = 0) {
+    static constexpr size_t element_size(size_t dims, size_t /*alignment*/ = 0,
+                                         size_t /*leanvec_dim*/ = 0) {
         return dims * sizeof(DataType);
     }
 

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -119,15 +119,31 @@ makeVamanaBuildParameters(const SVSParams &params) {
 // Join default SVS search parameters with VecSim query runtime parameters
 inline svs::index::vamana::VamanaSearchParameters
 joinSearchParams(svs::index::vamana::VamanaSearchParameters &&sp,
-                 const VecSimQueryParams *queryParams) {
+                 const VecSimQueryParams *queryParams, bool is_two_level_lvq) {
     if (queryParams == nullptr) {
         return std::move(sp);
     }
 
     auto &rt_params = queryParams->svsRuntimeParams;
+    size_t sws = sp.buffer_config_.get_search_window_size();
+    size_t sbc = sp.buffer_config_.get_total_capacity();
     if (rt_params.windowSize > 0) {
-        sp.buffer_config({rt_params.windowSize});
+        sws = rt_params.windowSize;
+        if(rt_params.bufferCapacity > 0) {
+            sbc = rt_params.bufferCapacity;
+        }
+        else {
+          if(!is_two_level_lvq) {
+              // set windowSize as default
+              sbc = rt_params.windowSize;
+          }
+          else {
+              // set windowSize * 1.5 as default for Two-level LVQ
+              sbc = static_cast<size_t>(rt_params.windowSize * 1.5);
+          }
+        }
     }
+    sp.buffer_config({sws, sbc});
     switch (rt_params.searchHistory) {
     case VecSimOption_ENABLE:
         sp.search_buffer_visited_set(true);
@@ -204,7 +220,7 @@ struct SVSStorageTraits {
 
     template <svs::data::ImmutableMemoryDataset Dataset, svs::threads::ThreadPool Pool>
     static index_storage_type create_storage(const Dataset &data, size_t block_size, Pool &pool,
-                                             std::shared_ptr<VecSimAllocator> allocator) {
+                                             std::shared_ptr<VecSimAllocator> allocator, size_t /* leanvec_dim */) {
         const auto dim = data.dimensions();
         const auto size = data.size();
         // SVS storage element size and block size can be differ than VecSim
@@ -224,7 +240,7 @@ struct SVSStorageTraits {
     }
 
     // SVS storage element size can be differ than VecSim DataSize
-    static constexpr size_t element_size(size_t dims, size_t /*alignment*/ = 0) {
+    static constexpr size_t element_size(size_t dims, size_t /*alignment*/ = 0, size_t /*leanvec_dim*/ = 0) {
         return dims * sizeof(DataType);
     }
 

--- a/src/VecSim/index_factories/svs_factory.cpp
+++ b/src/VecSim/index_factories/svs_factory.cpp
@@ -117,12 +117,13 @@ VecSimIndex *NewIndexImpl(const VecSimParams *params, bool is_normalized) {
 // QuantizedVectorSize() is the chain of template functions to estimate vector DataSize.
 template <typename DataType, size_t QuantBits, size_t ResidualBits, bool IsLeanVec>
 constexpr size_t QuantizedVectorSize(size_t dims, size_t alignment = 0, size_t leanvec_dim = 0) {
-    return SVSStorageTraits<DataType, QuantBits, ResidualBits, IsLeanVec>::element_size(dims,
-                                                                                        alignment, leanvec_dim);
+    return SVSStorageTraits<DataType, QuantBits, ResidualBits, IsLeanVec>::element_size(
+        dims, alignment, leanvec_dim);
 }
 
 template <typename DataType>
-size_t QuantizedVectorSize(VecSimSvsQuantBits quant_bits, size_t dims, size_t alignment = 0, size_t leanvec_dim = 0) {
+size_t QuantizedVectorSize(VecSimSvsQuantBits quant_bits, size_t dims, size_t alignment = 0,
+                           size_t leanvec_dim = 0) {
     // Ignore the 'supported' flag because we always fallback at least to the non-quantized mode
     // elsewhere we got code coverage failure for the `supported==false` case
     auto quantBits = std::get<0>(svs_details::isSVSQuantBitsSupported(quant_bits));
@@ -205,7 +206,8 @@ size_t EstimateElementSize(const SVSParams *params) {
     // Assuming that the graph_max_degree can be unset in params.
     const auto graph_max_degree = svs_details::makeVamanaBuildParameters(*params).graph_max_degree;
     const auto graph_node_size = SVSGraphBuilder<graph_idx_type>::element_size(graph_max_degree);
-    const auto vector_size = QuantizedVectorSize(params->type, params->quantBits, params->dim, 0, params->leanvec_dim);
+    const auto vector_size =
+        QuantizedVectorSize(params->type, params->quantBits, params->dim, 0, params->leanvec_dim);
 
     return vector_size + graph_node_size;
 }

--- a/src/VecSim/index_factories/svs_factory.cpp
+++ b/src/VecSim/index_factories/svs_factory.cpp
@@ -116,13 +116,13 @@ VecSimIndex *NewIndexImpl(const VecSimParams *params, bool is_normalized) {
 
 // QuantizedVectorSize() is the chain of template functions to estimate vector DataSize.
 template <typename DataType, size_t QuantBits, size_t ResidualBits, bool IsLeanVec>
-constexpr size_t QuantizedVectorSize(size_t dims, size_t alignment = 0) {
+constexpr size_t QuantizedVectorSize(size_t dims, size_t alignment = 0, size_t leanvec_dim = 0) {
     return SVSStorageTraits<DataType, QuantBits, ResidualBits, IsLeanVec>::element_size(dims,
-                                                                                        alignment);
+                                                                                        alignment, leanvec_dim);
 }
 
 template <typename DataType>
-size_t QuantizedVectorSize(VecSimSvsQuantBits quant_bits, size_t dims, size_t alignment = 0) {
+size_t QuantizedVectorSize(VecSimSvsQuantBits quant_bits, size_t dims, size_t alignment = 0, size_t leanvec_dim = 0) {
     // Ignore the 'supported' flag because we always fallback at least to the non-quantized mode
     // elsewhere we got code coverage failure for the `supported==false` case
     auto quantBits = std::get<0>(svs_details::isSVSQuantBitsSupported(quant_bits));
@@ -141,9 +141,9 @@ size_t QuantizedVectorSize(VecSimSvsQuantBits quant_bits, size_t dims, size_t al
     case VecSimSvsQuant_4x8:
         return QuantizedVectorSize<DataType, 4, 8, false>(dims, alignment);
     case VecSimSvsQuant_4x8_LeanVec:
-        return QuantizedVectorSize<DataType, 4, 8, true>(dims, alignment);
+        return QuantizedVectorSize<DataType, 4, 8, true>(dims, alignment, leanvec_dim);
     case VecSimSvsQuant_8x8_LeanVec:
-        return QuantizedVectorSize<DataType, 8, 8, true>(dims, alignment);
+        return QuantizedVectorSize<DataType, 8, 8, true>(dims, alignment, leanvec_dim);
     default:
         // If we got here something is wrong.
         assert(false && "Unsupported quantization mode");
@@ -152,12 +152,12 @@ size_t QuantizedVectorSize(VecSimSvsQuantBits quant_bits, size_t dims, size_t al
 }
 
 size_t QuantizedVectorSize(VecSimType data_type, VecSimSvsQuantBits quant_bits, size_t dims,
-                           size_t alignment = 0) {
+                           size_t alignment = 0, size_t leanvec_dim = 0) {
     switch (data_type) {
     case VecSimType_FLOAT32:
-        return QuantizedVectorSize<float>(quant_bits, dims, alignment);
+        return QuantizedVectorSize<float>(quant_bits, dims, alignment, leanvec_dim);
     case VecSimType_FLOAT16:
-        return QuantizedVectorSize<svs::Float16>(quant_bits, dims, alignment);
+        return QuantizedVectorSize<svs::Float16>(quant_bits, dims, alignment, leanvec_dim);
     default:
         // If we got here something is wrong.
         assert(false && "Unsupported data type");
@@ -205,7 +205,7 @@ size_t EstimateElementSize(const SVSParams *params) {
     // Assuming that the graph_max_degree can be unset in params.
     const auto graph_max_degree = svs_details::makeVamanaBuildParameters(*params).graph_max_degree;
     const auto graph_node_size = SVSGraphBuilder<graph_idx_type>::element_size(graph_max_degree);
-    const auto vector_size = QuantizedVectorSize(params->type, params->quantBits, params->dim);
+    const auto vector_size = QuantizedVectorSize(params->type, params->quantBits, params->dim, 0, params->leanvec_dim);
 
     return vector_size + graph_node_size;
 }

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -55,6 +55,7 @@ const char *VecSimCommonStrings::HNSW_ENTRYPOINT = "ENTRYPOINT";
 const char *VecSimCommonStrings::HNSW_NUM_MARKED_DELETED = "NUMBER_OF_MARKED_DELETED";
 
 const char *VecSimCommonStrings::SVS_WS_SEARCH_STRING = "WS_SEARCH";
+const char *VecSimCommonStrings::SVS_BC_SEARCH_STRING = "BC_SEARCH";
 const char *VecSimCommonStrings::SVS_USE_SEARCH_HISTORY_STRING = "USE_SEARCH_HISTORY";
 
 const char *VecSimCommonStrings::BLOCK_SIZE_STRING = "BLOCK_SIZE";

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -56,6 +56,7 @@ public:
     // static const char *HNSW_VISITED_NODES_POOL_SIZE_STRING;
 
     static const char *SVS_WS_SEARCH_STRING;
+    static const char *SVS_BC_SEARCH_STRING;
     static const char *SVS_USE_SEARCH_HISTORY_STRING;
 
     static const char *BLOCK_SIZE_STRING;

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -68,6 +68,23 @@ static VecSimResolveCode _ResolveParams_WSSearch(VecSimAlgo index_type, VecSimRa
     return VecSimParamResolver_OK;
 }
 
+static VecSimResolveCode _ResolveParams_BCSearch(VecSimAlgo index_type, VecSimRawParam rparam,
+                                                 VecSimQueryParams *qparams) {
+    long long num_val;
+    // BC_SEARCH is a valid parameter only in SVS algorithm.
+    if (index_type != VecSimAlgo_SVS) {
+        return VecSimParamResolverErr_UnknownParam;
+    }
+    if (qparams->svsRuntimeParams.bufferCapacity != 0) {
+        return VecSimParamResolverErr_AlreadySet;
+    }
+    if (validate_positive_integer_param(rparam, &num_val) != VecSimParamResolver_OK) {
+        return VecSimParamResolverErr_BadValue;
+    }
+
+    qparams->svsRuntimeParams.bufferCapacity = (size_t)num_val;
+    return VecSimParamResolver_OK;
+}
 static VecSimResolveCode _ResolveParams_UseSearchHistory(VecSimAlgo index_type,
                                                          VecSimRawParam rparam,
                                                          VecSimQueryParams *qparams) {
@@ -224,6 +241,11 @@ extern "C" VecSimResolveCode VecSimIndex_ResolveParams(VecSimIndex *index, VecSi
             }
         } else if (!strcasecmp(rparams[i].name, VecSimCommonStrings::SVS_WS_SEARCH_STRING)) {
             if ((res = _ResolveParams_WSSearch(index_type, rparams[i], qparams)) !=
+                VecSimParamResolver_OK) {
+                return res;
+            }
+        } else if (!strcasecmp(rparams[i].name, VecSimCommonStrings::SVS_BC_SEARCH_STRING)) {
+            if ((res = _ResolveParams_BCSearch(index_type, rparams[i], qparams)) !=
                 VecSimParamResolver_OK) {
                 return res;
             }

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -46,8 +46,8 @@ extern "C" {
 #define SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE 10
 // NOTE: No need to have SVS_VAMANA_DEFAULT_SEARCH_BUFFER_CAPACITY
 // as the default is determined by the search_window_size
-#define SVS_VAMANA_DEFAULT_LEANVEC_DIM            0
-#define SVS_VAMANA_DEFAULT_EPSILON            0.01f
+#define SVS_VAMANA_DEFAULT_LEANVEC_DIM 0
+#define SVS_VAMANA_DEFAULT_EPSILON     0.01f
 
 // Datatypes for indexing.
 typedef enum {
@@ -244,8 +244,8 @@ typedef struct {
 } HNSWRuntimeParams;
 
 typedef struct {
-    size_t windowSize;              // Search window size for Vamana graph accuracy/latency tune.
-    size_t bufferCapacity;          // Search buffer capacity for Vamana graph accuracy/latency tune.
+    size_t windowSize;     // Search window size for Vamana graph accuracy/latency tune.
+    size_t bufferCapacity; // Search buffer capacity for Vamana graph accuracy/latency tune.
     VecSimOptionMode searchHistory; // Enabling of the visited set for search.
     double epsilon; // Epsilon parameter for SVS graph accuracy/latency for range search.
 } SVSRuntimeParams;
@@ -346,8 +346,8 @@ typedef struct {
     size_t numThreads;             // Maximum number of threads to be used by svs for ingestion.
     size_t numberOfMarkedDeletedNodes; // The number of nodes that are marked as deleted.
     size_t searchWindowSize;           // Search window size for Vamana graph accuracy/latency tune.
-    size_t searchBufferCapacity;       // Search buffer capacity for Vamana graph accuracy/latency tune.
-    size_t leanvecDim;                 // Leanvec dimension to use when LeanVec is enabled.
+    size_t searchBufferCapacity; // Search buffer capacity for Vamana graph accuracy/latency tune.
+    size_t leanvecDim;           // Leanvec dimension to use when LeanVec is enabled.
     double epsilon; // Epsilon parameter for SVS graph accuracy/latency for range search.
 } svsInfoStruct;
 

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -44,6 +44,9 @@ extern "C" {
 // DEFAULT_BLOCK_SIZE is used to round the training threshold to FLAT index blocks
 #define SVS_VAMANA_DEFAULT_TRAINING_THRESHOLD (10 * DEFAULT_BLOCK_SIZE) // 10 * 1024 vectors
 #define SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE 10
+// NOTE: No need to have SVS_VAMANA_DEFAULT_SEARCH_BUFFER_CAPACITY
+// as the default is determined by the search_window_size
+#define SVS_VAMANA_DEFAULT_LEANVEC_DIM            0
 #define SVS_VAMANA_DEFAULT_EPSILON            0.01f
 
 // Datatypes for indexing.
@@ -175,6 +178,8 @@ typedef struct {
                                          // the entire search history.
     size_t num_threads;                  // Maximum number of threads in threadpool.
     size_t search_window_size;           // Search window size to use during search.
+    size_t search_buffer_capacity;       // Search buffer capacity to use during search.
+    size_t leanvec_dim;                  // Leanvec dimension to use when LeanVec is enabled.
     double epsilon; // Epsilon parameter for SVS graph accuracy/latency for range search.
 } SVSParams;
 
@@ -240,6 +245,7 @@ typedef struct {
 
 typedef struct {
     size_t windowSize;              // Search window size for Vamana graph accuracy/latency tune.
+    size_t bufferCapacity;          // Search buffer capacity for Vamana graph accuracy/latency tune.
     VecSimOptionMode searchHistory; // Enabling of the visited set for search.
     double epsilon; // Epsilon parameter for SVS graph accuracy/latency for range search.
 } SVSRuntimeParams;
@@ -340,6 +346,8 @@ typedef struct {
     size_t numThreads;             // Maximum number of threads to be used by svs for ingestion.
     size_t numberOfMarkedDeletedNodes; // The number of nodes that are marked as deleted.
     size_t searchWindowSize;           // Search window size for Vamana graph accuracy/latency tune.
+    size_t searchBufferCapacity;       // Search buffer capacity for Vamana graph accuracy/latency tune.
+    size_t leanvecDim;                 // Leanvec dimension to use when LeanVec is enabled.
     double epsilon; // Epsilon parameter for SVS graph accuracy/latency for range search.
 } svsInfoStruct;
 

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -693,6 +693,8 @@ PYBIND11_MODULE(VecSim, m) {
         .def_readwrite("prune_to", &SVSParams::prune_to)
         .def_readwrite("use_search_history", &SVSParams::use_search_history)
         .def_readwrite("search_window_size", &SVSParams::search_window_size)
+        .def_readwrite("search_buffer_capacity", &SVSParams::search_buffer_capacity)
+        .def_readwrite("leanvec_dim", &SVSParams::leanvec_dim)
         .def_readwrite("epsilon", &SVSParams::epsilon)
         .def_readwrite("num_threads", &SVSParams::num_threads);
 
@@ -731,6 +733,7 @@ PYBIND11_MODULE(VecSim, m) {
     py::class_<SVSRuntimeParams>(queryParams, "SVSRuntimeParams")
         .def(py::init<>())
         .def_readwrite("windowSize", &SVSRuntimeParams::windowSize)
+        .def_readwrite("bufferCapacity", &SVSRuntimeParams::bufferCapacity)
         .def_readwrite("searchHistory", &SVSRuntimeParams::searchHistory)
         .def_readwrite("epsilon", &SVSRuntimeParams::epsilon);
 

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -1465,6 +1465,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_combinations_and_defaults) {
           .numThreads = SVS_VAMANA_DEFAULT_NUM_THREADS,
           .numberOfMarkedDeletedNodes = 0,
           .searchWindowSize = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .searchBufferCapacity = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .leanvecDim = SVS_VAMANA_DEFAULT_LEANVEC_DIM,
           .epsilon = SVS_VAMANA_DEFAULT_EPSILON}},
 
         // Test: Cosine metric with defaults
@@ -1483,6 +1485,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_combinations_and_defaults) {
           .numThreads = SVS_VAMANA_DEFAULT_NUM_THREADS,
           .numberOfMarkedDeletedNodes = 0,
           .searchWindowSize = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .searchBufferCapacity = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .leanvecDim = SVS_VAMANA_DEFAULT_LEANVEC_DIM,
           .epsilon = SVS_VAMANA_DEFAULT_EPSILON}},
 
         // Test: Custom alpha parameter
@@ -1502,6 +1506,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_combinations_and_defaults) {
           .numThreads = SVS_VAMANA_DEFAULT_NUM_THREADS,
           .numberOfMarkedDeletedNodes = 0,
           .searchWindowSize = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .searchBufferCapacity = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .leanvecDim = SVS_VAMANA_DEFAULT_LEANVEC_DIM,
           .epsilon = SVS_VAMANA_DEFAULT_EPSILON}},
 
         // Test: Custom graph parameters
@@ -1523,6 +1529,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_combinations_and_defaults) {
           .numberOfMarkedDeletedNodes = 0,
 
           .searchWindowSize = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .searchBufferCapacity = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .leanvecDim = SVS_VAMANA_DEFAULT_LEANVEC_DIM,
           .epsilon = SVS_VAMANA_DEFAULT_EPSILON}},
 
         // Test: All custom parameters
@@ -1538,6 +1546,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_combinations_and_defaults) {
              .use_search_history = VecSimOption_DISABLE,
              .num_threads = 4,
              .search_window_size = 20,
+             .search_buffer_capacity = 40,
+             .leanvec_dim = dim / 2,
              .epsilon = 0.05,
          },
          {.quantBits = get<0>(svs_details::isSVSQuantBitsSupported(TypeParam::get_quant_bits())),
@@ -1550,6 +1560,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_combinations_and_defaults) {
           .numThreads = 4,
           .numberOfMarkedDeletedNodes = 0,
           .searchWindowSize = 20,
+          .searchBufferCapacity = 40,
+          .leanvecDim = dim / 2,
           .epsilon = 0.05}},
 
         // Test: Search history AUTO mode
@@ -1569,6 +1581,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_combinations_and_defaults) {
           .numThreads = SVS_VAMANA_DEFAULT_NUM_THREADS,
           .numberOfMarkedDeletedNodes = 0,
           .searchWindowSize = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .searchBufferCapacity = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .leanvecDim = SVS_VAMANA_DEFAULT_LEANVEC_DIM,
           .epsilon = SVS_VAMANA_DEFAULT_EPSILON}},
         // Test: Search history AUTO mode
         {"search_history_enable",
@@ -1587,6 +1601,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_combinations_and_defaults) {
           .numThreads = SVS_VAMANA_DEFAULT_NUM_THREADS,
           .numberOfMarkedDeletedNodes = 0,
           .searchWindowSize = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .searchBufferCapacity = SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE,
+          .leanvecDim = SVS_VAMANA_DEFAULT_LEANVEC_DIM,
           .epsilon = SVS_VAMANA_DEFAULT_EPSILON}}};
 
     // Run tests for each parameter combination
@@ -1645,6 +1661,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_consistency_across_metrics) {
         EXPECT_EQ(info.svsInfo.graphMaxDegree, SVS_VAMANA_DEFAULT_GRAPH_MAX_DEGREE);
         EXPECT_EQ(info.svsInfo.constructionWindowSize, SVS_VAMANA_DEFAULT_CONSTRUCTION_WINDOW_SIZE);
         EXPECT_EQ(info.svsInfo.searchWindowSize, SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE);
+        EXPECT_EQ(info.svsInfo.searchBufferCapacity, SVS_VAMANA_DEFAULT_SEARCH_WINDOW_SIZE);
+        EXPECT_DOUBLE_EQ(info.svsInfo.leanvecDim, SVS_VAMANA_DEFAULT_LEANVEC_DIM);
         EXPECT_DOUBLE_EQ(info.svsInfo.epsilon, SVS_VAMANA_DEFAULT_EPSILON);
         EXPECT_EQ(info.svsInfo.numThreads, SVS_VAMANA_DEFAULT_NUM_THREADS);
         EXPECT_EQ(info.svsInfo.useSearchHistory, SVS_VAMANA_DEFAULT_USE_SEARCH_HISTORY);

--- a/tests/unit/unit_test_utils.cpp
+++ b/tests/unit/unit_test_utils.cpp
@@ -170,6 +170,8 @@ void compareSVSInfo(svsInfoStruct info1, svsInfoStruct info2) {
     ASSERT_EQ(info1.pruneTo, info2.pruneTo);
     ASSERT_EQ(info1.quantBits, info2.quantBits);
     ASSERT_EQ(info1.searchWindowSize, info2.searchWindowSize);
+    ASSERT_EQ(info1.searchBufferCapacity, info2.searchBufferCapacity);
+    ASSERT_EQ(info1.leanvecDim, info2.leanvecDim);
     ASSERT_EQ(info1.useSearchHistory, info2.useSearchHistory);
     ASSERT_EQ(info1.epsilon, info2.epsilon);
     ASSERT_EQ(info1.numThreads, info2.numThreads);


### PR DESCRIPTION
**Describe the changes in the pull request**
This PR exposes SVS search buffer capacity and LeanVec dimension parameters for better performance tuning.

**Which issues this PR fixes**



**Main objects this PR modified**
1. SVS integration code


**Mark if applicable**

- [] This PR introduces API changes
- [] This PR introduces serialization changes
