### PR TITLE
[0.8] Bump GitHub Actions to Node 24 compatible versions [MOD-15112]

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -11,14 +11,14 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -44,13 +44,13 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,11 +32,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -59,4 +59,4 @@ jobs:
     # - run: make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,14 +9,14 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -33,13 +33,13 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: install dependencies
         run: sudo .install/install_script.sh
       - name: run codecov
         run: make coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           file: ./bin/Linux-x86_64-debug/cov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -55,13 +55,13 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -14,9 +14,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: install dependencies
@@ -49,7 +49,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@v0
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -28,10 +28,10 @@ jobs:
         startsWith(github.event.comment.body, '/backport')
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create backport pull requests
         id: backport
-        uses: korthout/backport-action@v2
+        uses: korthout/backport-action@v4
         with:
           pull_title: '[${target_branch}] ${pull_title}'
           merge_commits: 'skip'

--- a/.github/workflows/task-unit-test.yml
+++ b/.github/workflows/task-unit-test.yml
@@ -33,7 +33,7 @@ jobs:
         shell: sh -l -eo pipefail {0}
         run: ${{ inputs.pre-checkout-script }}
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || github.head_ref }}
       - name: install dependencies
@@ -57,7 +57,7 @@ jobs:
           echo "path=bin/${FULL_VARIANT}/unit_tests/Testing/Temporary/" >> $GITHUB_OUTPUT
       - name: Archive san tests reports
         if: ${{ inputs.san  == 'address' && failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: san tests reports on ${{ steps.artifact-name.outputs.name }}
           path: ${{ steps.tests-artifact-path.outputs.path }}


### PR DESCRIPTION
**Describe the changes in the pull request**

Manual backport of #947 to `0.8`. The automated backport failed due to conflicts.

Migrates JavaScript-based GitHub Actions to versions running on the Node 24 runtime, ahead of the [June 2, 2026 Node 20 deprecation](https://github.blog/changelog/2025-09-23-actions-deprecating-node20-runtime-replaced-by-node24/).

Version bumps applied to the workflow files that exist on `0.8`:

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-python` | `v5` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |
| `aws-actions/configure-aws-credentials` | `v4` | `v6` |
| `machulav/ec2-github-runner` | `v2.4.2` | `v2.6.1` |
| `codecov/codecov-action` | `v4` | `v6` |
| `github/codeql-action/*` | `v3` | `v4` |
| `korthout/backport-action` | `v2` | `v4` |
| `release-drafter/release-drafter` | `v6` | `v7` |

Conflict-resolution notes:
- Only the version bumps from #947 were taken; main-only additions (CPU info logging, `Upload Logs` artifact step in PR workflow, sanitizer step in coverage, `notify-on-failure` Slack job in nightly, and `submodules: recursive` adds) were intentionally dropped because they don’t exist on `0.8`.
- `slackapi/slack-github-action` v1→v3 from #947 was dropped because the `notify-on-failure` job doesn’t exist on `0.8`.
- `benchmark-runner.yml` doesn’t exist on `0.8`, so its changes were skipped.

**Which issues this PR fixes**
1. MOD-15112

**Main objects this PR modified**
1. `.github/workflows/arm.yml`
2. `.github/workflows/codeql-analysis.yml`
3. `.github/workflows/coverage.yml`
4. `.github/workflows/event-pull_request.yml`
5. `.github/workflows/release-drafter.yml`
6. `.github/workflows/task-backport_pr.yml`
7. `.github/workflows/task-unit-test.yml`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only bumps GitHub Action versions in CI workflows, but could affect CI behavior if any new action defaults/inputs change.
> 
> **Overview**
> Upgrades GitHub Actions versions across the repo’s CI workflows to Node 24–compatible releases.
> 
> This bumps `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `aws-actions/configure-aws-credentials`, `machulav/ec2-github-runner`, `codecov/codecov-action`, `github/codeql-action/*`, `korthout/backport-action`, and `release-drafter/release-drafter` without changing the workflows’ logic beyond the action version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf77569de9a572d2bf913ad74a78b5b4895933cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->