### PR TITLE
[8.4] ci: temporarily disable focal job in merge-queue and nightly flows (#954)

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -11,8 +11,9 @@ jobs:
 
   jammy:
     uses: ./.github/workflows/jammy.yml
-  focal:
-    uses: ./.github/workflows/focal.yml
+# TODO: re-enable once Launchpad PPA flakiness is resolved (pre-built CI image planned).
+#  focal:
+#    uses: ./.github/workflows/focal.yml
 #  bionic:
 #    needs: [check-if-docs-only]
 #    if: ${{ needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}
@@ -46,7 +47,7 @@ jobs:
   pr-validation:
     needs:
       - jammy
-      - focal
+#      - focal
 #      - bionic
       - bullseye
 #      - amazonlinux2

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -14,8 +14,9 @@ jobs:
 
   jammy:
     uses: ./.github/workflows/jammy.yml
-  focal:
-    uses: ./.github/workflows/focal.yml
+  # TODO: re-enable once Launchpad PPA flakiness is resolved (pre-built CI image planned).
+  #  focal:
+  #    uses: ./.github/workflows/focal.yml
   #  bionic:
   #    needs: [check-if-docs-only]
   #    if: ${{ needs.check-if-docs-only.outputs.only-docs-changed == 'false' }}
@@ -53,7 +54,7 @@ jobs:
     needs:
       - benchmark
       - jammy
-      - focal
+#      - focal
 #      - bionic
       - bullseye
 #      - amazonlinux2


### PR DESCRIPTION
Backport of #954 to `8.4`.

Auto-backport reported `Git push to origin failed for backport-954-to-8.4 with exitcode 1`. The cherry-pick itself applies cleanly on `8.4` (workflow shape matches `main`); the failure was on the bot's `git push` step, almost certainly a permissions/branch-protection issue specific to the backport bot's GitHub App on the `8.x` branches. A manual push as the PR author succeeds, so this PR is opened that way.

**Describe the changes in the pull request**

Comment out the `focal` job (and its `pr-validation.needs:` entry) in both `event-merge-to-queue.yml` and `event-nightly.yml`, so the merge queue and nightly are no longer blocked by Ubuntu 20.04 CI failures caused by Canonical's PPA edge intermittently refusing connections.

See #954 for the full root-cause analysis. Diff is identical to `main`'s (and to the `0.6` (#955), `0.7` (#956), `0.8` (#957), `8.2` backports modulo the workflow-shape differences).

**Which issues this PR fixes**
1. Backport of #954.

**Main objects this PR modified**
1. `.github/workflows/event-merge-to-queue.yml` — `focal` job and its `pr-validation.needs:` entry commented out; `# TODO` re-enable marker added.
2. `.github/workflows/event-nightly.yml` — `focal` job and its `notify-on-failure.needs:` entry commented out.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow orchestration, removing the Ubuntu 20.04 (`focal`) CI leg from gating/notification dependencies.
> 
> **Overview**
> **Temporarily disables Ubuntu 20.04 CI** by commenting out the `focal` job in `event-merge-to-queue.yml` and `event-nightly.yml`.
> 
> Updates downstream dependency lists (`pr-validation.needs` and `notify-on-failure.needs`) to stop requiring `focal`, and adds a TODO note to re-enable later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dffd436858f42df9be94514c1b84e336e82bea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->