### PR TITLE
[SVS] Fix SVSTieredIndexTestBasic.overwriteVectorAsync test

### DIFF
--- a/src/VecSim/algorithms/svs/svs_tiered.h
+++ b/src/VecSim/algorithms/svs/svs_tiered.h
@@ -736,8 +736,6 @@ public:
             // Remove vector from the backend index if it exists in case of non-MULTI.
             std::lock_guard lock(this->mainIndexGuard);
             ret -= svs_index->deleteVectors(&label, 1);
-            // If main index is empty then update_threshold is trainingTriggerThreshold,
-            // overwise it is 1.
         }
         { // Add vector to the frontend index.
             std::lock_guard lock(this->flatIndexGuard);
@@ -755,6 +753,8 @@ public:
             frontend_index_size = this->frontendIndex->indexSize();
         }
         {
+            // If main index is empty then update_threshold is trainingTriggerThreshold,
+            // overwise it is updateTriggerThreshold.
             std::shared_lock lock(this->mainIndexGuard);
             update_threshold = this->backendIndex->indexSize() == 0 ? this->trainingTriggerThreshold
                                                                     : this->updateTriggerThreshold;

--- a/tests/unit/test_svs_tiered.cpp
+++ b/tests/unit/test_svs_tiered.cpp
@@ -729,9 +729,10 @@ TYPED_TEST(SVSTieredIndexTestBasic, KNNSearchCosine) {
         }
         VecSimIndex_AddVector(tiered_index, f, i);
     }
-    ASSERT_EQ(VecSimIndex_IndexSize(tiered_index), n);
 
     mock_thread_pool.thread_pool_join();
+
+    ASSERT_EQ(VecSimIndex_IndexSize(tiered_index), n);
     // Verify that vectors were moved to SVS as expected
     auto sz_f = tiered_index->GetFlatIndex()->indexSize();
     auto sz_b = tiered_index->GetBackendIndex()->indexSize();


### PR DESCRIPTION
**Which issues this PR fixes**
1. Data-racing for SVS index threadpool size - now the SVS threadpool size is always updated under backend index lock
2. Wrong addVector() returning value in case of overwriting vector is being moved by the update job:
  If update job moved an updating vector during execution of `SVSTieredIndex::addVector()` it is possible the case when `svs_index->deleteVectors()` returns 0 and `frontendIndex->addVector()` returns 1 even if label exists in the index:
    * Initial state: frontend index contains a vector with the label `L` and value `X` (`{L: X}`); backend index is `empty`
    * User calls `addVector(L, Y)`
    * `addVector()`:
      * lock backend index
      * call `backend->deleteVector(L)` => `ret = 0`
      * unlock backend index
      * `<thread suspended>`
    * Background update job is started and finished
      * Index state: frontend is `empty`; backend contains `{L: X}`
    * `addVector()`:
      * `<thread wakeup>`
      * call `frontend->addVector(L, Y)` => `ret = 1` - because frontend is `emptied` by update job
    * User receives `ret=1` when `ret=0` is expected 


**Main objects this PR modified**
1. `SVSTieredIndex`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
