### PR TITLE
[MOD-10986] Fix ARM build disk space issue 

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -27,7 +27,7 @@ jobs:
           ec2-instance-type: t4g.medium
           subnet-id: ${{ secrets.AWS_EC2_SUBNET_ID }}
           security-group-id: ${{ secrets.AWS_EC2_SG_ID }}
-          ec2-volume-size: 15
+          ec2-volume-size: 30
 
   arm:
     needs: start-runner # required to start the main job when the runner is ready


### PR DESCRIPTION
This PR Resolves ARM build failures caused by insufficient disk space
```
(/usr/bin/ld: final link failed: No space left on device).
``` 

- Upgraded `machulav/ec2-github-runner` from`v2` to `v2.4.1` to access the `ec2-volume-size` parameter
- increased storage volume from the default 8GB to 30GB. 