### PR TITLE
Fix -Wmaybe-uninitialized with GCC 16 in CHOOSE_IMPLEMENTATION macros

### DIFF
--- a/src/VecSim/spaces/functions/implementation_chooser.h
+++ b/src/VecSim/spaces/functions/implementation_chooser.h
@@ -50,7 +50,7 @@
 #define CHOOSE_IMPLEMENTATION(out, dim, chunk, func)                                               \
     do {                                                                                           \
         decltype(out) __ret_dist_func;                                                             \
-        switch ((dim) % (chunk)) { CASES##chunk(func) }                                            \
+        switch ((dim) % (chunk)) { CASES##chunk(func) default: __builtin_unreachable(); }          \
         out = __ret_dist_func;                                                                     \
     } while (0)
 
@@ -74,6 +74,7 @@
             SVE_CASE(base_func, 1);                                                                \
             SVE_CASE(base_func, 2);                                                                \
             SVE_CASE(base_func, 3);                                                                \
+            default: __builtin_unreachable();                                                      \
         }                                                                                          \
         out = __ret_dist_func;                                                                     \
     } while (0)


### PR DESCRIPTION
GCC 16 improved its uninitialized variable analysis and now warns that `__ret_dist_func` may be used uninitialized: the switch is exhaustive (e.g. `CASES16` covers exactly 0-15 and `dim % 16` can only produce 0-15), but GCC cannot prove this from the recursive macro expansion.

Add `default: __builtin_unreachable()` to both `CHOOSE_IMPLEMENTATION` and `CHOOSE_SVE_IMPLEMENTATION` to explicitly signal to the compiler that no other case is reachable, allowing it to conclude the variable is always initialized before use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, compile-time-only change adding `default: __builtin_unreachable()` to exhaustive switch macros to satisfy newer GCC uninitialized-variable analysis. Runtime behavior should be unchanged unless invariants are violated, in which case it becomes UB as intended.
> 
> **Overview**
> Fixes GCC 16 `-Wmaybe-uninitialized` warnings in the SIMD implementation selection macros by making the `switch` statements explicitly exhaustive.
> 
> Adds `default: __builtin_unreachable()` to both `CHOOSE_IMPLEMENTATION` and `CHOOSE_SVE_IMPLEMENTATION`, ensuring `__ret_dist_func` is always considered initialized when the remainder/step calculations are within expected ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a25d9c36de4f3254963eebcc01447e52a901458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->