### PR TITLE
[8.2] Bump GitHub Actions to Node 24 compatible versions [MOD-15112]

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -11,14 +11,14 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -44,13 +44,13 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -24,14 +24,14 @@ jobs:
       ec2_instance_id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION_BENCHMARK }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
       - name: Pre checkout deps
         run:  sudo apt-get update && sudo apt-get -y install git
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Print runner info
@@ -96,13 +96,13 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION_BENCHMARK }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -48,7 +48,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -60,4 +60,4 @@ jobs:
     # - run: make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
-          file: ./bin/Linux-x86_64-debug/cov.info
+          files: ./bin/Linux-x86_64-debug/cov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_safe_directory: true
           disable_search: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,14 +9,14 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION_BENCHMARK }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
       - name: Pre checkout deps
         run:  sudo apt-get update && sudo apt-get install -y git
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Print CPU information
@@ -67,7 +67,7 @@ jobs:
       - name: run codecov
         run: make coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           file: ./bin/Linux-x86_64-debug/cov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
           echo "path=bin/${FULL_VARIANT}/unit_tests/Testing/Temporary/" >> $GITHUB_OUTPUT
       - name: Archive san tests reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: san tests reports on intel
           path: ${{ steps.tests-artifact-path.outputs.path }}
@@ -97,13 +97,13 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION_BENCHMARK }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -69,8 +69,8 @@ jobs:
     if: failure()
     steps:
       - name: Notify on failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
-          payload: '{ "failed_run": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" }'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILURE }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILURE }}
+          webhook-type: incoming-webhook
+          payload: '{ "failed_run": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}", "repository": "${{github.repository}}" }'

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -14,7 +14,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Print CPU information
@@ -31,7 +31,7 @@ jobs:
           echo "Runner Architecture: ${{ runner.arch }}"
           echo "========================"
       - name: setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: install dependencies
@@ -44,11 +44,10 @@ jobs:
         run: make unit_test
       - name: flow tests
         run: make flow_test VERBOSE=1
-            # Using version 4 if node20 is supported, since it is MUCH faster (15m vs 25s)
       - name: Upload Logs
         # Upload artifacts only if flow tests failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test Logs
           path: |
@@ -74,7 +73,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Spellcheck

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,5 @@ jobs:
       - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-           config-name: release-drafter-config.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          config-name: release-drafter-config.yml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -28,12 +28,12 @@ jobs:
         startsWith(github.event.comment.body, '/backport')
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Create backport pull requests
         id: backport
-        uses: korthout/backport-action@v3
+        uses: korthout/backport-action@v4
         with:
           pull_title: '[${target_branch}] ${pull_title}'
           merge_commits: 'skip'

--- a/.github/workflows/task-unit-test.yml
+++ b/.github/workflows/task-unit-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: pre-checkout script
         run: ${{ inputs.pre-checkout-script }}
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Print CPU information
@@ -76,7 +76,7 @@ jobs:
           echo "path=bin/${FULL_VARIANT}/unit_tests/Testing/Temporary/" >> $GITHUB_OUTPUT
       - name: Archive san tests reports
         if: ${{ inputs.san  == 'address' && failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: san tests reports on ${{ steps.artifact-name.outputs.name }}
           path: ${{ steps.tests-artifact-path.outputs.path }}


### PR DESCRIPTION
**Describe the changes in the pull request**

Manual backport of #947 and #953 to `8.2`. Replaces #952 (which carried the broken `file:` input that #953 fixed). Both upstream changes are squashed into this PR as two commits.

Migrates JavaScript-based GitHub Actions to versions running on the Node 24 runtime, ahead of the [June 2, 2026 Node 20 deprecation](https://github.blog/changelog/2025-09-23-actions-deprecating-node20-runtime-replaced-by-node24/), and uses the correct `files:` input for `codecov/codecov-action@v6`.

Version bumps:

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-python` | `v5` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |
| `aws-actions/configure-aws-credentials` | `v4` | `v6` |
| `machulav/ec2-github-runner` | `v2.4.2` | `v2.6.1` |
| `codecov/codecov-action` | `v4` | `v6` (input renamed `file` → `files`) |
| `github/codeql-action/*` | `v3` | `v4` |
| `korthout/backport-action` | `v3` | `v4` |
| `release-drafter/release-drafter` | `v6` | `v7` |
| `slackapi/slack-github-action` | `v1` | `v3` (input-based webhook config) |

Conflict resolution: took the v3 incoming-webhook variant of the Slack notify step from #947 (replaces the `SLACK_WEBHOOK_URL` env var with `webhook` / `webhook-type` inputs and adds `repository` to the payload).

**Which issues this PR fixes**
1. MOD-15112

**Main objects this PR modified**
1. `.github/workflows/arm.yml`
2. `.github/workflows/benchmark-runner.yml`
3. `.github/workflows/codeql-analysis.yml`
4. `.github/workflows/coverage.yml`
5. `.github/workflows/event-nightly.yml`
6. `.github/workflows/event-pull_request.yml`
7. `.github/workflows/release-drafter.yml`
8. `.github/workflows/task-backport_pr.yml`
9. `.github/workflows/task-unit-test.yml`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/workflow behavior may change due to major-version bumps of multiple GitHub Actions (including AWS EC2 runner management, CodeQL, Codecov, and Slack notifications), which could break builds or notifications if inputs/outputs differ.
> 
> **Overview**
> Modernizes the CI workflows by bumping multiple GitHub Actions to newer major versions (e.g., `actions/checkout`, `setup-python`, `upload-artifact`, `configure-aws-credentials`, `machulav/ec2-github-runner`, `codeql-action`, `release-drafter`, `backport-action`).
> 
> Fixes/aligns action configuration changes: switches Codecov upload to the `files:` input for `codecov/codecov-action@v6`, and updates nightly Slack failure notifications to `slackapi/slack-github-action@v3` using input-based incoming-webhook configuration (including an expanded payload).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c3dadbfb68608a477bd5dfd47829e5257a1378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->