### PR TITLE
[MOD-11651] Fix wrong template type deduction in `GenerateAndAddVector` (#785)

### DIFF
--- a/tests/unit/test_bruteforce_multi.cpp
+++ b/tests/unit/test_bruteforce_multi.cpp
@@ -1293,7 +1293,7 @@ TYPED_TEST(BruteForceMultiTest, rangeQuery) {
         GenerateAndAddVector<TEST_DATA_T>(index, dim, i, i);
         // Add some vectors, worst than the second loop (for the given query)
         for (size_t j = 0; j < per_label - 1; j++)
-            GenerateAndAddVector(index, dim, i, (TEST_DATA_T)i + n);
+            GenerateAndAddVector<TEST_DATA_T>(index, dim, i, (TEST_DATA_T)i + n);
     }
 
     ASSERT_EQ(VecSimIndex_IndexSize(index), n);

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -1022,7 +1022,7 @@ TYPED_TEST(HNSWTieredIndexTest, deleteFromHNSWWithRepairJobExec) {
     auto allocator = tiered_index->getAllocator();
 
     for (size_t i = 0; i < n; i++) {
-        GenerateAndAddVector(tiered_index->getHNSWIndex(), dim, i, i);
+        GenerateAndAddVector<TEST_DATA_T>(tiered_index->getHNSWIndex(), dim, i, i);
     }
 
     // Delete vectors one by one and run the resulted repair jobs.
@@ -2703,7 +2703,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfo) {
     ASSERT_EQ(info.commonInfo.basicInfo.type, s_info.type);
     ASSERT_EQ(info.commonInfo.basicInfo.isTiered, s_info.isTiered);
 
-    GenerateAndAddVector(tiered_index, dim, 1, 1);
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, 1, 1);
     info = tiered_index->debugInfo();
     stats = tiered_index->statisticInfo();
 
@@ -2736,7 +2736,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfo) {
     EXPECT_EQ(info.tieredInfo.backgroundIndexing, false);
 
     if (TypeParam::isMulti()) {
-        GenerateAndAddVector(tiered_index, dim, 1, 1);
+        GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, 1, 1);
         info = tiered_index->debugInfo();
         stats = tiered_index->statisticInfo();
 
@@ -2785,7 +2785,7 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
     auto *tiered_index = this->CreateTieredHNSWIndex(hnsw_params, mock_thread_pool, 1);
     auto allocator = tiered_index->getAllocator();
 
-    GenerateAndAddVector(tiered_index, dim, 1, 1);
+    GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, 1, 1);
     VecSimIndexDebugInfo info = tiered_index->debugInfo();
     VecSimIndexDebugInfo frontendIndexInfo = tiered_index->frontendIndex->debugInfo();
     VecSimIndexDebugInfo backendIndexInfo = tiered_index->backendIndex->debugInfo();

--- a/tests/unit/test_utils.h
+++ b/tests/unit/test_utils.h
@@ -58,8 +58,10 @@ static void GenerateVector(data_t *output, size_t dim, data_t value = 1.0) {
     }
 }
 
+// use std::type_identity to force explicit template specification.
 template <typename data_t>
-int GenerateAndAddVector(VecSimIndex *index, size_t dim, size_t id, data_t value = 1.0) {
+int GenerateAndAddVector(VecSimIndex *index, size_t dim, size_t id,
+                         typename std::type_identity<data_t>::type value = 1.0) {
     data_t v[dim];
     GenerateVector(v, dim, value);
     return VecSimIndex_AddVector(index, v, id);


### PR DESCRIPTION
backport of #785 to 0.8