### PR TITLE
MOD-14618 Fix race condition when calling `indexLabelCount` on SVS without locks

### DIFF
--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -376,8 +376,6 @@ public:
         return impl_ ? storage_traits_t::storage_capacity(impl_->view_data()) : 0;
     }
 
-    // WARNING: Not thread-safe. When used within a tiered index, the caller MUST hold
-    // mainIndexGuard to avoid crashes caused by concurrent index modifications.
     size_t indexLabelCount() const override {
         if constexpr (isMulti) {
             return impl_ ? impl_->labelcount() : 0;

--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -376,6 +376,8 @@ public:
         return impl_ ? storage_traits_t::storage_capacity(impl_->view_data()) : 0;
     }
 
+    // WARNING: Not thread-safe. When used within a tiered index, the caller MUST hold
+    // mainIndexGuard to avoid crashes caused by concurrent index modifications.
     size_t indexLabelCount() const override {
         if constexpr (isMulti) {
             return impl_ ? impl_->labelcount() : 0;

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -147,6 +147,10 @@ public:
 
     bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override {
         // For now, decide according to the bigger index.
+        // Hold locks to safely access both indexes - backend's preferAdHocSearch may call
+        // indexLabelCount() which requires synchronization with concurrent modifications.
+        std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
+        std::shared_lock<std::shared_mutex> main_lock(this->mainIndexGuard);
         return this->backendIndex->indexSize() > this->frontendIndex->indexSize()
                    ? this->backendIndex->preferAdHocSearch(subsetSize, k, initial_check)
                    : this->frontendIndex->preferAdHocSearch(subsetSize, k, initial_check);

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -423,18 +423,22 @@ VecSimDebugInfoIterator *VecSimTieredIndex<DataType, DistType>::debugInfoIterato
                          .fieldType = INFOFIELD_UINT64,
                          .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.bufferLimit}}});
 
-    // Acquire shared locks to safely access the sub-indexes' debug info during background indexing.
-    std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
-    std::shared_lock<std::shared_mutex> main_lock(this->mainIndexGuard);
+    // Acquire shared locks to safely access each sub-index's debug info during background indexing.
+    // Only hold each lock while accessing its respective index to minimize contention.
+    {
+        std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
+        infoIterator->addInfoField(VecSim_InfoField{
+            .fieldName = VecSimCommonStrings::FRONTEND_INDEX_STRING,
+            .fieldType = INFOFIELD_ITERATOR,
+            .fieldValue = {FieldValue{.iteratorValue = this->frontendIndex->debugInfoIterator()}}});
+    }
 
-    infoIterator->addInfoField(VecSim_InfoField{
-        .fieldName = VecSimCommonStrings::FRONTEND_INDEX_STRING,
-        .fieldType = INFOFIELD_ITERATOR,
-        .fieldValue = {FieldValue{.iteratorValue = this->frontendIndex->debugInfoIterator()}}});
-
-    infoIterator->addInfoField(VecSim_InfoField{
-        .fieldName = VecSimCommonStrings::BACKEND_INDEX_STRING,
-        .fieldType = INFOFIELD_ITERATOR,
-        .fieldValue = {FieldValue{.iteratorValue = this->backendIndex->debugInfoIterator()}}});
+    {
+        std::shared_lock<std::shared_mutex> main_lock(this->mainIndexGuard);
+        infoIterator->addInfoField(VecSim_InfoField{
+            .fieldName = VecSimCommonStrings::BACKEND_INDEX_STRING,
+            .fieldType = INFOFIELD_ITERATOR,
+            .fieldValue = {FieldValue{.iteratorValue = this->backendIndex->debugInfoIterator()}}});
+    }
     return infoIterator;
 };

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -423,6 +423,10 @@ VecSimDebugInfoIterator *VecSimTieredIndex<DataType, DistType>::debugInfoIterato
                          .fieldType = INFOFIELD_UINT64,
                          .fieldValue = {FieldValue{.uintegerValue = info.tieredInfo.bufferLimit}}});
 
+    // Acquire shared locks to safely access the sub-indexes' debug info during background indexing.
+    std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
+    std::shared_lock<std::shared_mutex> main_lock(this->mainIndexGuard);
+
     infoIterator->addInfoField(VecSim_InfoField{
         .fieldName = VecSimCommonStrings::FRONTEND_INDEX_STRING,
         .fieldType = INFOFIELD_ITERATOR,

--- a/src/VecSim/vec_sim_tiered_index.h
+++ b/src/VecSim/vec_sim_tiered_index.h
@@ -147,10 +147,6 @@ public:
 
     bool preferAdHocSearch(size_t subsetSize, size_t k, bool initial_check) const override {
         // For now, decide according to the bigger index.
-        // Hold locks to safely access both indexes - backend's preferAdHocSearch may call
-        // indexLabelCount() which requires synchronization with concurrent modifications.
-        std::shared_lock<std::shared_mutex> flat_lock(this->flatIndexGuard);
-        std::shared_lock<std::shared_mutex> main_lock(this->mainIndexGuard);
         return this->backendIndex->indexSize() > this->frontendIndex->indexSize()
                    ? this->backendIndex->preferAdHocSearch(subsetSize, k, initial_check)
                    : this->frontendIndex->preferAdHocSearch(subsetSize, k, initial_check);


### PR DESCRIPTION
Fixes a race condition in `VecSimTieredIndex::debugInfoIterator()` that can crash when called while background indexing is running.

**Root Cause**

`debugInfoIterator()` accesses both sub-indexes without holding any locks. For SVS, `debugInfoIterator()` internally calls `indexLabelCount()`, which reads internal translation tables. These tables can be concurrently modified by background threads, causing a crash.

```
VecSimTieredIndex::debugInfoIterator()
  → backendIndex->debugInfoIterator()      ← NO LOCK HELD
    → SVSIndex::debugInfoIterator()
      → SVSIndex::debugInfo()
        → SVSIndex::indexLabelCount()      ← reads translation tables
          → CRASH: tables appear inconsistent due to concurrent modification
```

**Fix**

Hold the appropriate shared lock when accessing each sub-index's debug info:
- Hold `flatIndexGuard` when calling `frontendIndex->debugInfoIterator()`
- Hold `mainIndexGuard` when calling `backendIndex->debugInfoIterator()`

Each lock is released as soon as the respective iterator is created, minimizing contention.

**Follow-up:** Once Intel releases a new version of SVS that includes [intel/ScalableVectorSearch#301](https://github.com/intel/ScalableVectorSearch/pull/301), we need a follow-up PR to upgrade SVS and compile with `SVS_EXPERIMENTAL_CHECK_BOUNDS=OFF`.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

---

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

---



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk concurrency fix that only adds shared-lock guards around `frontendIndex`/`backendIndex` debug-info access; main concern is potential for minor lock contention in debug/info paths.
> 
> **Overview**
> Prevents a race when retrieving tiered index debug info during background indexing by acquiring `flatIndexGuard` and `mainIndexGuard` (shared) while calling `frontendIndex->debugInfoIterator()` and `backendIndex->debugInfoIterator()`.
> 
> Locks are scoped independently per sub-index to keep contention minimal while ensuring thread-safe access to backend SVS debug paths that may touch mutable translation tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56d0b33cc13cbf1a59205a660532616c65c8fb8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->