### PR TITLE
[0.7] ci: temporarily disable focal job in merge-queue and nightly flows (#954)

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -13,10 +13,11 @@ jobs:
     uses: ./.github/workflows/task-unit-test.yml
     with:
       container: ubuntu:jammy
-  focal:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: ubuntu:focal
+# TODO: re-enable once Launchpad PPA flakiness is resolved (pre-built CI image planned).
+#  focal:
+#    uses: ./.github/workflows/task-unit-test.yml
+#    with:
+#      container: ubuntu:focal
 #  bionic:
 #    needs: [check-if-docs-only]
 #    if: ${{ needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}
@@ -58,7 +59,7 @@ jobs:
   pr-validation:
     needs:
       - jammy
-      - focal
+#      - focal
 #      - bionic
       - bullseye
 #       - centos7

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -16,10 +16,11 @@ jobs:
     uses: ./.github/workflows/task-unit-test.yml
     with:
       container: ubuntu:jammy
-  focal:
-    uses: ./.github/workflows/task-unit-test.yml
-    with:
-      container: ubuntu:focal
+# TODO: re-enable once Launchpad PPA flakiness is resolved (pre-built CI image planned).
+#  focal:
+#    uses: ./.github/workflows/task-unit-test.yml
+#    with:
+#      container: ubuntu:focal
 #  bionic:
 #    uses: ./.github/workflows/task-unit-test.yml
 #    with:


### PR DESCRIPTION
Backport of #954 to `0.7`.

Auto-backport failed because the surrounding workflow YAML differs between branches (on `0.7`, the `jammy`/`focal` jobs call `task-unit-test.yml` directly with a `with: container:` block, rather than via dedicated `jammy.yml`/`focal.yml` reusable workflows on `main`). Conflict resolved manually by:
- Keeping `0.7`'s structure (the 4-line `focal:` job using `task-unit-test.yml` directly).
- Commenting out the same 4 lines (instead of the 2 lines on `main`) plus the `# TODO` marker.
- Commenting out `- focal` in `pr-validation.needs` in `event-merge-to-queue.yml` (auto-applied; same as `main`).
- Skipping the `notify-on-failure` job hunk from `main`'s diff because that job does not exist on `0.7`; backporting it would be scope creep beyond "disable focal".

Resolution is identical to the one applied for the `0.6` backport (#955).

**Describe the changes in the pull request**

Comment out the `focal` job (and its `pr-validation.needs:` entry) in both `event-merge-to-queue.yml` and `event-nightly.yml`, so the merge queue and nightly are no longer blocked by Ubuntu 20.04 CI failures caused by Canonical's PPA edge intermittently refusing connections.

See #954 for the full root-cause analysis. The fix is identical in spirit; only the file context differs. `focal.yml` does not exist on this branch, so nothing to leave behind for manual triggering — the focal flow on `0.7` is fully dormant until either Launchpad stabilises or a pre-built CI image is introduced.

**Which issues this PR fixes**
1. Backport of #954.

**Main objects this PR modified**
1. `.github/workflows/event-merge-to-queue.yml` — 4-line `focal` job and its `pr-validation.needs:` entry commented out.
2. `.github/workflows/event-nightly.yml` — 4-line `focal` job commented out (no `notify-on-failure` job exists on this branch).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that reduce CI coverage by skipping the `focal` run, but do not affect product/runtime behavior.
> 
> **Overview**
> Disables the Ubuntu 20.04 `focal` unit-test job in both merge-queue (`event-merge-to-queue.yml`) and nightly (`event-nightly.yml`) workflows, with a TODO note to re-enable once upstream flakiness is resolved.
> 
> Updates merge-queue gating by removing `focal` from `pr-validation.needs`, so merge-queue validation no longer waits on that job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c02ba6e67de0f5030917f0195c84edba69b0a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->