### PR TITLE
Fix release-drafter v7 auth: env GITHUB_TOKEN -> with: token [MOD-15112]

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,5 @@ jobs:
       - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-           config-name: release-drafter-config.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          config-name: release-drafter-config.yml
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Describe the changes in the pull request**

Follow-up to #947 (which bumped `release-drafter/release-drafter` from v6 to v7).

In v7, [authentication moved from the `GITHUB_TOKEN` environment variable to a `token` input](https://github.com/release-drafter/release-drafter/blob/v7/action.yml) (which defaults to `${{ github.token }}`). The existing `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` block is now silently ignored.

The workflow currently still functions because v7 falls back to the default `github.token`, but the explicit token configuration is dead config — which would become a real problem if a PAT were ever needed here instead of the default token. This PR moves the token to the documented `with: token:` input so the original intent is preserved.

```diff
       - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-           config-name: release-drafter-config.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          config-name: release-drafter-config.yml
+          token: ${{ secrets.GITHUB_TOKEN }}
```

This fix will also be propagated to the open backport PRs (#960, #961, #962, #963, #964).

**Which issues this PR fixes**
1. MOD-15112

**Main objects this PR modified**
1. `.github/workflows/release-drafter.yml`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that updates how the Release Drafter GitHub Action receives credentials; the main risk is misconfiguration causing release notes drafting to fail.
> 
> **Overview**
> Updates the `release-drafter` GitHub Actions workflow to pass authentication via the v7-supported `with: token` input instead of the `GITHUB_TOKEN` environment variable, keeping the explicit secret-based token configuration effective.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097d43f14ff1b7658b8e6f71db845e3358b2b7c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->