### PR TITLE
Fix flaky SVS tiered flow test by removing incorrect flat buffer assertion

### DIFF
--- a/tests/flow/test_svs_tiered.py
+++ b/tests/flow/test_svs_tiered.py
@@ -256,7 +256,6 @@ def search_insert(test_logger, is_multi: bool, num_per_label=1, data_type=VecSim
     # SVS labels count updates before the job is done, so we need to wait for the queue to be empty.
     index.wait_for_index(1)
     index_dur = time.time() - index_start
-    assert index.get_curr_bf_size() == 0
     test_logger.info(f"Indexing in the tiered index took {round_(index_dur)} s")
 
     # Measure recall.


### PR DESCRIPTION
Remove an incorrect assertion in `search_insert` that checked `get_curr_bf_size() == 0` immediately after `wait_for_index(1)`.

The flat buffer is not guaranteed to be empty at that point: vectors added during the current update job — but not enough to trigger another one — may still reside in the buffer. This caused flaky test failures.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes