### PR TITLE
Fix codecov-action input: file -> files [MOD-15112]

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
-          file: ./bin/Linux-x86_64-debug/cov.info
+          files: ./bin/Linux-x86_64-debug/cov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_safe_directory: true
           disable_search: true


### PR DESCRIPTION
**Describe the changes in the pull request**

Follow-up to #947. Renames the `file` input of `codecov/codecov-action` to `files`.

`codecov/codecov-action` removed the `file` input in [v5.0.0](https://github.com/codecov/codecov-action/releases/tag/v5.0.0) (renamed to `files`); v6 (the version we just bumped to) did not reintroduce it - see [v6/action.yml](https://github.com/codecov/codecov-action/blob/v6/action.yml). GitHub Actions silently drops unknown `with:` keys, so the previous `file: ./bin/Linux-x86_64-debug/cov.info` was being ignored. Combined with `disable_search: true`, the action would run successfully and upload no coverage report.

**Which issues this PR fixes**
1. MOD-15112

**Main objects this PR modified**
1. `.github/workflows/coverage.yml`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that corrects a misnamed Codecov action input so coverage reports are actually uploaded.
> 
> **Overview**
> Fixes the Codecov upload step in `.github/workflows/coverage.yml` by renaming the `codecov/codecov-action@v6` input from `file` to `files`, ensuring `cov.info` is actually discovered and uploaded (instead of being silently ignored).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cb890d41555c243e69f88dd7fe82dff96a8aa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->