### PR TITLE
[SVS] Add support for GLIBC 2.26 systems and GCC v11.2. E.g. AmazonLinux 2

### DIFF
--- a/cmake/svs.cmake
+++ b/cmake/svs.cmake
@@ -44,12 +44,12 @@ if(USE_SVS)
     include(CheckSymbolExists)
     check_symbol_exists(__GLIBC__ "features.h" GLIBC_FOUND)
     if(GLIBC_FOUND)
-        include(CheckCSourceRuns)
-        check_c_source_runs("#include <features.h>
-            int main(){ return __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 28 ?0:1; }"
+        include(CheckCXXSourceRuns)
+        check_cxx_source_runs("#include <features.h>
+            int main(){ return __GLIBC__ == 2 && __GLIBC_MINOR__ >= 28 ?0:1; }"
             GLIBC_2_28_FOUND)
-        check_c_source_runs("#include <features.h>
-            int main(){ return __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 26 ?0:1; }"
+        check_cxx_source_runs("#include <features.h>
+            int main(){ return __GLIBC__ == 2 && __GLIBC_MINOR__ >= 26 ?0:1; }"
             GLIBC_2_26_FOUND)
     endif()
 

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -2790,7 +2790,7 @@ TYPED_TEST(SVSTest, logging_runtime_params) {
     index_logger->critical("Custom log critical");
     index_logger->flush();
     // Check that the log messages are written to the ostringstream
-    auto index_log = os_index.view();
+    auto index_log = os_index.str();
     EXPECT_NE(index_log.find("Custom log trace"), std::string::npos);
     EXPECT_NE(index_log.find("Custom log debug"), std::string::npos);
     EXPECT_NE(index_log.find("Custom log info"), std::string::npos);
@@ -2800,7 +2800,7 @@ TYPED_TEST(SVSTest, logging_runtime_params) {
 
     VecSimIndex_Free(index);
 
-    auto global_log = os_global.view();
+    auto global_log = os_global.str();
     EXPECT_TRUE(global_log.empty()) << "Global log should be empty, but got: " << global_log;
 }
 


### PR DESCRIPTION
**Describe the changes in the pull request**

This change includes compatibility issues for Linux OSes with GLIBC prior to v.2.28 including AmazonLinux 2.
Now the minimum supported GLIBC version is 2.26.
This change also includes the workaround for GCC v.11.2, which does not fully support C++20 standard.

**Which issues this PR fixes**
1. AmazonLinux 2 has old GLIBC version 2.26 released in August 2017
2. Limited support of C++20 standard in GCC v.11.2

**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
