### PR TITLE
MOD-14826 Use try_lock in debugInfo() to avoid blocking main thread during SVS training

### DIFF
--- a/src/VecSim/algorithms/svs/svs_tiered.h
+++ b/src/VecSim/algorithms/svs/svs_tiered.h
@@ -992,9 +992,19 @@ public:
             .updateJobWaitTime = this->updateJobWaitTime,
         };
         {
-            std::lock_guard<std::mutex> lock(this->updateJobMutex);
-            svsTieredInfo.indexUpdateScheduled =
-                this->indexUpdateScheduled.test() == VecSimBool_TRUE;
+            // Use try_lock to avoid blocking the main thread during long-running
+            // training operations. updateSVSIndexWrapper holds updateJobMutex for
+            // the entire training duration (which can take 40-85s on slow machines).
+            // If the mutex is held, training is actively running, so we report
+            // indexUpdateScheduled = true (BACKGROUND_INDEXING = 1).
+            std::unique_lock<std::mutex> lock(this->updateJobMutex, std::try_to_lock);
+            if (lock.owns_lock()) {
+                svsTieredInfo.indexUpdateScheduled =
+                    this->indexUpdateScheduled.test() == VecSimBool_TRUE;
+            } else {
+                // Mutex is held by updateSVSIndexWrapper — training is in progress.
+                svsTieredInfo.indexUpdateScheduled = true;
+            }
         }
         info.tieredInfo.specificTieredBackendInfo.svsTieredInfo = svsTieredInfo;
         info.tieredInfo.backgroundIndexing =

--- a/tests/flow/test_svs_tiered.py
+++ b/tests/flow/test_svs_tiered.py
@@ -235,13 +235,11 @@ def search_insert(test_logger, is_multi: bool, num_per_label=1, data_type=VecSim
     searches_number = 0
     # run knn query every 1 s.
     total_tiered_search_time = 0
-    prev_bf_size = num_labels
     cur_svs_label_count = index.svs_label_count()
 
     test_logger.info(f"SVS labels number = {cur_svs_label_count}")
     while searches_number == 0 or cur_svs_label_count < num_labels - updateThreshold:
         # For each run get the current svs size and the query time.
-        bf_curr_size = index.get_curr_bf_size()
         query_start = time.time()
         tiered_labels, _ = index.knn_query(query_data, k)
         query_dur = time.time() - query_start
@@ -249,21 +247,16 @@ def search_insert(test_logger, is_multi: bool, num_per_label=1, data_type=VecSim
 
         test_logger.info(f"query time = {round_ms(query_dur)} ms")
 
-        # BF size should decrease.
-        test_logger.info(f"bf size = {bf_curr_size}")
-        assert bf_curr_size < prev_bf_size
-
         # Run the query also in the bf index to get the ground truth results.
         bf_labels, _ = bf_index.knn_query(query_data, k)
         correct += len(np.intersect1d(tiered_labels[0], bf_labels[0]))
         time.sleep(1)
         searches_number += 1
-        prev_bf_size = bf_curr_size
         cur_svs_label_count = index.svs_label_count()
-
     # SVS labels count updates before the job is done, so we need to wait for the queue to be empty.
     index.wait_for_index(1)
     index_dur = time.time() - index_start
+    assert index.get_curr_bf_size() == 0
     test_logger.info(f"Indexing in the tiered index took {round_(index_dur)} s")
 
     # Measure recall.


### PR DESCRIPTION
`TieredSVSIndex::debugInfo()` used a blocking `std::lock_guard` on `updateJobMutex`. Since `updateSVSIndexWrapper` holds that mutex for the **entire duration** of SVS training (which can take tens of seconds), any call to `debugInfo()` — including via `svs_label_count()` in the Python bindings — would block until training completed.

This means that reading debug info (e.g., `BACKGROUND_INDEXING`, `INDEX_UPDATE_SCHEDULED`) could stall the calling thread for the full training duration, defeating the purpose of non-blocking status queries. 
### Fix

Replace `std::lock_guard` with `std::unique_lock` using `std::try_to_lock`:

- If the lock is acquired: read `indexUpdateScheduled` normally.
- If the lock is not acquired (training is in progress): report `indexUpdateScheduled = true`, since the mutex being held by `updateSVSIndexWrapper` means an update is actively running.

### Flow test update

The `search_insert` flow test was implicitly relying on the old blocking behavior — `svs_label_count()` (which calls `debugInfo()`) acted as an accidental synchronization point, blocking until background indexing finished. With the fix, `debugInfo()` returns immediately, so the test could observe intermediate states (e.g., flat buffer not yet drained while SVS already has vectors).

Updated the test to remove the per-iteration `assert bf_curr_size < prev_bf_size` check and instead assert `bf_size == 0` after `wait_for_index()` completes.



**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only debug/observability behavior and a flow test assertion, without affecting indexing or query logic. Main risk is slightly altered `BACKGROUND_INDEXING` reporting while training is in progress.
> 
> **Overview**
> Prevents `TieredSVSIndex::debugInfo()` from blocking for the full SVS training duration by switching the `updateJobMutex` acquisition to `try_to_lock`; when the mutex is held (training running), it reports `indexUpdateScheduled=true` to keep `BACKGROUND_INDEXING` on.
> 
> Updates `test_search_insert` to stop asserting the flat-buffer size monotonically decreases during background indexing, and instead asserts the buffer is fully drained (`get_curr_bf_size()==0`) after `wait_for_index()` completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9edf21d9ba2cfeae1fef11b3a211520be0161d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->