### PR TITLE
[8.4] MOD-14916 Devirtualize HNSW / brute-force search hot path

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force.h
+++ b/src/VecSim/algorithms/brute_force/brute_force.h
@@ -43,7 +43,10 @@ public:
     size_t indexCapacity() const override;
     std::unique_ptr<RawDataContainer::Iterator> getVectorsIterator() const;
     const DataType *getDataByInternalId(idType id) const {
-        return reinterpret_cast<const DataType *>(this->vectors->getElement(id));
+        // `vectors` is always a DataBlocksContainer; skip the RawDataContainer vtable.
+        return reinterpret_cast<const DataType *>(
+            static_cast<const DataBlocksContainer *>(this->vectors)
+                ->DataBlocksContainer::getElement(id));
     }
     VecSimQueryReply *topKQuery(const void *queryBlob, size_t k,
                                 VecSimQueryParams *queryParams) const override;

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -385,7 +385,9 @@ labelType HNSWIndex<DataType, DistType>::getEntryPointLabel() const {
 
 template <typename DataType, typename DistType>
 const char *HNSWIndex<DataType, DistType>::getDataByInternalId(idType internal_id) const {
-    return this->vectors->getElement(internal_id);
+    // `vectors` is always a DataBlocksContainer; skip the RawDataContainer vtable on the hot path.
+    return static_cast<const DataBlocksContainer *>(this->vectors)
+        ->DataBlocksContainer::getElement(internal_id);
 }
 
 template <typename DataType, typename DistType>

--- a/src/VecSim/containers/data_blocks_container.cpp
+++ b/src/VecSim/containers/data_blocks_container.cpp
@@ -38,11 +38,6 @@ RawDataContainer::Status DataBlocksContainer::addElement(const void *element, si
     return Status::OK;
 }
 
-const char *DataBlocksContainer::getElement(size_t id) const {
-    assert(id < element_count);
-    return blocks.at(id / this->block_size).getElement(id % this->block_size);
-}
-
 RawDataContainer::Status DataBlocksContainer::removeElement(size_t id) {
     assert(id == element_count - 1); // only the last element can be removed
     blocks.back().popLastElement();

--- a/src/VecSim/containers/data_blocks_container.h
+++ b/src/VecSim/containers/data_blocks_container.h
@@ -40,7 +40,11 @@ public:
 
     Status addElement(const void *element, size_t id) override;
 
-    const char *getElement(size_t id) const override;
+    // Inlined so the hot search path (via getDataByInternalId) can fold the indexing arithmetic.
+    const char *getElement(size_t id) const override {
+        assert(id < element_count);
+        return blocks[id / block_size].getElement(id % block_size);
+    }
 
     Status removeElement(size_t id) override;
 

--- a/src/VecSim/spaces/computer/calculator.h
+++ b/src/VecSim/spaces/computer/calculator.h
@@ -23,6 +23,9 @@ public:
     virtual ~IndexCalculatorInterface() = default;
 
     virtual DistType calcDistance(const void *v1, const void *v2, size_t dim) const = 0;
+
+    // Raw distance function; cached by the index to skip the vtable on the hot path.
+    virtual spaces::dist_func_t<DistType> getDistFunc() const = 0;
 };
 
 /**
@@ -56,4 +59,6 @@ public:
     DistType calcDistance(const void *v1, const void *v2, size_t dim) const override {
         return this->dist_func(v1, v2, dim);
     }
+
+    spaces::dist_func_t<DistType> getDistFunc() const override { return this->dist_func; }
 };

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -84,6 +84,7 @@ protected:
     RawDataContainer *vectors;      // The raw vectors data container.
 private:
     IndexCalculatorInterface<DistType> *indexCalculator; // Distance calculator.
+    spaces::dist_func_t<DistType> cachedDistFunc;        // Cached dist func, used on the hot path.
     PreprocessorsContainerAbstract *preprocessors;       // Storage and query preprocessors.
 
     size_t inputBlobSize; // The size of input vectors/queries blob in bytes. May differ from dim *
@@ -120,8 +121,11 @@ public:
           metric(params.metric),
           blockSize(params.blockSize ? params.blockSize : DEFAULT_BLOCK_SIZE), lastMode(EMPTY_MODE),
           isMulti(params.multi), logCallbackCtx(params.logCtx),
-          indexCalculator(components.indexCalculator), preprocessors(components.preprocessors),
-          inputBlobSize(params.inputBlobSize), storedDataSize(params.storedDataSize) {
+          indexCalculator(components.indexCalculator),
+          cachedDistFunc(components.indexCalculator ? components.indexCalculator->getDistFunc()
+                                                    : nullptr),
+          preprocessors(components.preprocessors), inputBlobSize(params.inputBlobSize),
+          storedDataSize(params.storedDataSize) {
         assert(VecSimType_sizeof(vecType));
         assert(storedDataSize);
         assert(inputBlobSize);
@@ -142,10 +146,16 @@ public:
     /**
      * @brief Calculate the distance between two vectors based on index parameters.
      *
+     * Uses the cached dist func to avoid the indexCalculator vtable on the hot path.
+     *
+     * @note Precondition: @c cachedDistFunc must be non-null. Subclasses that construct
+     *       this index with a null @c indexCalculator (e.g. SVS, which uses its own
+     *       internal distance kernels) must not call this method.
+     *
      * @return the distance between the vectors.
      */
     DistType calcDistance(const void *vector_data1, const void *vector_data2) const {
-        return indexCalculator->calcDistance(vector_data1, vector_data2, this->dim);
+        return cachedDistFunc(vector_data1, vector_data2, this->dim);
     }
 
     /**

--- a/tests/unit/test_components.cpp
+++ b/tests/unit/test_components.cpp
@@ -31,6 +31,9 @@ public:
     virtual DistType calcDistance(const void *v1, const void *v2, size_t dim) const {
         return this->dist_func(7);
     }
+
+    // Dummy uses a non-standard dist func signature, so the standard slot is unavailable.
+    spaces::dist_func_t<DistType> getDistFunc() const override { return nullptr; }
 };
 
 } // namespace dummyCalcultor


### PR DESCRIPTION
# Description
Backport of #937 to `8.4`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core search hot paths by bypassing virtual dispatch for vector access and distance computation; incorrect assumptions about container/calculator types could cause crashes or subtle correctness regressions.
> 
> **Overview**
> **Devirtualizes core VecSim search paths** to reduce per-distance overhead in HNSW and brute-force queries.
> 
> Indexes now cache the raw distance function pointer (`cachedDistFunc`) from `IndexCalculatorInterface::getDistFunc()` and call it directly in `VecSimIndexAbstract::calcDistance`, and `DataBlocksContainer::getElement` is inlined while HNSW/BF `getDataByInternalId` explicitly downcasts `vectors` to `DataBlocksContainer` to avoid `RawDataContainer` vtable dispatch. Unit tests are updated to implement `getDistFunc()` for a dummy calculator (returning `nullptr` for non-standard signatures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2672461781b1cbd56795ea4cbf476fb51af5b22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->