### PR TITLE
Handle Homebrew conflicts: Install cmake only if not present

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,5 +6,5 @@ jobs:
   macos:
     uses: ./.github/workflows/task-unit-test.yml
     with:
-      env: macos-14
+      env: macos-latest
       run-valgrind: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,5 +6,5 @@ jobs:
   macos:
     uses: ./.github/workflows/task-unit-test.yml
     with:
-      env: macos-latest
+      env: macos-14
       run-valgrind: false

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -6,6 +6,7 @@ MODE=$1 # whether to install using sudo or not
 
 if [[ $OS_TYPE = 'Darwin' ]]
 then
+    brew uninstall cmake
     brew install cmake
 else
     if [[ $processor = 'x86_64' ]]

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -6,8 +6,11 @@ MODE=$1 # whether to install using sudo or not
 
 if [[ $OS_TYPE = 'Darwin' ]]
 then
-    brew uninstall cmake
-    brew install cmake
+    if ! command -v cmake &> /dev/null; then
+        brew install cmake
+    else
+        echo "cmake already installed"
+    fi
 else
     if [[ $processor = 'x86_64' ]]
     then


### PR DESCRIPTION
Due to the change introduced in [Homebrew/brew#20304](https://github.com/Homebrew/brew/pull/20304), Homebrew now prevents installing formulae with the same name. This means that workflows attempting to install a formula already present will fail.

This PR fixes the error message failing macos WF by installing cmake only if it isn’t already present. 