### PR TITLE
ci: temporarily disable focal job in merge-queue and nightly flows

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -11,8 +11,9 @@ jobs:
 
   jammy:
     uses: ./.github/workflows/jammy.yml
-  focal:
-    uses: ./.github/workflows/focal.yml
+# TODO: re-enable once Launchpad PPA flakiness is resolved (pre-built CI image planned).
+#  focal:
+#    uses: ./.github/workflows/focal.yml
 #  bionic:
 #    needs: [check-if-docs-only]
 #    if: ${{ needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}
@@ -46,7 +47,7 @@ jobs:
   pr-validation:
     needs:
       - jammy
-      - focal
+#      - focal
 #      - bionic
       - bullseye
 #      - amazonlinux2

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -14,8 +14,9 @@ jobs:
 
   jammy:
     uses: ./.github/workflows/jammy.yml
-  focal:
-    uses: ./.github/workflows/focal.yml
+  # TODO: re-enable once Launchpad PPA flakiness is resolved (pre-built CI image planned).
+  #  focal:
+  #    uses: ./.github/workflows/focal.yml
   #  bionic:
   #    needs: [check-if-docs-only]
   #    if: ${{ needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}
@@ -53,7 +54,7 @@ jobs:
     needs:
       - benchmark
       - jammy
-      - focal
+#      - focal
 #      - bionic
       - bullseye
 #      - amazonlinux2


### PR DESCRIPTION

**Describe the changes in the pull request**

Comment out the `focal` job (and its corresponding `needs:` entry) in both `event-merge-to-queue.yml` and `event-nightly.yml`, so the merge queue and nightly notifier are no longer blocked by Ubuntu 20.04 CI failures.

For the past several days, Canonical's PPA edge (`ppa.launchpad.net` / `ppa.launchpadcontent.net`, both resolving to `185.125.190.80`) has been intermittently refusing connections, causing `add-apt-repository ppa:ubuntu-toolchain-r/test` to fail in `.install/ubuntu_20.04.sh`. We need that PPA because focal's stock GCC is 9, but the SVS code path requires C++20 features that need GCC ≥ 11 (see `cmake/svs.cmake`). The outage was verified from both the GitHub-hosted runner and a local network, confirming it is upstream and not workflow- or runner-related; no amount of apt retry/timeout/mirror-swap configuration in our workflow can route around it.

`focal.yml` itself is left untouched and remains manually-triggerable via `workflow_dispatch`, so we can keep iterating on a fix (likely a pre-built CI image with `gcc-11` baked in to remove the per-run Launchpad dependency) without re-enabling it in any auto-flow. A `TODO:` comment marks the spot for re-enablement.

**Which issues this PR fixes**
1. N/A — unblocks the merge queue from a transient upstream (Canonical) outage; no internal issue ID.

**Main objects this PR modified**
1. `.github/workflows/event-merge-to-queue.yml` — `focal` job and its entry in `pr-validation.needs` commented out.
2. `.github/workflows/event-nightly.yml` — `focal` job and its entry in `notify-on-failure.needs` commented out.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that removes Ubuntu 20.04 (`focal`) from required job dependencies, which may reduce CI coverage but does not affect runtime code.
> 
> **Overview**
> Temporarily comments out the Ubuntu 20.04 (`focal`) job in `event-merge-to-queue.yml` and `event-nightly.yml`, with a TODO note for re-enabling.
> 
> Updates the aggregate gating jobs (`pr-validation` and `notify-on-failure`) to drop `focal` from their `needs`, so merge-queue validation and nightly notifications no longer wait on `focal` results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 005d600db0ae084bc6c0c01ceda3986cf9e5eaf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->