### PR TITLE
Update clang static lib compiled with glibc 2.28

### DIFF
--- a/cmake/svs.cmake
+++ b/cmake/svs.cmake
@@ -50,7 +50,7 @@ if(USE_SVS)
 
     cmake_dependent_option(SVS_SHARED_LIB "Use SVS pre-compiled shared library" ON "USE_SVS AND GLIBC_FOUND AND SVS_LVQ_SUPPORTED" OFF)
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250629-clang.tar.gz" CACHE STRING "SVS URL")
+        set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250630-clang.tar.gz" CACHE STRING "SVS URL")
     else()
         set(SVS_URL "https://github.com/intel/ScalableVectorSearch/releases/download/v0.0.8-dev/svs-shared-library-0.0.8-NIGHTLY-20250630.tar.gz" CACHE STRING "SVS URL")
     endif()


### PR DESCRIPTION
**Describe the changes in the pull request**

Minor update that accompanies https://github.com/RedisAI/VectorSimilarity/pull/710/commits/57dfe7d86f59d99cf232079ef22e48b76c86bceb - updates SVS shared/static to be compiled with glibc 2.28 (previous static lib was not)

**Mark if applicable**

- [X] This PR introduces SVS shared library changes
