### PR TITLE
MOD-14661 Disable SVS bounds checking 

### DIFF
--- a/cmake/svs.cmake
+++ b/cmake/svs.cmake
@@ -88,6 +88,7 @@ if(USE_SVS)
         # This file is included from both CMakeLists.txt and python_bindings/CMakeLists.txt
         # Set `root` relative to this file, regardless of where it is included from.
         get_filename_component(root ${CMAKE_CURRENT_LIST_DIR}/.. ABSOLUTE)
+        set(SVS_EXPERIMENTAL_CHECK_BOUNDS OFF CACHE BOOL "Disable SVS bounds checking" FORCE)
         add_subdirectory(
             ${root}/deps/ScalableVectorSearch
             deps/ScalableVectorSearch


### PR DESCRIPTION
Disable SVS bounds checking (`SVS_EXPERIMENTAL_CHECK_BOUNDS=OFF`) when building `deps/ScalableVectorSearch` from source (non-`SVS_SHARED_LIB` path).

This addresses a race condition where `indexLabelCount()` is called concurrently with background indexing in tiered SVS, triggering an exception from SVS's translation table bounds check. Disabling the bounds check avoids the crash until the SVS submodule is bumped to a version that includes the upstream fix ([intel/ScalableVectorSearch#301](https://github.com/intel/ScalableVectorSearch/pull/301)).

**Which issues this PR fixes**
1. [MOD-14661](https://redislabs.atlassian.net/browse/MOD-14661) - Bump deps/svs version and compile with SVS_EXPERIMENTAL_CHECK_BOUNDS=OFF
2. Related to [MOD-14618](https://redislabs.atlassian.net/browse/MOD-14618) - Race condition in tiered SVS: indexLabelCount() called without locks causes crash

**Main objects this PR modified**
1. `cmake/svs.cmake` - Added `set(SVS_EXPERIMENTAL_CHECK_BOUNDS OFF CACHE BOOL "..." FORCE)` before `add_subdirectory` for the in-tree SVS build

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time change that alters SVS runtime validation behavior and could mask out-of-bounds bugs when using the in-tree SVS build. Scope is limited to the non-`SVS_SHARED_LIB` path in `cmake/svs.cmake`.
> 
> **Overview**
> **Disables SVS bounds checks in the vendored build.** When `SVS_SHARED_LIB` is off (building `deps/ScalableVectorSearch` from source), the CMake now forces `SVS_EXPERIMENTAL_CHECK_BOUNDS=OFF` via cache before `add_subdirectory`, changing SVS compilation defaults for that dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10571552f4ee0cc85d873d09b59c0d9053aedfa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MOD-14661]: https://redislabs.atlassian.net/browse/MOD-14661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-14618]: https://redislabs.atlassian.net/browse/MOD-14618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ