### PR TITLE
Fix overflow in VecSimParams_GetQueryBlobSize

### DIFF
--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -258,8 +258,17 @@ extern "C" size_t VecSimParams_GetQueryBlobSize(VecSimType type, size_t dim, Vec
     assert(type == VecSimType_FLOAT32 || type == VecSimType_FLOAT64 ||
            type == VecSimType_BFLOAT16 || type == VecSimType_FLOAT16 || type == VecSimType_INT8 ||
            type == VecSimType_UINT8);
-    size_t blobSize = VecSimType_sizeof(type) * dim;
+
+    size_t element_size = VecSimType_sizeof(type);
+    if (dim != 0 && element_size > SIZE_MAX / dim) {
+        return 0;
+    }
+
+    size_t blobSize = element_size * dim;
     if (metric == VecSimMetric_Cosine && (type == VecSimType_INT8 || type == VecSimType_UINT8)) {
+        if (blobSize > SIZE_MAX - sizeof(float)) {
+            return 0;
+        }
         blobSize += sizeof(float); // For the norm
     }
     return blobSize;

--- a/tests/unit/test_common.cpp
+++ b/tests/unit/test_common.cpp
@@ -907,6 +907,23 @@ TEST_P(CommonTypeMetricTests, TestGetQueryBlobSize) {
     ASSERT_EQ(actual, expected);
 }
 
+TEST_P(CommonTypeMetricTests, TestGetQueryBlobSizeOverflow) {
+    // We don't need to create an index for this test, set to nullptr to avoid cleanup issues
+    this->index = nullptr;
+
+    VecSimType type = std::get<0>(GetParam());
+    VecSimMetric metric = std::get<1>(GetParam());
+
+    size_t element_size = VecSimType_sizeof(type);
+    size_t overflow_dim = SIZE_MAX / element_size + 1;
+    ASSERT_EQ(VecSimParams_GetQueryBlobSize(type, overflow_dim, metric), 0);
+
+    if (metric == VecSimMetric_Cosine && (type == VecSimType_INT8 || type == VecSimType_UINT8)) {
+        size_t add_overflow_dim = SIZE_MAX - sizeof(float) + 1;
+        ASSERT_EQ(VecSimParams_GetQueryBlobSize(type, add_overflow_dim, metric), 0);
+    }
+}
+
 class CommonTypeMetricTieredTests : public CommonTypeMetricTests {
 protected:
     virtual void TearDown() override {}


### PR DESCRIPTION
### Motivation
- The public helper `VecSimParams_GetQueryBlobSize` computed `VecSimType_sizeof(type) * dim` and added `sizeof(float)` for INT8/UINT8 cosine without checking for `size_t` overflow, which can wrap and cause undersized allocations and subsequent out-of-bounds accesses.
- Existing tests only exercised small dimensions and did not detect the boundary overflow cases.

### Description
- Add overflow guards in `VecSimParams_GetQueryBlobSize` by checking `element_size > SIZE_MAX / dim` before multiplication and `blobSize > SIZE_MAX - sizeof(float)` before the cosine norm addition, returning `0` if the required size cannot be represented in `size_t`.
- Keep existing functionality for normal ranges while making the API safe for untrusted `dim` values.
- Add a unit test `TestGetQueryBlobSizeOverflow` in `tests/unit/test_common.cpp` that asserts `VecSimParams_GetQueryBlobSize` returns `0` for a multiplication overflow dimension and for the addition overflow case for INT8/UINT8 cosine.
- Files changed: `src/VecSim/vec_sim.cpp` and `tests/unit/test_common.cpp`.

### Testing
- Added the deterministic unit test `TestGetQueryBlobSizeOverflow` but could not execute the test suite in this environment because CMake `FetchContent` downloads from GitHub are blocked (HTTP 403) and configuring/building tests failed.
- attempted to configure a Release build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, which failed due to an SVS dependency download returning HTTP 403.
- attempted to configure and build tests with `-DUSE_SVS=OFF -DVECSIM_BUILD_TESTS=ON` but the build still failed because `googletest` download was blocked with HTTP 403; no unit tests were run here as a result.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a003a98e130832ea356db0a733f0f49)