### PR TITLE
Add SQ8-FP16 scalar kernels, dispatchers, tests and benchmarks [MOD-15141]

### DIFF
--- a/src/VecSim/spaces/IP/IP.cpp
+++ b/src/VecSim/spaces/IP/IP.cpp
@@ -76,6 +76,70 @@ float SQ8_FP32_Cosine(const void *pVect1v, const void *pVect2v, size_t dimension
     return SQ8_FP32_InnerProduct(pVect1v, pVect2v, dimension);
 }
 
+/*
+ * Optimized asymmetric SQ8-FP16 inner product using algebraic identity:
+ *   IP(x, y) = Σ(x_i * y_i)
+ *            ≈ Σ((min + delta * q_i) * y_i)
+ *            = min * Σy_i + delta * Σ(q_i * y_i)
+ *            = min * y_sum + delta * quantized_dot_product
+ *
+ * Each FP16 query value is widened to FP32 before accumulation. SQ8 metadata and
+ * query metadata are read as FP32.
+ *
+ * pVect1 is storage (SQ8): [uint8_t values (dim)] [min_val] [delta] [x_sum] [x_sum_squares (L2
+ * only)]
+ * pVect2 is query (FP16):  [float16 values (dim)] [y_sum] [y_sum_squares (L2 only)]
+ *
+ * Returns raw inner product value (not distance). Used by SQ8_FP16_InnerProduct, SQ8_FP16_Cosine,
+ * SQ8_FP16_L2Sqr.
+ */
+float SQ8_FP16_InnerProduct_Impl(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);
+    const auto *pVect2 = static_cast<const float16 *>(pVect2v);
+
+    // Use 4 accumulators for instruction-level parallelism
+    float sum0 = 0, sum1 = 0, sum2 = 0, sum3 = 0;
+
+    // Main loop: process 4 elements per iteration
+    size_t i = 0;
+    size_t dim4 = dimension & ~size_t(3); // dim4 is a multiple of 4
+    for (; i < dim4; i += 4) {
+        sum0 += static_cast<float>(pVect1[i + 0]) * vecsim_types::FP16_to_FP32(pVect2[i + 0]);
+        sum1 += static_cast<float>(pVect1[i + 1]) * vecsim_types::FP16_to_FP32(pVect2[i + 1]);
+        sum2 += static_cast<float>(pVect1[i + 2]) * vecsim_types::FP16_to_FP32(pVect2[i + 2]);
+        sum3 += static_cast<float>(pVect1[i + 3]) * vecsim_types::FP16_to_FP32(pVect2[i + 3]);
+    }
+
+    // Handle remainder (0-3 elements)
+    for (; i < dimension; i++) {
+        sum0 += static_cast<float>(pVect1[i]) * vecsim_types::FP16_to_FP32(pVect2[i]);
+    }
+
+    // Combine accumulators
+    float quantized_dot = (sum0 + sum1) + (sum2 + sum3);
+
+    // Get quantization parameters from stored vector (pVect1 is SQ8)
+    const float *params = reinterpret_cast<const float *>(pVect1 + dimension);
+    const float min_val = params[sq8::MIN_VAL];
+    const float delta = params[sq8::DELTA];
+
+    // Get precomputed y_sum from query blob (FP32 metadata stored after the dim float16 values)
+    const float *query_meta =
+        reinterpret_cast<const float *>(pVect2 + dimension);
+    const float y_sum = query_meta[sq8::SUM_QUERY];
+
+    // Apply formula: IP = min * y_sum + delta * Σ(q_i * y_i)
+    return min_val * y_sum + delta * quantized_dot;
+}
+
+float SQ8_FP16_InnerProduct(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    return 1.0f - SQ8_FP16_InnerProduct_Impl(pVect1v, pVect2v, dimension);
+}
+
+float SQ8_FP16_Cosine(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    return SQ8_FP16_InnerProduct(pVect1v, pVect2v, dimension);
+}
+
 // SQ8-to-SQ8: Common inner product implementation that returns the raw inner product value
 // (not distance). Used by both SQ8_SQ8_InnerProduct, SQ8_SQ8_Cosine, and SQ8_SQ8_L2Sqr.
 // Vector layout: [uint8_t values (dim)] [min_val (float)] [delta (float)] [sum (float)]

--- a/src/VecSim/spaces/IP/IP.cpp
+++ b/src/VecSim/spaces/IP/IP.cpp
@@ -10,7 +10,7 @@
 #include "VecSim/types/bfloat16.h"
 #include "VecSim/types/float16.h"
 #include "VecSim/types/sq8.h"
-#include <cstring>
+#include "VecSim/utils/alignment.h"
 
 using bfloat16 = vecsim_types::bfloat16;
 using float16 = vecsim_types::float16;
@@ -118,17 +118,14 @@ float SQ8_FP16_InnerProduct_Impl(const void *pVect1v, const void *pVect2v, size_
     // Combine accumulators
     float quantized_dot = (sum0 + sum1) + (sum2 + sum3);
 
-    // Get quantization parameters from stored vector (pVect1 is SQ8)
-    const float *params = reinterpret_cast<const float *>(pVect1 + dimension);
-    const float min_val = params[sq8::MIN_VAL];
-    const float delta = params[sq8::DELTA];
-
-    // Get precomputed y_sum from query blob (FP32 metadata stored after the dim float16 values).
-    // For odd `dimension` the byte offset 2*dimension is not 4-byte aligned, so use memcpy
-    // to avoid undefined behavior / faults from misaligned float loads.
+    // Get quantization parameters from stored vector (pVect1 is SQ8) and the precomputed
+    // y_sum from the query blob. The metadata sits at byte offsets that are not guaranteed
+    // 4-byte aligned for odd `dimension`, so use load_unaligned to avoid alignment UB.
+    const auto *params_bytes = pVect1 + dimension;
+    const float min_val = load_unaligned<float>(params_bytes + sq8::MIN_VAL * sizeof(float));
+    const float delta = load_unaligned<float>(params_bytes + sq8::DELTA * sizeof(float));
     const auto *query_meta_bytes = reinterpret_cast<const uint8_t *>(pVect2 + dimension);
-    float y_sum;
-    std::memcpy(&y_sum, query_meta_bytes + sq8::SUM_QUERY * sizeof(float), sizeof(float));
+    const float y_sum = load_unaligned<float>(query_meta_bytes + sq8::SUM_QUERY * sizeof(float));
 
     // Apply formula: IP = min * y_sum + delta * Σ(q_i * y_i)
     return min_val * y_sum + delta * quantized_dot;

--- a/src/VecSim/spaces/IP/IP.cpp
+++ b/src/VecSim/spaces/IP/IP.cpp
@@ -124,8 +124,7 @@ float SQ8_FP16_InnerProduct_Impl(const void *pVect1v, const void *pVect2v, size_
     const float delta = params[sq8::DELTA];
 
     // Get precomputed y_sum from query blob (FP32 metadata stored after the dim float16 values)
-    const float *query_meta =
-        reinterpret_cast<const float *>(pVect2 + dimension);
+    const float *query_meta = reinterpret_cast<const float *>(pVect2 + dimension);
     const float y_sum = query_meta[sq8::SUM_QUERY];
 
     // Apply formula: IP = min * y_sum + delta * Σ(q_i * y_i)

--- a/src/VecSim/spaces/IP/IP.cpp
+++ b/src/VecSim/spaces/IP/IP.cpp
@@ -123,9 +123,12 @@ float SQ8_FP16_InnerProduct_Impl(const void *pVect1v, const void *pVect2v, size_
     const float min_val = params[sq8::MIN_VAL];
     const float delta = params[sq8::DELTA];
 
-    // Get precomputed y_sum from query blob (FP32 metadata stored after the dim float16 values)
-    const float *query_meta = reinterpret_cast<const float *>(pVect2 + dimension);
-    const float y_sum = query_meta[sq8::SUM_QUERY];
+    // Get precomputed y_sum from query blob (FP32 metadata stored after the dim float16 values).
+    // For odd `dimension` the byte offset 2*dimension is not 4-byte aligned, so use memcpy
+    // to avoid undefined behavior / faults from misaligned float loads.
+    const auto *query_meta_bytes = reinterpret_cast<const uint8_t *>(pVect2 + dimension);
+    float y_sum;
+    std::memcpy(&y_sum, query_meta_bytes + sq8::SUM_QUERY * sizeof(float), sizeof(float));
 
     // Apply formula: IP = min * y_sum + delta * Σ(q_i * y_i)
     return min_val * y_sum + delta * quantized_dot;

--- a/src/VecSim/spaces/IP/IP.h
+++ b/src/VecSim/spaces/IP/IP.h
@@ -23,6 +23,19 @@ float SQ8_FP32_InnerProduct(const void *pVect1v, const void *pVect2v, size_t dim
 // pVect1v vector of type uint8 (SQ8) and pVect2v vector of type fp32
 float SQ8_FP32_Cosine(const void *pVect1v, const void *pVect2v, size_t dimension);
 
+// SQ8-FP16: Common inner product implementation that returns the raw inner product value
+// (not distance). Used by SQ8_FP16_InnerProduct, SQ8_FP16_Cosine, and SQ8_FP16_L2Sqr.
+// pVect1 is storage (SQ8): [uint8_t values (dim)] [min_val (float)] [delta (float)]
+//                          [x_sum (float)] [x_sum_squares (float, L2 only)]
+// pVect2 is query (FP16):  [float16 values (dim)] [y_sum (float)] [y_sum_squares (float, L2 only)]
+float SQ8_FP16_InnerProduct_Impl(const void *pVect1v, const void *pVect2v, size_t dimension);
+
+// pVect1v vector of type uint8 (SQ8) and pVect2v vector of type fp16
+float SQ8_FP16_InnerProduct(const void *pVect1v, const void *pVect2v, size_t dimension);
+
+// pVect1v vector of type uint8 (SQ8) and pVect2v vector of type fp16
+float SQ8_FP16_Cosine(const void *pVect1v, const void *pVect2v, size_t dimension);
+
 // SQ8-to-SQ8: Common inner product implementation that returns the raw inner product value
 // (not distance). Used by both SQ8_SQ8_InnerProduct, SQ8_SQ8_Cosine, and SQ8_SQ8_L2Sqr.
 // Vector layout: [uint8_t values (dim)] [min_val (float)] [delta (float)] [sum (float)]

--- a/src/VecSim/spaces/IP_space.cpp
+++ b/src/VecSim/spaces/IP_space.cpp
@@ -153,6 +153,34 @@ dist_func_t<float> Cosine_SQ8_FP32_GetDistFunc(size_t dim, unsigned char *alignm
     return ret_dist_func;
 }
 
+// SQ8-FP16: asymmetric inner product distance between SQ8 storage and FP16 query.
+// SIMD chooser slots are added by P1b (MOD-15152) / P1c (MOD-15153); for now this always
+// returns the scalar implementation.
+dist_func_t<float> IP_SQ8_FP16_GetDistFunc(size_t dim, unsigned char *alignment,
+                                           const void *arch_opt) {
+    unsigned char dummy_alignment;
+    if (alignment == nullptr) {
+        alignment = &dummy_alignment;
+    }
+    (void)dim;
+    (void)arch_opt;
+    return SQ8_FP16_InnerProduct;
+}
+
+// SQ8-FP16: asymmetric cosine distance between SQ8 storage and FP16 query.
+// SIMD chooser slots are added by P1b (MOD-15152) / P1c (MOD-15153); for now this always
+// returns the scalar implementation.
+dist_func_t<float> Cosine_SQ8_FP16_GetDistFunc(size_t dim, unsigned char *alignment,
+                                               const void *arch_opt) {
+    unsigned char dummy_alignment;
+    if (alignment == nullptr) {
+        alignment = &dummy_alignment;
+    }
+    (void)dim;
+    (void)arch_opt;
+    return SQ8_FP16_Cosine;
+}
+
 // SQ8-to-SQ8 Inner Product distance function (both vectors are uint8 quantized with precomputed
 // sum)
 dist_func_t<float> IP_SQ8_SQ8_GetDistFunc(size_t dim, unsigned char *alignment,

--- a/src/VecSim/spaces/IP_space.h
+++ b/src/VecSim/spaces/IP_space.h
@@ -13,6 +13,9 @@ namespace spaces {
 // SQ8-FP32: asymmetric distance between FP32 query and SQ8 storage
 dist_func_t<float> IP_SQ8_FP32_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
                                            const void *arch_opt = nullptr);
+// SQ8-FP16: asymmetric distance between FP16 query and SQ8 storage
+dist_func_t<float> IP_SQ8_FP16_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
+                                           const void *arch_opt = nullptr);
 
 dist_func_t<float> IP_FP32_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
                                        const void *arch_opt = nullptr);
@@ -32,6 +35,9 @@ dist_func_t<float> Cosine_UINT8_GetDistFunc(size_t dim, unsigned char *alignment
                                             const void *arch_opt = nullptr);
 // SQ8-FP32: asymmetric cosine distance between FP32 query and SQ8 storage
 dist_func_t<float> Cosine_SQ8_FP32_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
+                                               const void *arch_opt = nullptr);
+// SQ8-FP16: asymmetric cosine distance between FP16 query and SQ8 storage
+dist_func_t<float> Cosine_SQ8_FP16_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
                                                const void *arch_opt = nullptr);
 // SQ8-to-SQ8 distance functions (both vectors are uint8 quantized with precomputed sum)
 dist_func_t<float> IP_SQ8_SQ8_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,

--- a/src/VecSim/spaces/L2/L2.cpp
+++ b/src/VecSim/spaces/L2/L2.cpp
@@ -11,7 +11,7 @@
 #include "VecSim/types/bfloat16.h"
 #include "VecSim/types/float16.h"
 #include "VecSim/types/sq8.h"
-#include <cstring>
+#include "VecSim/utils/alignment.h"
 #include <iostream>
 
 using bfloat16 = vecsim_types::bfloat16;
@@ -58,19 +58,16 @@ float SQ8_FP16_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension)
     // Get the raw inner product using the common implementation
     const float ip = SQ8_FP16_InnerProduct_Impl(pVect1v, pVect2v, dimension);
 
-    // Get precomputed sum of squares from storage blob (pVect1 is SQ8)
+    // Get precomputed sum of squares from the storage and query blobs. The metadata sits at
+    // byte offsets that are not guaranteed 4-byte aligned for odd `dimension`, so use
+    // load_unaligned to avoid alignment UB.
     const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);
-    const float *params = reinterpret_cast<const float *>(pVect1 + dimension);
-    const float x_sum_sq = params[sq8::SUM_SQUARES];
-
-    // Get precomputed sum of squares from query blob (FP32 metadata after dim float16 values).
-    // For odd `dimension` the byte offset 2*dimension is not 4-byte aligned, so use memcpy
-    // to avoid undefined behavior / faults from misaligned float loads.
+    const float x_sum_sq =
+        load_unaligned<float>(pVect1 + dimension + sq8::SUM_SQUARES * sizeof(float));
     const auto *pVect2 = static_cast<const float16 *>(pVect2v);
     const auto *query_meta_bytes = reinterpret_cast<const uint8_t *>(pVect2 + dimension);
-    float y_sum_sq;
-    std::memcpy(&y_sum_sq, query_meta_bytes + sq8::SUM_SQUARES_QUERY * sizeof(float),
-                sizeof(float));
+    const float y_sum_sq =
+        load_unaligned<float>(query_meta_bytes + sq8::SUM_SQUARES_QUERY * sizeof(float));
 
     // L2² = ||x||² + ||y||² - 2*IP(x, y)
     return x_sum_sq + y_sum_sq - 2.0f * ip;

--- a/src/VecSim/spaces/L2/L2.cpp
+++ b/src/VecSim/spaces/L2/L2.cpp
@@ -44,6 +44,34 @@ float SQ8_FP32_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension)
     return x_sum_sq + y_sum_sq - 2.0f * ip;
 }
 
+/*
+ * Optimized asymmetric SQ8-FP16 L2 squared distance using algebraic identity:
+ *   ||x - y||² = Σx_i² - 2*IP(x, y) + Σy_i²
+ *              = x_sum_squares - 2 * IP(x, y) + y_sum_squares
+ *   where IP(x, y) = min * y_sum + delta * Σ(q_i * y_i) and FP16 query values are widened
+ *   to FP32 inside SQ8_FP16_InnerProduct_Impl.
+ *
+ * pVect1 is storage (SQ8): [uint8_t values (dim)] [min_val] [delta] [x_sum] [x_sum_squares]
+ * pVect2 is query (FP16):  [float16 values (dim)] [y_sum] [y_sum_squares]
+ */
+float SQ8_FP16_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension) {
+    // Get the raw inner product using the common implementation
+    const float ip = SQ8_FP16_InnerProduct_Impl(pVect1v, pVect2v, dimension);
+
+    // Get precomputed sum of squares from storage blob (pVect1 is SQ8)
+    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);
+    const float *params = reinterpret_cast<const float *>(pVect1 + dimension);
+    const float x_sum_sq = params[sq8::SUM_SQUARES];
+
+    // Get precomputed sum of squares from query blob (FP32 metadata after dim float16 values)
+    const auto *pVect2 = static_cast<const float16 *>(pVect2v);
+    const float *query_meta = reinterpret_cast<const float *>(pVect2 + dimension);
+    const float y_sum_sq = query_meta[sq8::SUM_SQUARES_QUERY];
+
+    // L2² = ||x||² + ||y||² - 2*IP(x, y)
+    return x_sum_sq + y_sum_sq - 2.0f * ip;
+}
+
 float FP32_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension) {
     float *vec1 = (float *)pVect1v;
     float *vec2 = (float *)pVect2v;

--- a/src/VecSim/spaces/L2/L2.cpp
+++ b/src/VecSim/spaces/L2/L2.cpp
@@ -63,10 +63,14 @@ float SQ8_FP16_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension)
     const float *params = reinterpret_cast<const float *>(pVect1 + dimension);
     const float x_sum_sq = params[sq8::SUM_SQUARES];
 
-    // Get precomputed sum of squares from query blob (FP32 metadata after dim float16 values)
+    // Get precomputed sum of squares from query blob (FP32 metadata after dim float16 values).
+    // For odd `dimension` the byte offset 2*dimension is not 4-byte aligned, so use memcpy
+    // to avoid undefined behavior / faults from misaligned float loads.
     const auto *pVect2 = static_cast<const float16 *>(pVect2v);
-    const float *query_meta = reinterpret_cast<const float *>(pVect2 + dimension);
-    const float y_sum_sq = query_meta[sq8::SUM_SQUARES_QUERY];
+    const auto *query_meta_bytes = reinterpret_cast<const uint8_t *>(pVect2 + dimension);
+    float y_sum_sq;
+    std::memcpy(&y_sum_sq, query_meta_bytes + sq8::SUM_SQUARES_QUERY * sizeof(float),
+                sizeof(float));
 
     // L2² = ||x||² + ||y||² - 2*IP(x, y)
     return x_sum_sq + y_sum_sq - 2.0f * ip;

--- a/src/VecSim/spaces/L2/L2.h
+++ b/src/VecSim/spaces/L2/L2.h
@@ -13,6 +13,9 @@
 // SQ8-FP32: pVect1v vector of type uint8 (SQ8) and pVect2v vector of type fp32
 float SQ8_FP32_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension);
 
+// SQ8-FP16: pVect1v vector of type uint8 (SQ8) and pVect2v vector of type fp16
+float SQ8_FP16_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension);
+
 float FP32_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension);
 
 double FP64_L2Sqr(const void *pVect1v, const void *pVect2v, size_t dimension);

--- a/src/VecSim/spaces/L2_space.cpp
+++ b/src/VecSim/spaces/L2_space.cpp
@@ -94,6 +94,20 @@ dist_func_t<float> L2_SQ8_FP32_GetDistFunc(size_t dim, unsigned char *alignment,
     return ret_dist_func;
 }
 
+// SQ8-FP16: asymmetric L2 distance between SQ8 storage and FP16 query.
+// SIMD chooser slots are added by P1b (MOD-15152) / P1c (MOD-15153); for now this always
+// returns the scalar implementation.
+dist_func_t<float> L2_SQ8_FP16_GetDistFunc(size_t dim, unsigned char *alignment,
+                                           const void *arch_opt) {
+    unsigned char dummy_alignment;
+    if (!alignment) {
+        alignment = &dummy_alignment;
+    }
+    (void)dim;
+    (void)arch_opt;
+    return SQ8_FP16_L2Sqr;
+}
+
 dist_func_t<float> L2_FP32_GetDistFunc(size_t dim, unsigned char *alignment, const void *arch_opt) {
     unsigned char dummy_alignment;
     if (!alignment) {

--- a/src/VecSim/spaces/L2_space.h
+++ b/src/VecSim/spaces/L2_space.h
@@ -25,6 +25,9 @@ dist_func_t<float> L2_UINT8_GetDistFunc(size_t dim, unsigned char *alignment = n
 // SQ8-FP32: asymmetric L2 distance between FP32 query and SQ8 storage
 dist_func_t<float> L2_SQ8_FP32_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
                                            const void *arch_opt = nullptr);
+// SQ8-FP16: asymmetric L2 distance between FP16 query and SQ8 storage
+dist_func_t<float> L2_SQ8_FP16_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
+                                           const void *arch_opt = nullptr);
 dist_func_t<float> L2_SQ8_SQ8_GetDistFunc(size_t dim, unsigned char *alignment = nullptr,
                                           const void *arch_opt = nullptr);
 } // namespace spaces

--- a/src/VecSim/spaces/spaces.cpp
+++ b/src/VecSim/spaces/spaces.cpp
@@ -130,6 +130,21 @@ dist_func_t<float> GetDistFunc<vecsim_types::sq8, float, float>(VecSimMetric met
 }
 
 template <>
+dist_func_t<float>
+GetDistFunc<vecsim_types::sq8, float, vecsim_types::float16>(VecSimMetric metric, size_t dim,
+                                                             unsigned char *alignment) {
+    switch (metric) {
+    case VecSimMetric_Cosine:
+        return Cosine_SQ8_FP16_GetDistFunc(dim, alignment);
+    case VecSimMetric_IP:
+        return IP_SQ8_FP16_GetDistFunc(dim, alignment);
+    case VecSimMetric_L2:
+        return L2_SQ8_FP16_GetDistFunc(dim, alignment);
+    }
+    throw std::invalid_argument("Invalid metric");
+}
+
+template <>
 normalizeVector_f<float> GetNormalizeFunc<float>(void) {
     return normalizeVector_imp<float>;
 }

--- a/src/VecSim/utils/alignment.h
+++ b/src/VecSim/utils/alignment.h
@@ -18,7 +18,8 @@
 // unaligned access; on strict-alignment targets it expands to a safe byte copy.
 template <typename T>
 static inline T load_unaligned(const void *ptr) {
-    static_assert(std::is_trivially_copyable_v<T>, "load_unaligned requires a trivially-copyable T");
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "load_unaligned requires a trivially-copyable T");
     T value;
     std::memcpy(&value, ptr, sizeof(T));
     return value;

--- a/src/VecSim/utils/alignment.h
+++ b/src/VecSim/utils/alignment.h
@@ -8,6 +8,22 @@
  */
 #pragma once
 
+#include <cstring>
+#include <type_traits>
+
+// Alignment-safe load of a trivially-copyable T from an arbitrary byte address.
+// Use when accessing fields whose alignment is not guaranteed by the layout
+// (e.g. FP32 metadata that follows a uint8_t / float16 payload of dynamic length).
+// Compilers reliably lower this to a single load on architectures that allow
+// unaligned access; on strict-alignment targets it expands to a safe byte copy.
+template <typename T>
+static inline T load_unaligned(const void *ptr) {
+    static_assert(std::is_trivially_copyable_v<T>, "load_unaligned requires a trivially-copyable T");
+    T value;
+    std::memcpy(&value, ptr, sizeof(T));
+    return value;
+}
+
 #if defined(__GNUC__) || defined(__clang__)
 #define PORTABLE_ALIGN16 __attribute__((aligned(16)))
 #define PORTABLE_ALIGN32 __attribute__((aligned(32)))

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 # Spaces benchmarks								                                          #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-set(DATA_TYPE fp32 fp64 bf16 fp16 int8 uint8 sq8_fp32 sq8_sq8)
+set(DATA_TYPE fp32 fp64 bf16 fp16 int8 uint8 sq8_fp32 sq8_fp16 sq8_sq8)
 foreach(data_type IN LISTS DATA_TYPE)
 	add_executable(bm_spaces_${data_type} spaces_benchmarks/bm_spaces_${data_type}.cpp)
 	target_link_libraries(bm_spaces_${data_type} VectorSimilarity benchmark::benchmark)

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_sq8_fp16.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_sq8_fp16.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+#include "bm_spaces.h"
+#include "VecSim/types/float16.h"
+#include "utils/tests_utils.h"
+
+using sq8 = vecsim_types::sq8;
+using float16 = vecsim_types::float16;
+
+/**
+ * SQ8-to-FP16 benchmarks: SQ8 quantized storage with FP16 query.
+ * Only naive (scalar) benchmarks are registered for now; SIMD chooser symbols are added
+ * by P1b (MOD-15152, x86) and P1c (MOD-15153, ARM).
+ */
+class BM_VecSimSpaces_SQ8_FP16 : public benchmark::Fixture {
+protected:
+    std::mt19937 rng;
+    size_t dim;
+    float16 *v1;
+    uint8_t *v2;
+
+public:
+    BM_VecSimSpaces_SQ8_FP16() { rng.seed(47); }
+    ~BM_VecSimSpaces_SQ8_FP16() = default;
+
+    void SetUp(const ::benchmark::State &state) {
+        dim = state.range(0);
+        size_t query_bytes =
+            dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+        v1 = reinterpret_cast<float16 *>(new uint8_t[query_bytes]);
+        test_utils::populate_sq8_fp16_query(v1, dim, true, 123);
+        size_t quantized_size =
+            dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+        v2 = new uint8_t[quantized_size];
+        test_utils::populate_float_vec_to_sq8_with_metadata(v2, dim, true, 1234);
+    }
+    void TearDown(const ::benchmark::State &state) {
+        delete[] reinterpret_cast<uint8_t *>(v1);
+        delete[] v2;
+    }
+};
+
+// Naive (scalar) algorithms. SIMD chooser slots will be added by P1b (MOD-15152) and
+// P1c (MOD-15153), following the SQ8_FP32 layout in bm_spaces_sq8_fp32.cpp.
+
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_SQ8_FP16, SQ8_FP16, InnerProduct, 16);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_SQ8_FP16, SQ8_FP16, Cosine, 16);
+INITIALIZE_NAIVE_BM(BM_VecSimSpaces_SQ8_FP16, SQ8_FP16, L2Sqr, 16);
+
+BENCHMARK_MAIN();

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_sq8_fp16.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_sq8_fp16.cpp
@@ -22,8 +22,10 @@ class BM_VecSimSpaces_SQ8_FP16 : public benchmark::Fixture {
 protected:
     std::mt19937 rng;
     size_t dim;
-    float16 *v1;
-    uint8_t *v2;
+    // The naive benchmark macro calls `SQ8_FP16_<metric>(v1, v2, dim)`, and the kernel signature
+    // is `(SQ8_storage, FP16_query, dim)`. v1 is therefore the SQ8 storage, v2 the FP16 query.
+    uint8_t *v1;
+    float16 *v2;
 
 public:
     BM_VecSimSpaces_SQ8_FP16() { rng.seed(47); }
@@ -31,18 +33,18 @@ public:
 
     void SetUp(const ::benchmark::State &state) {
         dim = state.range(0);
-        size_t query_bytes =
-            dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-        v1 = reinterpret_cast<float16 *>(new uint8_t[query_bytes]);
-        test_utils::populate_sq8_fp16_query(v1, dim, true, 123);
         size_t quantized_size =
             dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
-        v2 = new uint8_t[quantized_size];
-        test_utils::populate_float_vec_to_sq8_with_metadata(v2, dim, true, 1234);
+        v1 = new uint8_t[quantized_size];
+        test_utils::populate_float_vec_to_sq8_with_metadata(v1, dim, true, 1234);
+        size_t query_bytes =
+            dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+        v2 = reinterpret_cast<float16 *>(new uint8_t[query_bytes]);
+        test_utils::populate_sq8_fp16_query(v2, dim, true, 123);
     }
     void TearDown(const ::benchmark::State &state) {
-        delete[] reinterpret_cast<uint8_t *>(v1);
-        delete[] v2;
+        delete[] v1;
+        delete[] reinterpret_cast<uint8_t *>(v2);
     }
 };
 

--- a/tests/benchmark/spaces_benchmarks/bm_spaces_sq8_fp16.cpp
+++ b/tests/benchmark/spaces_benchmarks/bm_spaces_sq8_fp16.cpp
@@ -37,14 +37,16 @@ public:
             dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
         v1 = new uint8_t[quantized_size];
         test_utils::populate_float_vec_to_sq8_with_metadata(v1, dim, true, 1234);
-        size_t query_bytes =
-            dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-        v2 = reinterpret_cast<float16 *>(new uint8_t[query_bytes]);
+        // Allocate as float16[] so v2 is alignof(float16)-aligned for the SQ8_FP16 kernel's
+        // typed loads. Add extra float16 slots to cover the trailing FP32 metadata bytes.
+        size_t query_count =
+            dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+        v2 = new float16[query_count];
         test_utils::populate_sq8_fp16_query(v2, dim, true, 123);
     }
     void TearDown(const ::benchmark::State &state) {
         delete[] v1;
-        delete[] reinterpret_cast<uint8_t *>(v2);
+        delete[] v2;
     }
 };
 

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -361,6 +361,77 @@ TEST_F(SpacesTest, SQ8_FP32_l2sqr_no_optimization_func_test) {
     ASSERT_NEAR(dist, baseline, 0.01) << "SQ8_FP32_L2Sqr failed to match expected distance";
 }
 
+/* ======================== Tests SQ8-FP16 ========================= */
+
+TEST_F(SpacesTest, SQ8_FP16_ip_no_optimization_norm_func_test) {
+    size_t dim = 5;
+
+    // Create V1 fp16 query with precomputed sum and sum_squares
+    // Query layout: [float16 values (dim)] [sum (float)] [sum_squares (float)]
+    size_t query_bytes =
+        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v1_query(query_bytes);
+    test_utils::populate_sq8_fp16_query(v1_query.data(), dim, true, 1234);
+
+    // Create V2 as SQ8 quantized vector with different seed
+    size_t quantized_size =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v2_compressed(quantized_size);
+    test_utils::populate_float_vec_to_sq8_with_metadata(v2_compressed.data(), dim, true, 5678);
+
+    float baseline =
+        test_utils::SQ8_FP16_NotOptimized_InnerProduct(v2_compressed.data(), v1_query.data(), dim);
+
+    float dist = SQ8_FP16_InnerProduct((const void *)v2_compressed.data(),
+                                       (const void *)v1_query.data(), dim);
+
+    ASSERT_NEAR(dist, baseline, 0.01) << "SQ8_FP16_InnerProduct failed to match expected distance";
+}
+
+TEST_F(SpacesTest, SQ8_FP16_cosine_no_optimization_norm_func_test) {
+    size_t dim = 5;
+
+    size_t query_bytes =
+        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v1_query(query_bytes);
+    test_utils::populate_sq8_fp16_query(v1_query.data(), dim, true, 1234);
+
+    size_t quantized_size =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v2_compressed(quantized_size);
+    test_utils::populate_float_vec_to_sq8_with_metadata(v2_compressed.data(), dim, true, 5678);
+
+    float baseline =
+        test_utils::SQ8_FP16_NotOptimized_Cosine(v2_compressed.data(), v1_query.data(), dim);
+
+    float dist =
+        SQ8_FP16_Cosine((const void *)v2_compressed.data(), (const void *)v1_query.data(), dim);
+
+    ASSERT_NEAR(dist, baseline, 0.01) << "SQ8_FP16_Cosine failed to match expected distance";
+}
+
+TEST_F(SpacesTest, SQ8_FP16_l2sqr_no_optimization_func_test) {
+    size_t dim = 5;
+
+    size_t query_bytes =
+        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v1_query(query_bytes);
+    test_utils::populate_sq8_fp16_query(v1_query.data(), dim, false, 1234);
+
+    size_t quantized_size =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v2_compressed(quantized_size);
+    test_utils::populate_float_vec_to_sq8_with_metadata(v2_compressed.data(), dim, false, 5678);
+
+    float baseline =
+        test_utils::SQ8_FP16_NotOptimized_L2Sqr(v2_compressed.data(), v1_query.data(), dim);
+
+    float dist =
+        SQ8_FP16_L2Sqr((const void *)v2_compressed.data(), (const void *)v1_query.data(), dim);
+
+    ASSERT_NEAR(dist, baseline, 0.01) << "SQ8_FP16_L2Sqr failed to match expected distance";
+}
+
 /* ======================== Test Getters ======================== */
 
 TEST_F(SpacesTest, GetDistFuncInvalidMetricFP32) {
@@ -405,6 +476,12 @@ TEST_F(SpacesTest, GetDistFuncInvalidMetricSQ8ToFloat) {
                                                          10, nullptr)),
                  std::invalid_argument);
 }
+TEST_F(SpacesTest, GetDistFuncInvalidMetricSQ8ToFP16) {
+    // SQ8 storage with FP16 query (asymmetric)
+    EXPECT_THROW((spaces::GetDistFunc<sq8, float, float16>((VecSimMetric)(VecSimMetric_Cosine + 1),
+                                                           10, nullptr)),
+                 std::invalid_argument);
+}
 
 // Positive tests for GetDistFunc - verify correct function is returned
 TEST_F(SpacesTest, GetDistFuncSQ8Symmetric) {
@@ -427,6 +504,22 @@ TEST_F(SpacesTest, GetDistFuncSQ8Asymmetric) {
     ASSERT_EQ(l2_func, L2_SQ8_FP32_GetDistFunc(dim, nullptr));
     ASSERT_EQ(ip_func, IP_SQ8_FP32_GetDistFunc(dim, nullptr));
     ASSERT_EQ(cosine_func, Cosine_SQ8_FP32_GetDistFunc(dim, nullptr));
+}
+
+TEST_F(SpacesTest, GetDistFuncSQ8FP16Asymmetric) {
+    // SQ8 storage with FP16 query (asymmetric) - should return scalar SQ8_FP16 functions.
+    // SIMD chooser slots are added by P1b (MOD-15152) / P1c (MOD-15153); for now the
+    // dispatcher returns the scalar implementations regardless of dim or arch.
+    size_t dim = 128;
+    auto l2_func = spaces::GetDistFunc<sq8, float, float16>(VecSimMetric_L2, dim, nullptr);
+    auto ip_func = spaces::GetDistFunc<sq8, float, float16>(VecSimMetric_IP, dim, nullptr);
+    auto cosine_func = spaces::GetDistFunc<sq8, float, float16>(VecSimMetric_Cosine, dim, nullptr);
+    ASSERT_EQ(l2_func, L2_SQ8_FP16_GetDistFunc(dim, nullptr));
+    ASSERT_EQ(ip_func, IP_SQ8_FP16_GetDistFunc(dim, nullptr));
+    ASSERT_EQ(cosine_func, Cosine_SQ8_FP16_GetDistFunc(dim, nullptr));
+    ASSERT_EQ(l2_func, SQ8_FP16_L2Sqr);
+    ASSERT_EQ(ip_func, SQ8_FP16_InnerProduct);
+    ASSERT_EQ(cosine_func, SQ8_FP16_Cosine);
 }
 
 #ifdef CPU_FEATURES_ARCH_X86_64
@@ -2794,6 +2887,174 @@ TEST(SQ8_FP32_EdgeCases, CosineExtremeValuesTest) {
     float result = arch_opt_func(v2_quantized.data(), v1.data(), dim);
 
     ASSERT_NEAR(result, baseline, 0.01f) << "Extreme values Cosine should match baseline";
+}
+
+/* ======================== Tests SQ8_FP16 (parameterized) ========================= */
+
+// Parameterized tests that verify the scalar SQ8_FP16 kernels against the not-optimized
+// baseline across multiple dimensions, including odd dimensions and SIMD-boundary residues.
+// SIMD chooser slots are added by P1b (MOD-15152) / P1c (MOD-15153); the dispatcher always
+// returns the scalar implementation for now.
+class SQ8_FP16_NoOptimizationSpacesTest : public testing::TestWithParam<size_t> {};
+
+TEST_P(SQ8_FP16_NoOptimizationSpacesTest, SQ8_FP16_L2SqrTest) {
+    size_t dim = GetParam();
+
+    size_t query_bytes =
+        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v1_query(query_bytes);
+    test_utils::populate_sq8_fp16_query(v1_query.data(), dim, false, 1234);
+
+    size_t quantized_size =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v2_compressed(quantized_size);
+    test_utils::populate_float_vec_to_sq8_with_metadata(v2_compressed.data(), dim, false, 5678);
+
+    float baseline =
+        test_utils::SQ8_FP16_NotOptimized_L2Sqr(v2_compressed.data(), v1_query.data(), dim);
+    float dist = SQ8_FP16_L2Sqr(v2_compressed.data(), v1_query.data(), dim);
+
+    ASSERT_NEAR(dist, baseline, 0.01f) << "SQ8_FP16_L2Sqr mismatch for dim " << dim;
+}
+
+TEST_P(SQ8_FP16_NoOptimizationSpacesTest, SQ8_FP16_InnerProductTest) {
+    size_t dim = GetParam();
+
+    size_t query_bytes =
+        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v1_query(query_bytes);
+    test_utils::populate_sq8_fp16_query(v1_query.data(), dim, true, 1234);
+
+    size_t quantized_size =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v2_compressed(quantized_size);
+    test_utils::populate_float_vec_to_sq8_with_metadata(v2_compressed.data(), dim, true, 5678);
+
+    float baseline =
+        test_utils::SQ8_FP16_NotOptimized_InnerProduct(v2_compressed.data(), v1_query.data(), dim);
+    float dist = SQ8_FP16_InnerProduct(v2_compressed.data(), v1_query.data(), dim);
+
+    ASSERT_NEAR(dist, baseline, 0.01f) << "SQ8_FP16_InnerProduct mismatch for dim " << dim;
+}
+
+TEST_P(SQ8_FP16_NoOptimizationSpacesTest, SQ8_FP16_CosineTest) {
+    size_t dim = GetParam();
+
+    size_t query_bytes =
+        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v1_query(query_bytes);
+    test_utils::populate_sq8_fp16_query(v1_query.data(), dim, true, 1234);
+
+    size_t quantized_size =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v2_compressed(quantized_size);
+    test_utils::populate_float_vec_to_sq8_with_metadata(v2_compressed.data(), dim, true, 5678);
+
+    float baseline =
+        test_utils::SQ8_FP16_NotOptimized_Cosine(v2_compressed.data(), v1_query.data(), dim);
+    float dist = SQ8_FP16_Cosine(v2_compressed.data(), v1_query.data(), dim);
+
+    ASSERT_NEAR(dist, baseline, 0.01f) << "SQ8_FP16_Cosine mismatch for dim " << dim;
+}
+
+// Cover small dims, odd dims, SIMD-boundary residues for upcoming AVX2 / AVX512 / SVE / NEON
+// register widths (8/16/32/64 elements per register for SQ8 storage).
+INSTANTIATE_TEST_SUITE_P(SQ8_FP16_NoOpt, SQ8_FP16_NoOptimizationSpacesTest,
+                         testing::Values(1, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33, 47, 48, 49, 63, 64,
+                                         65, 127, 128));
+
+/* ======================== Tests SQ8_FP16 (edge cases) ========================= */
+
+// Zero FP16 query against a non-zero SQ8 storage. IP must be exactly 1.0 (1 - 0),
+// L2² must equal Σ dequantized².
+TEST(SQ8_FP16_EdgeCases, ZeroQueryTest) {
+    size_t dim = 64;
+
+    size_t query_bytes =
+        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v_zero_query(query_bytes, 0);
+    // Metadata is already zero (sum = 0, sum_squares = 0); FP16 zero is bit-pattern 0.
+
+    size_t quantized_size =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v_nonzero_quantized(quantized_size);
+    test_utils::populate_float_vec_to_sq8_with_metadata(v_nonzero_quantized.data(), dim, false,
+                                                        1234);
+
+    float ip_baseline = test_utils::SQ8_FP16_NotOptimized_InnerProduct(
+        v_nonzero_quantized.data(), v_zero_query.data(), dim);
+    float ip = SQ8_FP16_InnerProduct(v_nonzero_quantized.data(), v_zero_query.data(), dim);
+    ASSERT_NEAR(ip, ip_baseline, 0.01f) << "Zero-query SQ8_FP16_InnerProduct mismatch";
+    ASSERT_NEAR(ip, 1.0f, 0.01f) << "Zero-query IP must equal 1.0 (1 - 0)";
+
+    float l2_baseline = test_utils::SQ8_FP16_NotOptimized_L2Sqr(v_nonzero_quantized.data(),
+                                                                v_zero_query.data(), dim);
+    float l2 = SQ8_FP16_L2Sqr(v_nonzero_quantized.data(), v_zero_query.data(), dim);
+    ASSERT_NEAR(l2, l2_baseline, 0.01f) << "Zero-query SQ8_FP16_L2Sqr mismatch";
+}
+
+// Constant SQ8 storage (all values identical => delta = 0). Storage quantizer sets delta to 1.0
+// to avoid div-by-zero, so verify the kernels still match the dequantization baseline.
+TEST(SQ8_FP16_EdgeCases, ConstantStorageTest) {
+    size_t dim = 64;
+
+    size_t query_bytes =
+        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v_query(query_bytes);
+    test_utils::populate_sq8_fp16_query(v_query.data(), dim, false, 4321);
+
+    size_t quantized_size =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v_const_quantized(quantized_size);
+    std::vector<float> v_const(dim, 0.5f);
+    test_utils::quantize_float_vec_to_sq8_with_metadata(v_const.data(), dim,
+                                                        v_const_quantized.data());
+
+    float ip_baseline = test_utils::SQ8_FP16_NotOptimized_InnerProduct(v_const_quantized.data(),
+                                                                       v_query.data(), dim);
+    float ip = SQ8_FP16_InnerProduct(v_const_quantized.data(), v_query.data(), dim);
+    ASSERT_NEAR(ip, ip_baseline, 0.01f) << "Constant-storage SQ8_FP16_InnerProduct mismatch";
+
+    float l2_baseline =
+        test_utils::SQ8_FP16_NotOptimized_L2Sqr(v_const_quantized.data(), v_query.data(), dim);
+    float l2 = SQ8_FP16_L2Sqr(v_const_quantized.data(), v_query.data(), dim);
+    ASSERT_NEAR(l2, l2_baseline, 0.01f) << "Constant-storage SQ8_FP16_L2Sqr mismatch";
+}
+
+// Mixed-sign FP16 query (alternating positive/negative values) verifies sign handling
+// in the FP16->FP32 widening path and in the algebraic identity used by the kernels.
+TEST(SQ8_FP16_EdgeCases, MixedSignQueryTest) {
+    size_t dim = 64;
+
+    // Build an alternating +0.75 / -0.75 FP16 query manually so we don't depend on RNG sign mix.
+    size_t query_bytes =
+        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v_query(query_bytes);
+    auto *fp16_values = reinterpret_cast<float16 *>(v_query.data());
+    for (size_t i = 0; i < dim; i++) {
+        fp16_values[i] = vecsim_types::FP32_to_FP16((i % 2 == 0) ? 0.75f : -0.75f);
+    }
+    test_utils::preprocess_sq8_fp16_query(v_query.data(), dim);
+
+    size_t quantized_size =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    std::vector<uint8_t> v_quantized(quantized_size);
+    test_utils::populate_float_vec_to_sq8_with_metadata(v_quantized.data(), dim, false, 9876);
+
+    float ip_baseline = test_utils::SQ8_FP16_NotOptimized_InnerProduct(v_quantized.data(),
+                                                                       v_query.data(), dim);
+    float ip = SQ8_FP16_InnerProduct(v_quantized.data(), v_query.data(), dim);
+    ASSERT_NEAR(ip, ip_baseline, 0.01f) << "Mixed-sign SQ8_FP16_InnerProduct mismatch";
+
+    float cos_baseline =
+        test_utils::SQ8_FP16_NotOptimized_Cosine(v_quantized.data(), v_query.data(), dim);
+    float cos = SQ8_FP16_Cosine(v_quantized.data(), v_query.data(), dim);
+    ASSERT_NEAR(cos, cos_baseline, 0.01f) << "Mixed-sign SQ8_FP16_Cosine mismatch";
+
+    float l2_baseline =
+        test_utils::SQ8_FP16_NotOptimized_L2Sqr(v_quantized.data(), v_query.data(), dim);
+    float l2 = SQ8_FP16_L2Sqr(v_quantized.data(), v_query.data(), dim);
+    ASSERT_NEAR(l2, l2_baseline, 0.01f) << "Mixed-sign SQ8_FP16_L2Sqr mismatch";
 }
 
 /* ======================== Tests SQ8_SQ8 ========================= */

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -450,9 +450,7 @@ TEST_F(SpacesTest, SQ8_FP16_l2sqr_odd_dim_unaligned_metadata_test) {
         storage[i] = static_cast<uint8_t>(i + 1);
     }
 
-    auto store_float = [](uint8_t *dst, float value) {
-        std::memcpy(dst, &value, sizeof(value));
-    };
+    auto store_float = [](uint8_t *dst, float value) { std::memcpy(dst, &value, sizeof(value)); };
 
     constexpr float min_val = 0.0f;
     constexpr float delta = 1.0f;
@@ -474,10 +472,8 @@ TEST_F(SpacesTest, SQ8_FP16_l2sqr_odd_dim_unaligned_metadata_test) {
     store_float(query_meta + sq8::SUM_QUERY * sizeof(float), query_sum);
     store_float(query_meta + sq8::SUM_SQUARES_QUERY * sizeof(float), query_sum_squares);
 
-    const auto *storage_sum_squares_addr =
-        storage_meta + sq8::SUM_SQUARES * sizeof(float);
-    const auto *query_sum_squares_addr =
-        query_meta + sq8::SUM_SQUARES_QUERY * sizeof(float);
+    const auto *storage_sum_squares_addr = storage_meta + sq8::SUM_SQUARES * sizeof(float);
+    const auto *query_sum_squares_addr = query_meta + sq8::SUM_SQUARES_QUERY * sizeof(float);
     ASSERT_NE(reinterpret_cast<std::uintptr_t>(storage_sum_squares_addr) % alignof(float), 0u);
     ASSERT_NE(reinterpret_cast<std::uintptr_t>(query_sum_squares_addr) % alignof(float), 0u);
 

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -371,9 +371,12 @@ TEST_F(SpacesTest, SQ8_FP16_ip_no_optimization_norm_func_test) {
 
     // Create V1 fp16 query with precomputed sum and sum_squares
     // Query layout: [float16 values (dim)] [sum (float)] [sum_squares (float)]
-    size_t query_bytes =
-        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-    std::vector<uint8_t> v1_query(query_bytes);
+    // Allocate as std::vector<float16> so v1_query.data() is alignof(float16)-aligned, as
+    // required by the SQ8_FP16 production kernels' typed float16* loads. Add extra float16
+    // slots to cover the trailing FP32 metadata bytes.
+    size_t query_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+    std::vector<float16> v1_query(query_count);
     test_utils::populate_sq8_fp16_query(v1_query.data(), dim, true, 1234);
 
     // Create V2 as SQ8 quantized vector with different seed
@@ -394,9 +397,9 @@ TEST_F(SpacesTest, SQ8_FP16_ip_no_optimization_norm_func_test) {
 TEST_F(SpacesTest, SQ8_FP16_cosine_no_optimization_norm_func_test) {
     size_t dim = 5;
 
-    size_t query_bytes =
-        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-    std::vector<uint8_t> v1_query(query_bytes);
+    size_t query_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+    std::vector<float16> v1_query(query_count);
     test_utils::populate_sq8_fp16_query(v1_query.data(), dim, true, 1234);
 
     size_t quantized_size =
@@ -416,9 +419,9 @@ TEST_F(SpacesTest, SQ8_FP16_cosine_no_optimization_norm_func_test) {
 TEST_F(SpacesTest, SQ8_FP16_l2sqr_no_optimization_func_test) {
     size_t dim = 5;
 
-    size_t query_bytes =
-        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-    std::vector<uint8_t> v1_query(query_bytes);
+    size_t query_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+    std::vector<float16> v1_query(query_count);
     test_utils::populate_sq8_fp16_query(v1_query.data(), dim, false, 1234);
 
     size_t quantized_size =
@@ -2950,9 +2953,9 @@ class SQ8_FP16_NoOptimizationSpacesTest : public testing::TestWithParam<size_t> 
 TEST_P(SQ8_FP16_NoOptimizationSpacesTest, SQ8_FP16_L2SqrTest) {
     size_t dim = GetParam();
 
-    size_t query_bytes =
-        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-    std::vector<uint8_t> v1_query(query_bytes);
+    size_t query_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+    std::vector<float16> v1_query(query_count);
     test_utils::populate_sq8_fp16_query(v1_query.data(), dim, false, 1234);
 
     size_t quantized_size =
@@ -2970,9 +2973,9 @@ TEST_P(SQ8_FP16_NoOptimizationSpacesTest, SQ8_FP16_L2SqrTest) {
 TEST_P(SQ8_FP16_NoOptimizationSpacesTest, SQ8_FP16_InnerProductTest) {
     size_t dim = GetParam();
 
-    size_t query_bytes =
-        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-    std::vector<uint8_t> v1_query(query_bytes);
+    size_t query_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+    std::vector<float16> v1_query(query_count);
     test_utils::populate_sq8_fp16_query(v1_query.data(), dim, true, 1234);
 
     size_t quantized_size =
@@ -2990,9 +2993,9 @@ TEST_P(SQ8_FP16_NoOptimizationSpacesTest, SQ8_FP16_InnerProductTest) {
 TEST_P(SQ8_FP16_NoOptimizationSpacesTest, SQ8_FP16_CosineTest) {
     size_t dim = GetParam();
 
-    size_t query_bytes =
-        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-    std::vector<uint8_t> v1_query(query_bytes);
+    size_t query_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+    std::vector<float16> v1_query(query_count);
     test_utils::populate_sq8_fp16_query(v1_query.data(), dim, true, 1234);
 
     size_t quantized_size =
@@ -3020,10 +3023,10 @@ INSTANTIATE_TEST_SUITE_P(SQ8_FP16_NoOpt, SQ8_FP16_NoOptimizationSpacesTest,
 TEST(SQ8_FP16_EdgeCases, ZeroQueryTest) {
     size_t dim = 64;
 
-    size_t query_bytes =
-        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-    std::vector<uint8_t> v_zero_query(query_bytes, 0);
-    // Metadata is already zero (sum = 0, sum_squares = 0); FP16 zero is bit-pattern 0.
+    size_t query_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+    std::vector<float16> v_zero_query(query_count, float16{0});
+    // Metadata bits are zero (sum = 0, sum_squares = 0); FP16 zero is bit-pattern 0.
 
     size_t quantized_size =
         dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
@@ -3048,9 +3051,9 @@ TEST(SQ8_FP16_EdgeCases, ZeroQueryTest) {
 TEST(SQ8_FP16_EdgeCases, ConstantStorageTest) {
     size_t dim = 64;
 
-    size_t query_bytes =
-        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-    std::vector<uint8_t> v_query(query_bytes);
+    size_t query_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+    std::vector<float16> v_query(query_count);
     test_utils::populate_sq8_fp16_query(v_query.data(), dim, false, 4321);
 
     size_t quantized_size =
@@ -3077,12 +3080,13 @@ TEST(SQ8_FP16_EdgeCases, MixedSignQueryTest) {
     size_t dim = 64;
 
     // Build an alternating +0.75 / -0.75 FP16 query manually so we don't depend on RNG sign mix.
-    size_t query_bytes =
-        dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float);
-    std::vector<uint8_t> v_query(query_bytes);
-    auto *fp16_values = reinterpret_cast<float16 *>(v_query.data());
+    // Allocated as std::vector<float16> so v_query.data() is alignof(float16)-aligned for
+    // the SQ8_FP16 production kernel.
+    size_t query_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * (sizeof(float) / sizeof(float16));
+    std::vector<float16> v_query(query_count);
     for (size_t i = 0; i < dim; i++) {
-        fp16_values[i] = vecsim_types::FP32_to_FP16((i % 2 == 0) ? 0.75f : -0.75f);
+        v_query[i] = vecsim_types::FP32_to_FP16((i % 2 == 0) ? 0.75f : -0.75f);
     }
     test_utils::preprocess_sq8_fp16_query(v_query.data(), dim);
 

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -2981,8 +2981,8 @@ TEST(SQ8_FP16_EdgeCases, ZeroQueryTest) {
     test_utils::populate_float_vec_to_sq8_with_metadata(v_nonzero_quantized.data(), dim, false,
                                                         1234);
 
-    float ip_baseline = test_utils::SQ8_FP16_NotOptimized_InnerProduct(
-        v_nonzero_quantized.data(), v_zero_query.data(), dim);
+    float ip_baseline = test_utils::SQ8_FP16_NotOptimized_InnerProduct(v_nonzero_quantized.data(),
+                                                                       v_zero_query.data(), dim);
     float ip = SQ8_FP16_InnerProduct(v_nonzero_quantized.data(), v_zero_query.data(), dim);
     ASSERT_NEAR(ip, ip_baseline, 0.01f) << "Zero-query SQ8_FP16_InnerProduct mismatch";
     ASSERT_NEAR(ip, 1.0f, 0.01f) << "Zero-query IP must equal 1.0 (1 - 0)";
@@ -3041,8 +3041,8 @@ TEST(SQ8_FP16_EdgeCases, MixedSignQueryTest) {
     std::vector<uint8_t> v_quantized(quantized_size);
     test_utils::populate_float_vec_to_sq8_with_metadata(v_quantized.data(), dim, false, 9876);
 
-    float ip_baseline = test_utils::SQ8_FP16_NotOptimized_InnerProduct(v_quantized.data(),
-                                                                       v_query.data(), dim);
+    float ip_baseline =
+        test_utils::SQ8_FP16_NotOptimized_InnerProduct(v_quantized.data(), v_query.data(), dim);
     float ip = SQ8_FP16_InnerProduct(v_quantized.data(), v_query.data(), dim);
     ASSERT_NEAR(ip, ip_baseline, 0.01f) << "Mixed-sign SQ8_FP16_InnerProduct mismatch";
 

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -7,6 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
  */
 
+#include <array>
+#include <cstdint>
+#include <cstring>
 #include <utility>
 #include <random>
 #include <cmath>
@@ -430,6 +433,57 @@ TEST_F(SpacesTest, SQ8_FP16_l2sqr_no_optimization_func_test) {
         SQ8_FP16_L2Sqr((const void *)v2_compressed.data(), (const void *)v1_query.data(), dim);
 
     ASSERT_NEAR(dist, baseline, 0.01) << "SQ8_FP16_L2Sqr failed to match expected distance";
+}
+
+TEST_F(SpacesTest, SQ8_FP16_l2sqr_odd_dim_unaligned_metadata_test) {
+    constexpr size_t dim = 5;
+    constexpr size_t storage_bytes =
+        dim * sizeof(uint8_t) + sq8::storage_metadata_count<VecSimMetric_L2>() * sizeof(float);
+    static_assert(sizeof(float) % sizeof(float16) == 0);
+    constexpr size_t query_values_count =
+        dim + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float) / sizeof(float16);
+
+    alignas(float) std::array<uint8_t, storage_bytes> storage{};
+    alignas(float) std::array<float16, query_values_count> query{};
+
+    for (size_t i = 0; i < dim; i++) {
+        storage[i] = static_cast<uint8_t>(i + 1);
+    }
+
+    auto store_float = [](uint8_t *dst, float value) {
+        std::memcpy(dst, &value, sizeof(value));
+    };
+
+    constexpr float min_val = 0.0f;
+    constexpr float delta = 1.0f;
+    constexpr float storage_sum = 15.0f;
+    constexpr float storage_sum_squares = 55.0f;
+    uint8_t *storage_meta = storage.data() + dim;
+    store_float(storage_meta + sq8::MIN_VAL * sizeof(float), min_val);
+    store_float(storage_meta + sq8::DELTA * sizeof(float), delta);
+    store_float(storage_meta + sq8::SUM * sizeof(float), storage_sum);
+    store_float(storage_meta + sq8::SUM_SQUARES * sizeof(float), storage_sum_squares);
+
+    for (size_t i = 0; i < dim; i++) {
+        query[i] = vecsim_types::FP32_to_FP16(static_cast<float>(i + 2));
+    }
+
+    constexpr float query_sum = 20.0f;
+    constexpr float query_sum_squares = 90.0f;
+    uint8_t *query_meta = reinterpret_cast<uint8_t *>(query.data() + dim);
+    store_float(query_meta + sq8::SUM_QUERY * sizeof(float), query_sum);
+    store_float(query_meta + sq8::SUM_SQUARES_QUERY * sizeof(float), query_sum_squares);
+
+    const auto *storage_sum_squares_addr =
+        storage_meta + sq8::SUM_SQUARES * sizeof(float);
+    const auto *query_sum_squares_addr =
+        query_meta + sq8::SUM_SQUARES_QUERY * sizeof(float);
+    ASSERT_NE(reinterpret_cast<std::uintptr_t>(storage_sum_squares_addr) % alignof(float), 0u);
+    ASSERT_NE(reinterpret_cast<std::uintptr_t>(query_sum_squares_addr) % alignof(float), 0u);
+
+    const float dist = SQ8_FP16_L2Sqr(storage.data(), query.data(), dim);
+
+    ASSERT_FLOAT_EQ(dist, 5.0f);
 }
 
 /* ======================== Test Getters ======================== */

--- a/tests/utils/tests_utils.h
+++ b/tests/utils/tests_utils.h
@@ -15,6 +15,7 @@
 #include "VecSim/spaces/spaces.h"
 #include "VecSim/types/float16.h"
 #include "VecSim/types/sq8.h"
+#include "VecSim/utils/alignment.h"
 
 using sq8 = vecsim_types::sq8;
 
@@ -270,8 +271,10 @@ static float SQ8_FP16_NotOptimized_InnerProduct(const void *pVect1v, const void 
     const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);               // SQ8 storage
     const auto *pVect2 = static_cast<const vecsim_types::float16 *>(pVect2v); // FP16 query
 
-    const float min_val = *reinterpret_cast<const float *>(pVect1 + dimension);
-    const float delta = *reinterpret_cast<const float *>(pVect1 + dimension + sizeof(float));
+    // Storage metadata sits at byte offset `dimension` into the uint8 buffer and is not
+    // guaranteed 4-byte aligned for odd `dimension`; use load_unaligned to avoid alignment UB.
+    const float min_val = load_unaligned<float>(pVect1 + dimension + sq8::MIN_VAL * sizeof(float));
+    const float delta = load_unaligned<float>(pVect1 + dimension + sq8::DELTA * sizeof(float));
 
     float res = 0.0f;
     for (size_t i = 0; i < dimension; i++) {
@@ -303,16 +306,15 @@ static float SQ8_FP16_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2
     const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);
     const auto *pVect2 = static_cast<const vecsim_types::float16 *>(pVect2v);
 
-    const float min_val = *reinterpret_cast<const float *>(pVect1 + dimension);
-    const float delta = *reinterpret_cast<const float *>(pVect1 + dimension + sizeof(float));
-    const float *storage_meta = reinterpret_cast<const float *>(pVect1 + dimension);
-    const float x_sum_sq = storage_meta[sq8::SUM_SQUARES];
-    // FP32 metadata after the dim float16 values is only 2-byte aligned for odd dim, so use
-    // memcpy to avoid undefined behavior / faults from misaligned float loads.
+    // Storage and query metadata sit at byte offsets that are not guaranteed 4-byte aligned
+    // for odd `dimension`; use load_unaligned to avoid alignment UB.
+    const float min_val = load_unaligned<float>(pVect1 + dimension + sq8::MIN_VAL * sizeof(float));
+    const float delta = load_unaligned<float>(pVect1 + dimension + sq8::DELTA * sizeof(float));
+    const float x_sum_sq =
+        load_unaligned<float>(pVect1 + dimension + sq8::SUM_SQUARES * sizeof(float));
     const auto *query_meta_bytes = reinterpret_cast<const uint8_t *>(pVect2 + dimension);
-    float y_sum_sq;
-    std::memcpy(&y_sum_sq, query_meta_bytes + sq8::SUM_SQUARES_QUERY * sizeof(float),
-                sizeof(float));
+    const float y_sum_sq =
+        load_unaligned<float>(query_meta_bytes + sq8::SUM_SQUARES_QUERY * sizeof(float));
 
     float ip = 0.0f;
     for (size_t i = 0; i < dimension; i++) {

--- a/tests/utils/tests_utils.h
+++ b/tests/utils/tests_utils.h
@@ -256,6 +256,107 @@ static float SQ8_FP32_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2
     }
     return res;
 }
+/*
+ * SQ8-FP16 inner product distance reference implementation without algebraic optimizations.
+ * Uses element-wise dequantization of the SQ8 storage and widens FP16 query values to FP32:
+ * IP = Σ((min + delta * q_i) * FP16_to_FP32(y_i))
+ * pVect1 = SQ8 storage (quantized values + metadata)
+ * pVect2 = FP16 query (float16 values + FP32 metadata)
+ */
+static float SQ8_FP16_NotOptimized_InnerProduct(const void *pVect1v, const void *pVect2v,
+                                                size_t dimension) {
+
+    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);            // SQ8 storage
+    const auto *pVect2 = static_cast<const vecsim_types::float16 *>(pVect2v); // FP16 query
+
+    const float min_val = *reinterpret_cast<const float *>(pVect1 + dimension);
+    const float delta = *reinterpret_cast<const float *>(pVect1 + dimension + sizeof(float));
+
+    float res = 0.0f;
+    for (size_t i = 0; i < dimension; i++) {
+        res += (pVect1[i] * delta + min_val) * vecsim_types::FP16_to_FP32(pVect2[i]);
+    }
+    return 1.0f - res;
+}
+
+/*
+ * SQ8-FP16 cosine reference. For normalized vectors, cosine equals inner product distance.
+ */
+static float SQ8_FP16_NotOptimized_Cosine(const void *pVect1v, const void *pVect2v,
+                                          size_t dimension) {
+    return SQ8_FP16_NotOptimized_InnerProduct(pVect1v, pVect2v, dimension);
+}
+
+/*
+ * SQ8-FP16 L2 squared reference implementation without algebraic optimizations.
+ * Mirrors the algebraic identity used by the optimized kernel:
+ *   L2² = ||x_orig||² + ||y||² - 2 * Σ(dequant(x_i) * FP16_to_FP32(y_i))
+ * where ||x_orig||² is the SUM_SQUARES precomputed from the *original* (pre-quantization)
+ * floats and stored in the SQ8 metadata, and ||y||² is the SUM_SQUARES_QUERY computed
+ * from the FP16-widened-to-FP32 query values. This intentionally differs from a pure
+ * Σ(y - dequant(x))² by a quantization-error term that grows with dim, since the
+ * production storage stores the pre-quantization norm.
+ */
+static float SQ8_FP16_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2v,
+                                         size_t dimension) {
+    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);
+    const auto *pVect2 = static_cast<const vecsim_types::float16 *>(pVect2v);
+
+    const float min_val = *reinterpret_cast<const float *>(pVect1 + dimension);
+    const float delta = *reinterpret_cast<const float *>(pVect1 + dimension + sizeof(float));
+    const float *storage_meta = reinterpret_cast<const float *>(pVect1 + dimension);
+    const float x_sum_sq = storage_meta[sq8::SUM_SQUARES];
+    const float *query_meta = reinterpret_cast<const float *>(pVect2 + dimension);
+    const float y_sum_sq = query_meta[sq8::SUM_SQUARES_QUERY];
+
+    float ip = 0.0f;
+    for (size_t i = 0; i < dimension; i++) {
+        const float dequantized = pVect1[i] * delta + min_val;
+        ip += dequantized * vecsim_types::FP16_to_FP32(pVect2[i]);
+    }
+    return x_sum_sq + y_sum_sq - 2.0f * ip;
+}
+
+// Preprocess FP16 query for SQ8 IP/Cosine/L2 space.
+// Query layout: [float16 values (dim)] [sum (float)] [sum_squares (float)]
+// `buf` must be at least
+//   dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float)
+// bytes (defaults to L2 layout, sufficient for IP/Cosine).
+// The metadata is computed from the FP16 values widened back to FP32, so it matches
+// what the SQ8-FP16 distance kernels will accumulate.
+static void preprocess_sq8_fp16_query(void *buf, size_t dim) {
+    auto *values = static_cast<vecsim_types::float16 *>(buf);
+    float sum = 0.0f;
+    float sum_squares = 0.0f;
+    for (size_t i = 0; i < dim; i++) {
+        const float widened = vecsim_types::FP16_to_FP32(values[i]);
+        sum += widened;
+        sum_squares += widened * widened;
+    }
+    auto *metadata = reinterpret_cast<float *>(values + dim);
+    metadata[sq8::SUM_QUERY] = sum;
+    metadata[sq8::SUM_SQUARES_QUERY] = sum_squares;
+}
+
+// Populate an FP16 query buffer for SQ8 IP/Cosine/L2 space.
+// `buf` must be at least
+//   dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float)
+// bytes. Generates float values, optionally normalizes them in FP32 (matching the
+// FP32 query helper), converts to FP16, then computes FP32 metadata.
+static void populate_sq8_fp16_query(void *buf, size_t dim, bool should_normalize = false,
+                                    int seed = 1234, float min = -1.0f, float max = 1.0f) {
+    std::vector<float> tmp(dim);
+    populate_float_vec(tmp.data(), dim, seed, min, max);
+    if (should_normalize) {
+        spaces::GetNormalizeFunc<float>()(tmp.data(), dim);
+    }
+    auto *values = static_cast<vecsim_types::float16 *>(buf);
+    for (size_t i = 0; i < dim; i++) {
+        values[i] = vecsim_types::FP32_to_FP16(tmp[i]);
+    }
+    preprocess_sq8_fp16_query(buf, dim);
+}
+
 /**
  * Populate a float vector and quantize to SQ8 with precomputed sum and sum_squares.
  * Vector layout: [uint8_t values (dim)] [min (float)] [delta (float)] [sum (float)] [sum_squares

--- a/tests/utils/tests_utils.h
+++ b/tests/utils/tests_utils.h
@@ -266,7 +266,7 @@ static float SQ8_FP32_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2
 static float SQ8_FP16_NotOptimized_InnerProduct(const void *pVect1v, const void *pVect2v,
                                                 size_t dimension) {
 
-    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);            // SQ8 storage
+    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);               // SQ8 storage
     const auto *pVect2 = static_cast<const vecsim_types::float16 *>(pVect2v); // FP16 query
 
     const float min_val = *reinterpret_cast<const float *>(pVect1 + dimension);

--- a/tests/utils/tests_utils.h
+++ b/tests/utils/tests_utils.h
@@ -268,8 +268,10 @@ static float SQ8_FP32_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2
 static float SQ8_FP16_NotOptimized_InnerProduct(const void *pVect1v, const void *pVect2v,
                                                 size_t dimension) {
 
-    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);               // SQ8 storage
-    const auto *pVect2 = static_cast<const vecsim_types::float16 *>(pVect2v); // FP16 query
+    const auto *pVect1 = static_cast<const uint8_t *>(pVect1v); // SQ8 storage
+    // FP16 query buffer may be only 1-byte aligned (e.g. backed by std::vector<uint8_t>),
+    // so access float16 values via memcpy on uint16_t to avoid alignment UB.
+    const auto *pVect2 = static_cast<const uint8_t *>(pVect2v); // FP16 query
 
     // Storage metadata sits at byte offset `dimension` into the uint8 buffer and is not
     // guaranteed 4-byte aligned for odd `dimension`; use load_unaligned to avoid alignment UB.
@@ -278,7 +280,10 @@ static float SQ8_FP16_NotOptimized_InnerProduct(const void *pVect1v, const void 
 
     float res = 0.0f;
     for (size_t i = 0; i < dimension; i++) {
-        res += (pVect1[i] * delta + min_val) * vecsim_types::FP16_to_FP32(pVect2[i]);
+        uint16_t raw;
+        std::memcpy(&raw, pVect2 + i * sizeof(vecsim_types::float16), sizeof(raw));
+        res += (pVect1[i] * delta + min_val) *
+               vecsim_types::FP16_to_FP32(vecsim_types::float16{raw});
     }
     return 1.0f - res;
 }
@@ -304,7 +309,9 @@ static float SQ8_FP16_NotOptimized_Cosine(const void *pVect1v, const void *pVect
 static float SQ8_FP16_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2v,
                                          size_t dimension) {
     const auto *pVect1 = static_cast<const uint8_t *>(pVect1v);
-    const auto *pVect2 = static_cast<const vecsim_types::float16 *>(pVect2v);
+    // FP16 query buffer may be only 1-byte aligned; access float16 values via memcpy on
+    // uint16_t to avoid alignment UB on strict-alignment targets.
+    const auto *pVect2 = static_cast<const uint8_t *>(pVect2v);
 
     // Storage and query metadata sit at byte offsets that are not guaranteed 4-byte aligned
     // for odd `dimension`; use load_unaligned to avoid alignment UB.
@@ -312,14 +319,16 @@ static float SQ8_FP16_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2
     const float delta = load_unaligned<float>(pVect1 + dimension + sq8::DELTA * sizeof(float));
     const float x_sum_sq =
         load_unaligned<float>(pVect1 + dimension + sq8::SUM_SQUARES * sizeof(float));
-    const auto *query_meta_bytes = reinterpret_cast<const uint8_t *>(pVect2 + dimension);
+    const auto *query_meta_bytes = pVect2 + dimension * sizeof(vecsim_types::float16);
     const float y_sum_sq =
         load_unaligned<float>(query_meta_bytes + sq8::SUM_SQUARES_QUERY * sizeof(float));
 
     float ip = 0.0f;
     for (size_t i = 0; i < dimension; i++) {
+        uint16_t raw;
+        std::memcpy(&raw, pVect2 + i * sizeof(vecsim_types::float16), sizeof(raw));
         const float dequantized = pVect1[i] * delta + min_val;
-        ip += dequantized * vecsim_types::FP16_to_FP32(pVect2[i]);
+        ip += dequantized * vecsim_types::FP16_to_FP32(vecsim_types::float16{raw});
     }
     return x_sum_sq + y_sum_sq - 2.0f * ip;
 }
@@ -331,18 +340,21 @@ static float SQ8_FP16_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2
 // bytes (defaults to L2 layout, sufficient for IP/Cosine).
 // The metadata is computed from the FP16 values widened back to FP32, so it matches
 // what the SQ8-FP16 distance kernels will accumulate.
+// `buf` may be only 1-byte aligned (callers commonly back it with std::vector<uint8_t>),
+// so FP16 values and FP32 metadata are accessed via memcpy to avoid alignment UB on
+// strict-alignment targets.
 static void preprocess_sq8_fp16_query(void *buf, size_t dim) {
-    auto *values = static_cast<vecsim_types::float16 *>(buf);
+    auto *bytes = static_cast<uint8_t *>(buf);
     float sum = 0.0f;
     float sum_squares = 0.0f;
     for (size_t i = 0; i < dim; i++) {
-        const float widened = vecsim_types::FP16_to_FP32(values[i]);
+        uint16_t raw;
+        std::memcpy(&raw, bytes + i * sizeof(vecsim_types::float16), sizeof(raw));
+        const float widened = vecsim_types::FP16_to_FP32(vecsim_types::float16{raw});
         sum += widened;
         sum_squares += widened * widened;
     }
-    // FP32 metadata after the dim float16 values is only 2-byte aligned for odd dim, so use
-    // memcpy to avoid undefined behavior / faults from misaligned float stores.
-    auto *metadata_bytes = reinterpret_cast<uint8_t *>(values + dim);
+    auto *metadata_bytes = bytes + dim * sizeof(vecsim_types::float16);
     std::memcpy(metadata_bytes + sq8::SUM_QUERY * sizeof(float), &sum, sizeof(float));
     std::memcpy(metadata_bytes + sq8::SUM_SQUARES_QUERY * sizeof(float), &sum_squares,
                 sizeof(float));
@@ -353,6 +365,8 @@ static void preprocess_sq8_fp16_query(void *buf, size_t dim) {
 //   dim * sizeof(float16) + sq8::query_metadata_count<VecSimMetric_L2>() * sizeof(float)
 // bytes. Generates float values, optionally normalizes them in FP32 (matching the
 // FP32 query helper), converts to FP16, then computes FP32 metadata.
+// `buf` may be only 1-byte aligned; FP16 stores go through memcpy on uint16_t to avoid
+// alignment UB on strict-alignment targets.
 static void populate_sq8_fp16_query(void *buf, size_t dim, bool should_normalize = false,
                                     int seed = 1234, float min = -1.0f, float max = 1.0f) {
     std::vector<float> tmp(dim);
@@ -360,9 +374,10 @@ static void populate_sq8_fp16_query(void *buf, size_t dim, bool should_normalize
     if (should_normalize) {
         spaces::GetNormalizeFunc<float>()(tmp.data(), dim);
     }
-    auto *values = static_cast<vecsim_types::float16 *>(buf);
+    auto *bytes = static_cast<uint8_t *>(buf);
     for (size_t i = 0; i < dim; i++) {
-        values[i] = vecsim_types::FP32_to_FP16(tmp[i]);
+        const uint16_t raw = vecsim_types::FP32_to_FP16(tmp[i]).val;
+        std::memcpy(bytes + i * sizeof(vecsim_types::float16), &raw, sizeof(raw));
     }
     preprocess_sq8_fp16_query(buf, dim);
 }

--- a/tests/utils/tests_utils.h
+++ b/tests/utils/tests_utils.h
@@ -282,8 +282,8 @@ static float SQ8_FP16_NotOptimized_InnerProduct(const void *pVect1v, const void 
     for (size_t i = 0; i < dimension; i++) {
         uint16_t raw;
         std::memcpy(&raw, pVect2 + i * sizeof(vecsim_types::float16), sizeof(raw));
-        res += (pVect1[i] * delta + min_val) *
-               vecsim_types::FP16_to_FP32(vecsim_types::float16{raw});
+        res +=
+            (pVect1[i] * delta + min_val) * vecsim_types::FP16_to_FP32(vecsim_types::float16{raw});
     }
     return 1.0f - res;
 }

--- a/tests/utils/tests_utils.h
+++ b/tests/utils/tests_utils.h
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include <cstring>
 #include <random>
 #include <vector>
 #include "VecSim/spaces/normalize/compute_norm.h"
@@ -306,8 +307,12 @@ static float SQ8_FP16_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2
     const float delta = *reinterpret_cast<const float *>(pVect1 + dimension + sizeof(float));
     const float *storage_meta = reinterpret_cast<const float *>(pVect1 + dimension);
     const float x_sum_sq = storage_meta[sq8::SUM_SQUARES];
-    const float *query_meta = reinterpret_cast<const float *>(pVect2 + dimension);
-    const float y_sum_sq = query_meta[sq8::SUM_SQUARES_QUERY];
+    // FP32 metadata after the dim float16 values is only 2-byte aligned for odd dim, so use
+    // memcpy to avoid undefined behavior / faults from misaligned float loads.
+    const auto *query_meta_bytes = reinterpret_cast<const uint8_t *>(pVect2 + dimension);
+    float y_sum_sq;
+    std::memcpy(&y_sum_sq, query_meta_bytes + sq8::SUM_SQUARES_QUERY * sizeof(float),
+                sizeof(float));
 
     float ip = 0.0f;
     for (size_t i = 0; i < dimension; i++) {
@@ -333,9 +338,12 @@ static void preprocess_sq8_fp16_query(void *buf, size_t dim) {
         sum += widened;
         sum_squares += widened * widened;
     }
-    auto *metadata = reinterpret_cast<float *>(values + dim);
-    metadata[sq8::SUM_QUERY] = sum;
-    metadata[sq8::SUM_SQUARES_QUERY] = sum_squares;
+    // FP32 metadata after the dim float16 values is only 2-byte aligned for odd dim, so use
+    // memcpy to avoid undefined behavior / faults from misaligned float stores.
+    auto *metadata_bytes = reinterpret_cast<uint8_t *>(values + dim);
+    std::memcpy(metadata_bytes + sq8::SUM_QUERY * sizeof(float), &sum, sizeof(float));
+    std::memcpy(metadata_bytes + sq8::SUM_SQUARES_QUERY * sizeof(float), &sum_squares,
+                sizeof(float));
 }
 
 // Populate an FP16 query buffer for SQ8 IP/Cosine/L2 space.


### PR DESCRIPTION
**Describe the changes in the pull request**

Adds asymmetric SQ8-to-FP16 distance support (scalar path only) for L2, IP, and Cosine, where stored vectors are SQ8-quantized (uint8 + FP32 metadata) and queries are FP16. This is the first step (P1a) of [MOD-15141](https://redislabs.atlassian.net/browse/MOD-15141); SIMD kernels (P1b/P1c) and `QuantPreprocessor` FP16 input support (P1a-2) are intentionally out of scope and tracked as follow-ups.

The scalar kernels use the algebraic identity `dist = ||x||² + ||y||² - 2 * IP(x, y)` with precomputed FP32 sums-of-squares stored alongside both the SQ8 storage and FP16 query, which keeps the quantization-error path consistent between the kernel and the test baseline. Each FP16 query element is widened to FP32 during accumulation; SQ8 metadata (`min`, `delta`, `x_sum`, `x_sum_squares`) and FP16 query metadata (`y_sum`, `y_sum_squares`) are read as FP32.

The new `GetDistFunc<sq8, float, float16>` specialization routes through `IP_SQ8_FP16_GetDistFunc`, `Cosine_SQ8_FP16_GetDistFunc`, and `L2_SQ8_FP16_GetDistFunc`. These dispatchers currently always return the scalar implementation; SIMD chooser slots are reserved for P1b (MOD-15152) and P1c (MOD-15153).

**Which issues this PR fixes**
1. MOD-15141

**Main objects this PR modified**
1. `src/VecSim/spaces/IP/IP.{h,cpp}` — adds `SQ8_FP16_InnerProduct_Impl`, `SQ8_FP16_InnerProduct`, and `SQ8_FP16_Cosine`.
2. `src/VecSim/spaces/L2/L2.{h,cpp}` — adds `SQ8_FP16_L2Sqr` using the algebraic identity over the precomputed sums-of-squares.
3. `src/VecSim/spaces/IP_space.{h,cpp}` — adds `IP_SQ8_FP16_GetDistFunc` and `Cosine_SQ8_FP16_GetDistFunc` dispatchers.
4. `src/VecSim/spaces/L2_space.{h,cpp}` — adds `L2_SQ8_FP16_GetDistFunc` dispatcher.
5. `src/VecSim/spaces/spaces.cpp` — adds the `GetDistFunc<vecsim_types::sq8, float, vecsim_types::float16>` specialization wiring L2/IP/Cosine to the new dispatchers.
6. `tests/utils/tests_utils.h` — adds `populate_sq8_fp16_query` and `SQ8_FP16_NotOptimized_{InnerProduct,Cosine,L2Sqr}` baselines (the L2 baseline mirrors the kernel's algebraic identity to avoid quantization-error drift at high `dim`).
7. `tests/unit/test_spaces.cpp` — adds `SQ8_FP16_NoOptimizationSpacesTest` parameterized over 19 dimensions (including odd and SIMD-boundary residues: 1, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33, 47, 48, 49, 63, 64, 65, 127, 128) for L2/IP/Cosine, plus `SQ8_FP16_EdgeCases` (zero query, constant storage, mixed-sign), `SpacesTest.GetDistFuncSQ8FP16Asymmetric`, and `SpacesTest.GetDistFuncInvalidMetricSQ8ToFP16`.
8. `tests/benchmark/spaces_benchmarks/bm_spaces_sq8_fp16.cpp` (new) + `tests/benchmark/CMakeLists.txt` — registers naive scalar benchmarks for L2/IP/Cosine; SIMD benchmark blocks will be added by P1b/P1c when the chooser symbols become available.

**Test results**
- All 1096 `test_spaces` tests pass locally.
- `bm_spaces_sq8_fp16` builds and runs successfully.

**Follow-ups (separate stories, out of scope here)**
- MOD-15152 (P1b) — x86 SIMD kernels (AVX2 / AVX512 / AVX512_VNNI / SSE4) and benchmark wiring.
- MOD-15153 (P1c) — ARM SIMD kernels (NEON / SVE / SVE2) and benchmark wiring.
- MOD-15141 P1a-2 — `QuantPreprocessor` FP16 input support (no plumbing into the index types yet).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


[MOD-15141]: https://redislabs.atlassian.net/browse/MOD-15141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core distance computation and dispatch for a new datatype combination; primary risk is subtle correctness/UB issues around mixed-type layouts and unaligned metadata reads, mitigated by added `load_unaligned` and broad test coverage.
> 
> **Overview**
> Adds asymmetric **SQ8 storage + FP16 query** support for `IP`, `Cosine`, and `L2` by introducing new scalar kernels (`SQ8_FP16_InnerProduct_Impl`/`SQ8_FP16_InnerProduct`/`SQ8_FP16_Cosine` and `SQ8_FP16_L2Sqr`) that widen FP16 elements to FP32 and use precomputed SQ8/query metadata.
> 
> Wires the new mode into the public dispatch path via `GetDistFunc<sq8, float, float16>` and new `*_SQ8_FP16_GetDistFunc` helpers (currently always returning scalar implementations), and adds `load_unaligned` to safely read trailing FP32 metadata for odd dimensions.
> 
> Extends validation and performance tooling with a new `bm_spaces_sq8_fp16` benchmark target plus unit tests (including odd-dimension unaligned-metadata and edge cases) and new SQ8-FP16 baseline/query-population utilities in `tests_utils.h`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304450db202fd8f1629099cd141534ab48f3ee9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->