### PR TITLE
MOD-14977 Fix std::vector::swap assertion failure with GCC 15

### DIFF
--- a/src/VecSim/memory/vecsim_malloc.h
+++ b/src/VecSim/memory/vecsim_malloc.h
@@ -113,6 +113,10 @@ inline void vecsim_free(void *p) { VecSimAllocator::memFunctions.freeFunction(p)
 template <typename T>
 struct VecsimSTLAllocator {
     using value_type = T;
+    // Tiered indexes use separate allocators for frontend/backend/management layers.
+    // Swapping containers across these layers is safe (same underlying alloc functions),
+    // so we must tell std::vector::swap to swap the allocator along with the data.
+    using propagate_on_container_swap = std::true_type;
 
 private:
     VecsimSTLAllocator() {}
@@ -148,3 +152,9 @@ template <class T, class U>
 bool operator!=(const VecsimSTLAllocator<T> &a, const VecsimSTLAllocator<U> &b) {
     return a.vecsim_allocator != b.vecsim_allocator;
 }
+
+// Guard against regressions of the allocator swap-propagation trait. Tiered indexes swap
+// std::vectors whose allocators reference different VecSimAllocator instances, which is UB
+// unless the allocator is swapped along with the buffer (see hnsw_tiered.h getNextResults).
+static_assert(std::allocator_traits<VecsimSTLAllocator<char>>::propagate_on_container_swap::value,
+              "VecsimSTLAllocator must propagate on container swap.");


### PR DESCRIPTION
GCC 15 (Fedora 43) auto-enables `_GLIBCXX_ASSERTIONS` in unoptimized builds (`-O0`). This activates a runtime check in `std::vector::swap` (`stl_vector.h:1847`) that requires either `propagate_on_container_swap` to be `true_type`, or the two allocators to compare equal.

`TieredHNSW_BatchIterator::getNextResults` swaps result vectors across allocator boundaries: `flat_results` (management-layer allocator) is swapped with the `VecSimQueryReply` returned by the frontend BF index (frontend allocator), and similarly for `hnsw_results`. These allocators are distinct `VecSimAllocator` instances, so `operator==` returns false, triggering `__glibcxx_assert_fail` → `abort()`.

### The fix

A `std::vector` stores both a buffer (`data_ptr`/`size`/`capacity`) and an allocator sub-object. `swap` always exchanges the buffer; it exchanges the allocator only when `propagate_on_container_swap` is `true_type`. 
With the **default** `false_type`, each vector keeps its original allocator, so after the swap it owns a buffer produced by a *different* allocator — a precondition violation that GCC 15 rejects upfront, and that would otherwise skew per-layer memory counters at destruction time (the buffer is freed correctly because all `VecSimAllocator`s share the same underlying `vecsim_free`, but `allocated` counters are decremented on the wrong instance).

Setting `propagate_on_container_swap = true_type` makes the allocator travel with the buffer, so each vector always destroys what its own allocator produced. It only affects `swap`; copy/move/assignment are governed by other traits and are unchanged. A `static_assert` next to the class guards against regressions.


**Which issues this PR fixes**


 `./build.sh RUN_PYTEST TEST=test_vecsim DEBUG` on `RediSearch` with Fedora 43 with gcc 15 was failing (but working **without** `DEBUG`).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes allocator traits globally for all containers using `VecsimSTLAllocator`, which could subtly affect swap behavior and memory accounting, though the change is narrowly scoped to `swap` semantics.
> 
> **Overview**
> Fixes a GCC 15 `_GLIBCXX_ASSERTIONS` abort when tiered HNSW batch iteration swaps result `std::vector`s built with different `VecSimAllocator` instances.
> 
> `VecsimSTLAllocator` now declares `propagate_on_container_swap = std::true_type` so `std::vector::swap` swaps the allocator along with the buffer, and a `static_assert` was added to prevent regressions of this trait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec6a3aefe37c29a5c126956d2c1a6ce824f7c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->