### PR TITLE
Bump cpu_features version from v0.9.0 to v0.10.1.

### DIFF
--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -4,6 +4,6 @@ option(CMAKE_POSITION_INDEPENDENT_CODE "" ON)
 FetchContent_Declare(
 	cpu_features
 	GIT_REPOSITORY  https://github.com/google/cpu_features.git
-	GIT_TAG         v0.9.0
+	GIT_TAG         v0.10.1
 )
 FetchContent_MakeAvailable(cpu_features)


### PR DESCRIPTION
### Bump cpu_features version from v0.9.0 to v0.10.1.
The previous version had a bug that caused `getArchitectureOptimization()` to return  `ARCH_OPT_NONE` instead of detecting `NEON/SVE` optimizations on macOS ARM64, particularly affecting macOS 15 runners. This was fixed in cpu_features v0.10.0 with PR #321 "fix: macos aarch64 detection" (see [release notes](https://github.com/google/cpu_features/releases/tag/v0.10.0) under Bug Fixes).