### PR TITLE
Fix -Wmaybe-uninitialized with GCC 16 in CHOOSE_IMPLEMENTATION macros

### DIFF
--- a/src/VecSim/spaces/functions/implementation_chooser.h
+++ b/src/VecSim/spaces/functions/implementation_chooser.h
@@ -50,7 +50,7 @@
 #define CHOOSE_IMPLEMENTATION(out, dim, chunk, func)                                               \
     do {                                                                                           \
         decltype(out) __ret_dist_func;                                                             \
-        switch ((dim) % (chunk)) { CASES##chunk(func) }                                            \
+        switch ((dim) % (chunk)) { CASES##chunk(func) default: __builtin_unreachable(); }          \
         out = __ret_dist_func;                                                                     \
     } while (0)
 
@@ -74,6 +74,7 @@
             SVE_CASE(base_func, 1);                                                                \
             SVE_CASE(base_func, 2);                                                                \
             SVE_CASE(base_func, 3);                                                                \
+            default: __builtin_unreachable();                                                      \
         }                                                                                          \
         out = __ret_dist_func;                                                                     \
     } while (0)

--- a/src/VecSim/spaces/functions/implementation_chooser.h
+++ b/src/VecSim/spaces/functions/implementation_chooser.h
@@ -50,7 +50,7 @@
 #define CHOOSE_IMPLEMENTATION(out, dim, chunk, func)                                               \
     do {                                                                                           \
         decltype(out) __ret_dist_func;                                                             \
-        switch ((dim) % (chunk)) { CASES##chunk(func) default: __builtin_unreachable(); }          \
+        switch ((dim) % (chunk)) { CASES##chunk(func) default : __builtin_unreachable(); }         \
         out = __ret_dist_func;                                                                     \
     } while (0)
 
@@ -74,7 +74,8 @@
             SVE_CASE(base_func, 1);                                                                \
             SVE_CASE(base_func, 2);                                                                \
             SVE_CASE(base_func, 3);                                                                \
-            default: __builtin_unreachable();                                                      \
+        default:                                                                                   \
+            __builtin_unreachable();                                                               \
         }                                                                                          \
         out = __ret_dist_func;                                                                     \
     } while (0)


### PR DESCRIPTION
GCC 16 improved its uninitialized variable analysis and now warns that `__ret_dist_func` may be used uninitialized: the switch is exhaustive (e.g. `CASES16` covers exactly 0-15 and `dim % 16` can only produce 0-15), but GCC cannot prove this from the recursive macro expansion.

Add `default: __builtin_unreachable()` to both `CHOOSE_IMPLEMENTATION` and `CHOOSE_SVE_IMPLEMENTATION` to explicitly signal to the compiler that no other case is reachable, allowing it to conclude the variable is always initialized before use.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a compile-time hint to silence GCC 16 `-Wmaybe-uninitialized` warnings, with no intended runtime behavior change. The main risk is undefined behavior if the switch becomes non-exhaustive in the future and hits `__builtin_unreachable()`.
> 
> **Overview**
> Fixes new GCC 16 `-Wmaybe-uninitialized` warnings in `implementation_chooser.h` by making the switch statements in `CHOOSE_IMPLEMENTATION` and `CHOOSE_SVE_IMPLEMENTATION` explicitly exhaustive.
> 
> Adds `default: __builtin_unreachable()` so the compiler can prove `__ret_dist_func` is always initialized before assignment, without changing the selected implementation for valid inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17073f71e1864be7044d7f35d56d521f15fc2a91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->