### PR TITLE
[0.6] ci: temporarily disable focal job in merge-queue and nightly flows (#954)

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -12,10 +12,11 @@ jobs:
     uses: ./.github/workflows/task-unit-test.yml
     with:
       container: ubuntu:jammy
-  focal:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: ubuntu:focal
+# TODO: re-enable once Launchpad PPA flakiness is resolved (pre-built CI image planned).
+#  focal:
+#    uses: ./.github/workflows/task-unit-test.yml
+#    with:
+#      container: ubuntu:focal
 #  bionic:
 #    needs: [check-if-docs-only]
 #    if: ${{ needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}
@@ -63,7 +64,7 @@ jobs:
   pr-validation:
     needs:
       - jammy
-      - focal
+#      - focal
 #      - bionic
 #      - xenial
       - bullseye

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -16,10 +16,11 @@ jobs:
     uses: ./.github/workflows/task-unit-test.yml
     with:
       container: ubuntu:jammy
-  focal:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: ubuntu:focal
+# TODO: re-enable once Launchpad PPA flakiness is resolved (pre-built CI image planned).
+#  focal:
+#    uses: ./.github/workflows/task-unit-test.yml
+#    with:
+#      container: ubuntu:focal
 #  bionic:
 #    uses: ./.github/workflows/task-unit-test.yml
 #    with:


### PR DESCRIPTION
Backport of #954 to `0.6`.

Auto-backport failed because the surrounding workflow YAML differs between branches (on `0.6`, the `jammy`/`focal` jobs call `task-unit-test.yml` directly with a `with: container:` block, rather than via dedicated `jammy.yml`/`focal.yml` reusable workflows on `main`). Conflict resolved manually by:
- Keeping `0.6`'s structure (the 4-line `focal:` job using `task-unit-test.yml` directly).
- Commenting out the same 4 lines (instead of the 2 lines on `main`) plus the `# TODO` marker.
- Commenting out `- focal` in `pr-validation.needs` in `event-merge-to-queue.yml` (auto-applied; same as `main`).
- Skipping the `notify-on-failure` job hunk from `main`'s diff because that job does not exist on `0.6`; backporting it would be scope creep beyond "disable focal".

**Describe the changes in the pull request**

Comment out the `focal` job (and its `pr-validation.needs:` entry) in both `event-merge-to-queue.yml` and `event-nightly.yml`, so the merge queue and nightly are no longer blocked by Ubuntu 20.04 CI failures caused by Canonical's PPA edge intermittently refusing connections.

See #954 for the full root-cause analysis. The fix is identical in spirit; only the file context differs. `focal.yml` does not exist on this branch, so nothing to leave behind for manual triggering — the focal flow on `0.6` is fully dormant until either Launchpad stabilises or a pre-built CI image is introduced.

**Which issues this PR fixes**
1. Backport of #954.

**Main objects this PR modified**
1. `.github/workflows/event-merge-to-queue.yml` — 4-line `focal` job and its `pr-validation.needs:` entry commented out.
2. `.github/workflows/event-nightly.yml` — 4-line `focal` job commented out (no `notify-on-failure` job exists on this branch).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust GitHub Actions workflow configuration to skip the Ubuntu 20.04 (`focal`) CI job; no product/runtime code paths are affected.
> 
> **Overview**
> **Temporarily disables the Ubuntu 20.04 (`focal`) CI run** in both merge-queue (`event-merge-to-queue.yml`) and nightly (`event-nightly.yml`) workflows by commenting out the `focal` job.
> 
> Updates merge-queue gating by removing `focal` from `pr-validation.needs`, and adds a TODO note to re-enable once the external PPA flakiness is resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd6c7ffe1427db3471c4c01807a3252f461db92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->