### PR TITLE
Fix std::vector::swap assertion failure with GCC 15

### DIFF
--- a/src/VecSim/memory/vecsim_malloc.h
+++ b/src/VecSim/memory/vecsim_malloc.h
@@ -113,6 +113,10 @@ inline void vecsim_free(void *p) { VecSimAllocator::memFunctions.freeFunction(p)
 template <typename T>
 struct VecsimSTLAllocator {
     using value_type = T;
+    // Tiered indexes use separate allocators for frontend/backend/management layers.
+    // Swapping containers across these layers is safe (same underlying alloc functions),
+    // so we must tell std::vector::swap to swap the allocator along with the data.
+    using propagate_on_container_swap = std::true_type;
 
 private:
     VecsimSTLAllocator() {}


### PR DESCRIPTION
GCC 15 (Fedora 43) auto-enables _GLIBCXX_ASSERTIONS in unoptimized builds (-O0). This activates a runtime check in std::vector::swap (stl_vector.h:1847) that requires either propagate_on_container_swap to be true_type, or the two allocators to compare equal.

TieredHNSW_BatchIterator::getNextResults swaps result vectors across allocator boundaries: flat_results (management-layer allocator) is swapped with the VecSimQueryReply returned by the frontend BF index (frontend allocator), and similarly for hnsw_results. These allocators are distinct VecSimAllocator instances, so operator== returns false, triggering __glibcxx_assert_fail -> abort().

Adding propagate_on_container_swap = true_type to VecsimSTLAllocator is safe because all VecSimAllocator instances use the same underlying allocation functions — they differ only in memory-tracking bookkeeping, not in actual alloc/free behavior.


**Which issues this PR fixes**

 `./build.sh RUN_PYTEST TEST=test_vecsim DEBUG` on `RediSearch` with Fedora 43 with gcc 15 was failing (but working **without** `DEBUG`).

Claude came up with this fix and explanation but I don't know enough about C++ to properly validate it. 😅 

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single trait change affecting only STL container swap behavior; risk is limited to allocator propagation semantics during swaps.
> 
> **Overview**
> Fixes a GCC 15 debug-build abort in `std::vector::swap` when vectors using `VecsimSTLAllocator` are swapped across different `VecSimAllocator` instances (e.g., tiered index front/back/management layers).
> 
> This changes `VecsimSTLAllocator` to set `propagate_on_container_swap = std::true_type`, allowing `std::vector::swap` to swap allocators along with data even when allocator instances are not equal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9ddf0bded3a796b0b7749c2460d3b26b7c91431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->