### PR TITLE
Use aws s3 cp instead of wget for benchmark index downloads

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -61,9 +61,15 @@ jobs:
       - name: Install benchmark dependencies
         run: |
           sudo .install/install_script.sh
-          sudo apt install python3-pip awscli -y
+          sudo apt install python3-pip unzip -y
           pip3 install --upgrade pip PyYAML setuptools redisbench-admin
           pip3 install -r requirements.txt
+      - name: Install AWS CLI v2
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
+          unzip -q /tmp/awscliv2.zip -d /tmp
+          sudo /tmp/aws/install
+          aws --version
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -61,9 +61,15 @@ jobs:
       - name: Install benchmark dependencies
         run: |
           sudo .install/install_script.sh
-          sudo apt install python3-pip -y
+          sudo apt install python3-pip awscli -y
           pip3 install --upgrade pip PyYAML setuptools redisbench-admin
           pip3 install -r requirements.txt
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION_BENCHMARK }}
       - name: Download pre-generated indices
         timeout-minutes: 20
         run: ./tests/benchmark/bm_files.sh ${{ inputs.setup }}

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -1,8 +1,23 @@
 BM_TYPE=$1
 alg="hnsw"
 
+S3_BUCKET="dev.cto.redis"
+S3_PREFIX="VectorSimilarity"
+DEST_DIR="tests/benchmark/data"
+
+# Download a file from S3 given its full HTTPS URL.
+# Extracts the object key from the URL and uses aws s3 cp.
+download_s3() {
+    local url="$1"
+    local filename
+    filename=$(basename "$url")
+    aws s3 cp "s3://${S3_BUCKET}/${S3_PREFIX}/${filename}" "${DEST_DIR}/${filename}"
+}
+export -f download_s3
+export S3_BUCKET S3_PREFIX DEST_DIR
+
 if [ -z "$BM_TYPE"  ] || [ "$BM_TYPE" = "benchmarks-all" ]; then
-    cat tests/benchmark/data/hnsw_indices/*.txt tests/benchmark/data/svs_indices/*.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data
+    cat tests/benchmark/data/hnsw_indices/*.txt tests/benchmark/data/svs_indices/*.txt | grep -v '^$' | sort -u | xargs -n 1 -P 0 -I {} bash -c 'download_s3 "$@"' _ {}
     exit 0
 elif [ "$BM_TYPE" = "benchmarks-default" ] \
 || [ "$BM_TYPE" = "bm-basics-fp32-single" ] \
@@ -57,4 +72,4 @@ else
     exit 0
 fi
 
-cat tests/benchmark/data/${alg}_indices/${alg}_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data
+cat tests/benchmark/data/${alg}_indices/${alg}_indices_$file_name.txt | grep -v '^$' | xargs -n 1 -P 0 -I {} bash -c 'download_s3 "$@"' _ {}

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -1,4 +1,6 @@
-BM_TYPE=$1
+set -euo pipefail
+
+BM_TYPE=${1:-}
 alg="hnsw"
 
 S3_BUCKET="dev.cto.redis"


### PR DESCRIPTION
## Problem

The nightly benchmark workflow intermittently fails on the **"Download pre-generated indices"** step due to a 20-minute timeout. The most recent failure ([run 23817284791](https://github.com/RedisAI/VectorSimilarity/actions/runs/23817284791/job/69420298633)) shows `wget` downloading multi-GB index files from S3 over HTTPS at ~8.7 MB/s, which is too slow to finish all files within the timeout.

## Root Cause

The `bm_files.sh` script uses `wget` over public HTTPS to download indices from `dev.cto.redis.s3.amazonaws.com`. Since the benchmark runners are **EC2 instances in the same AWS account**, this is unnecessarily slow — traffic goes out through the public internet instead of using the high-bandwidth internal S3 path.

## Fix

- **`bm_files.sh`**: Replace `wget` with `aws s3 cp`, which uses the internal S3 endpoint for same-region transfers (typically 10-25 Gbps). Also deduplicate URLs with `sort -u` in the `benchmarks-all` path to avoid redundant downloads.
- **`benchmark-runner.yml`**: Add `awscli` to the apt install step and add a **Configure AWS credentials** step (using the existing secrets) before the download step.

This is a minimal, targeted change — the download logic, file paths, parallelism, and timeout remain the same.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author