### PR TITLE
MOD-15579 Lazy initialization of the shared SVS thread pool

### DIFF
--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -473,33 +473,56 @@ public:
         return instance()->getAllocationSize();
     }
 
-    // Physically resize the pool. Creates new OS threads on grow, shuts down idle threads
-    // on shrink. new_size is total parallelism including the calling thread (minimum 1).
-    // Occupied threads (held by renters) survive shrink via the deferred-resize protocol —
-    // the pool defers shrink while jobs are in flight, so slots cannot be destroyed while rented.
-    //
-    // If jobs are in flight (pending_jobs_ > 0), shrink is deferred — the target size is
-    // stored and applied when the last job completes (see endScheduledJob()). Grow is
-    // always applied immediately so new jobs can use the extra threads right away.
+    // Resize the shared pool. in all cases the requested size is stored in
+    // deferred_size_ and applied later if not applied immediately:
+    //   * no SVS index attached yet → recorded; applied on first
+    //     onIndexAttached() (so no OS threads are spawned in deployments that
+    //     never create an SVS index).
+    //   * shrink while jobs are in flight (pending_jobs_ > 0) → recorded;
+    //     applied when endScheduledJob() drops pending_jobs_ back to 0 (avoids
+    //     destroying slots that already-reserved RediSearch workers will rent).
+    //   * otherwise (grows; shrinks with no jobs in flight) → applied
+    //     immediately via resize_locked().
+    // The two deferral cases never overlap — no jobs can be in flight before
+    // the first index attaches. Clamps to a minimum of 1.
     void resize(size_t new_size) {
         new_size = std::max(new_size, size_t{1});
         std::lock_guard lock{pool_mutex_};
-        resize_locked(new_size);
+        if (has_attached_index_) {
+            resize_locked(new_size);
+        } else {
+            deferred_size_ = new_size;
+        }
     }
 
-    // Deferred-resize protocol
-    // ========================
-    // When a job is created via createScheduledJobs(), the pool size is snapshotted
-    // to determine how many reserve jobs to submit to the RediSearch worker pool.
-    // If resize() shrinks the SVS pool between that snapshot and when the job
-    // actually executes, the RediSearch workers would have checked in (reserved
-    // threads exist) but the SVS pool slots they need to rent from would have been
-    // destroyed — causing a failure.
-    //
-    // To prevent this, beginScheduledJob() increments pending_jobs_, and any shrink
-    // while pending_jobs_ > 0 is deferred (stored in deferred_size_) until the last
-    // in-flight job completes and its destructor calls endScheduledJob(). Grows are
-    // always applied immediately since extra threads don't break anything.
+    // Called from the per-index VecSimSVSThreadPool ctor. The first call flips
+    // has_attached_index_ and applies any size requested earlier via resize()
+    // — this is where OS threads are actually spawned in the lazy path.
+    void onIndexAttached() {
+        std::lock_guard lock{pool_mutex_};
+        if (has_attached_index_)
+            return;
+        has_attached_index_ = true;
+        if (deferred_size_)
+            resize_locked(deferred_size_.value());
+    }
+
+#ifdef BUILD_TESTS
+    // Restore the singleton to its as-constructed state: drop all worker slots
+    // (releasing vector capacity so getAllocationSize() returns 0), clear
+    // has_attached_index_, deferred_size_, and pending_jobs_. Intended for unit
+    // tests that need a clean baseline (the singleton itself is process-wide
+    // and cannot be torn down). Caller must ensure no jobs are in flight.
+    void resetForTest() {
+        std::lock_guard lock{pool_mutex_};
+        assert(pending_jobs_ == 0 && "resetForTest called with jobs in flight");
+        // Swap with a fresh empty vector to release the capacity allocation
+        // (clear() destroys elements but retains capacity).
+        vecsim_stl::vector<SlotPtr>(allocator_).swap(slots_);
+        deferred_size_.reset();
+        has_attached_index_ = false;
+    }
+#endif
 
     // Atomically mark a logical job as pending and snapshot the current shared pool size.
     size_t beginScheduledJob() {
@@ -656,8 +679,14 @@ private:
     std::shared_ptr<VecSimAllocator> allocator_; // pool's own allocator for memory tracking
     mutable std::mutex pool_mutex_;
     vecsim_stl::vector<SlotPtr> slots_;
-    size_t pending_jobs_ = 0;             // jobs currently scheduled / in-flight
-    std::optional<size_t> deferred_size_; // resize target deferred until pending_jobs_ == 0
+    size_t pending_jobs_ = 0; // jobs currently scheduled / in-flight
+    // Pending pool size to apply at the next safe point: either the first SVS index
+    // attaches (onIndexAttached()) or pending_jobs_ drops to 0 (endScheduledJob()).
+    // The two cases are sequential and never overlap.
+    std::optional<size_t> deferred_size_;
+    // Flips true on the first onIndexAttached() call; gates resize() between
+    // "record only" and "apply immediately".
+    bool has_attached_index_ = false;
 };
 
 // Per-index wrapper around the shared VecSimSVSThreadPoolImpl singleton.
@@ -687,12 +716,16 @@ public:
     // explicit setParallelism() call.
     // parallelism_ is allocated through the provided VecsimAllocator so that the
     // allocation is tracked by the index's memory accounting.
+    // Notifies the shared pool that an index has attached — on the very first call this
+    // applies any size requested earlier via resize() (lazy thread spawn).
     explicit VecSimSVSThreadPool(const std::shared_ptr<VecSimAllocator> &allocator,
                                  void *log_ctx = nullptr)
         : pool_(VecSimSVSThreadPoolImpl::instance()),
           parallelism_(std::allocate_shared<std::atomic<size_t>>(
               VecsimSTLAllocator<std::atomic<size_t>>(allocator), size_t{1})),
-          log_ctx_(log_ctx) {}
+          log_ctx_(log_ctx) {
+        pool_->onIndexAttached();
+    }
 
     // Resize the shared pool singleton. Delegates to VecSimSVSThreadPoolImpl::instance().
     static void resize(size_t new_size) { VecSimSVSThreadPoolImpl::instance()->resize(new_size); }

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -41,9 +41,9 @@ extern "C" void VecSim_UpdateThreadPoolSize(size_t new_size) {
     } else {
         VecSimIndex::setWriteMode(VecSim_WriteAsync);
     }
-    // Resize the shared SVS thread pool. resize() clamps to minimum size 1.
-    // new_size == 0 → pool size 1 (only calling thread, write-in-place).
-    // new_size >  0 → pool size new_size (new_size - 1 worker threads).
+    // Resize the shared SVS pool. Clamped to a minimum of 1. OS threads are spawned
+    // lazily on first SVS index creation; once an index exists this resizes the
+    // shared pool immediately (cooperating with the deferred-shrink protocol).
     VecSimSVSThreadPool::resize(new_size);
 }
 

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -3304,6 +3304,10 @@ TEST(SVSTest, compute_distance) {
 // the shared singleton. Setting it should log a warning but not affect the pool.
 // ---------------------------------------------------------------------------
 TEST(SVSTest, NumThreadsParamIgnored) {
+    // Mark the pool as attached so resize() applies eagerly (this test resizes
+    // before constructing the SVS index, so the lazy code path would otherwise
+    // just record the size without spawning threads).
+    VecSimSVSThreadPoolImpl::instance()->onIndexAttached();
     // Resize the shared singleton pool to a known size.
     VecSimSVSThreadPool::resize(2);
     ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 2);
@@ -3357,8 +3361,9 @@ TEST(SVSTest, NumThreadsParamIgnored) {
 
     VecSimIndex_Free(index2);
 
-    // Restore pool to default size and clear log callback.
-    VecSimSVSThreadPool::resize(1);
+    // Restore singleton to baseline (clears has_attached_index_ and slots) and
+    // clear log callback so subsequent tests see a clean state.
+    VecSimSVSThreadPoolImpl::instance()->resetForTest();
     VecSimIndexInterface::logCallback = nullptr;
 }
 
@@ -3367,15 +3372,15 @@ TEST(SVSTest, NumThreadsParamIgnored) {
 // present on every algorithm. Verify it appears exactly once in an SVS
 // response and reports the same bytes as the public API.
 TYPED_TEST(SVSTest, debugInfoSharedMemoryMatchesApi) {
-    // Ensure the shared SVS thread pool singleton has allocated memory so the
-    // field reports a non-zero value. resize() always lazy-initializes the singleton.
+    // Request a non-trivial pool size; with lazy init the actual allocation only
+    // happens on first SVS index creation below.
     VecSim_UpdateThreadPoolSize(2);
-    ASSERT_GT(VecSim_GetSharedMemory(), 0u);
 
     size_t dim = 4;
     SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
     VecSimIndex *index = this->CreateNewIndex(params);
     ASSERT_INDEX(index);
+    ASSERT_GT(VecSim_GetSharedMemory(), 0u);
 
     VecSimDebugInfoIterator *infoIterator = VecSimIndex_DebugInfoIterator(index);
 
@@ -3407,6 +3412,12 @@ TYPED_TEST(SVSTest, debugInfoSharedMemoryMatchesApi) {
 // SHARED_MEMORY could be a constant and debugInfoSharedMemoryMatchesApi would
 // still pass (both readouts share the same getSharedAllocationSize() source).
 TYPED_TEST(SVSTest, sharedMemoryTracksThreadPoolResize) {
+    // With lazy init, resize() only records the requested size until an SVS index
+    // has attached. Mark the pool attached up front so the resizes below apply
+    // eagerly and their allocation effect is observable (idempotent, matches the
+    // pattern used by NumThreadsParamIgnored and the SVSThreadPoolTest fixture).
+    VecSimSVSThreadPoolImpl::instance()->onIndexAttached();
+
     // Use the C API to ensure it is covered. VecSim_UpdateThreadPoolSize(0)
     // sets WriteInPlace and pool size 1.
     VecSim_UpdateThreadPoolSize(0);
@@ -3426,6 +3437,42 @@ TYPED_TEST(SVSTest, sharedMemoryTracksThreadPoolResize) {
 
     // Restore to default baseline.
     VecSim_UpdateThreadPoolSize(0);
+}
+
+// ---------------------------------------------------------------------------
+// Lazy thread-pool init: VecSim_UpdateThreadPoolSize must not allocate worker
+// threads until the first SVS index attaches.
+// ---------------------------------------------------------------------------
+TEST(SVSTest, ThreadPoolLazyInit) {
+    // Reset the shared singleton to a clean state — earlier tests may have
+    // attached indexes and resized the pool. After reset, getAllocationSize()
+    // still reports sizeof(VecSimAllocator) (the allocator's self-accounting,
+    // see VecSimAllocator() ctor); assertions below compare against this
+    // baseline rather than absolute zero.
+    VecSimSVSThreadPoolImpl::instance()->resetForTest();
+    const size_t baseline_mem = VecSim_GetSharedMemory();
+
+    // Recording a non-trivial requested size before any SVS index exists must
+    // not allocate any worker slots.
+    VecSim_UpdateThreadPoolSize(8);
+    EXPECT_EQ(VecSim_GetSharedMemory(), baseline_mem)
+        << "VecSim_UpdateThreadPoolSize must not allocate threads before any SVS index exists";
+    EXPECT_EQ(VecSimSVSThreadPool::poolSize(), 1u)
+        << "Pool size must stay at 1 (no worker slots) until first index attaches";
+
+    // First SVS index creation triggers onIndexAttached(), which applies the
+    // recorded size and spawns 7 worker threads.
+    SVSParams params = {.type = VecSimType_FLOAT32, .dim = 4, .metric = VecSimMetric_L2};
+    VecSimParams vp{.algo = VecSimAlgo_SVS, .algoParams = {.svsParams = params}};
+    VecSimIndex *index = VecSimIndex_New(&vp);
+    ASSERT_NE(index, nullptr);
+    ASSERT_GT(VecSim_GetSharedMemory(), baseline_mem)
+        << "First SVS index creation must trigger lazy thread spawn";
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 8u)
+        << "Pool size must reflect the most recent requested size after first attach";
+
+    VecSimIndex_Free(index);
+    VecSimSVSThreadPoolImpl::instance()->resetForTest();
 }
 
 #else // HAVE_SVS

--- a/tests/unit/test_svs_threadpool.cpp
+++ b/tests/unit/test_svs_threadpool.cpp
@@ -44,6 +44,10 @@ protected:
         // don't assert on nullptr log_ctx (we don't have an index context).
         saved_callback_ = VecSimIndexInterface::logCallback;
         VecSimIndexInterface::logCallback = nullptr;
+        // Mark the shared pool as having an attached index so resize() behaves
+        // eagerly throughout the test (these unit tests exercise the pool in
+        // isolation, without constructing real SVS indexes). Idempotent.
+        VecSimSVSThreadPoolImpl::instance()->onIndexAttached();
         // Reset the shared singleton pool to size 1 — earlier test suites may have
         // resized it via VecSim_UpdateThreadPoolSize() and left it in that state.
         VecSimSVSThreadPool::resize(1);
@@ -330,15 +334,26 @@ TEST_F(SVSThreadPoolTest, TwoIndexesIndependentParallelism) {
 
 // ---------------------------------------------------------------------------
 // Test 6: VecSim_UpdateThreadPoolSize mode transitions
-// The C API sets write mode and resizes the shared singleton pool.
+// The C API always sets write mode immediately. The pool resize is lazy: it is
+// applied at first index attach if no index has attached yet, otherwise
+// immediately.
 // ---------------------------------------------------------------------------
 TEST_F(SVSThreadPoolTest, UpdateThreadPoolSizeModeTransitions) {
-    // 0 → 4: switch to async mode, pool resizes to 4.
+    // Reset to a fresh state — previous tests may have attached indexes via
+    // VecSimSVSThreadPool wrappers, leaving has_attached_index_ set.
+    VecSimSVSThreadPoolImpl::instance()->resetForTest();
+
+    // 0 → 4: switch to async mode immediately. Pool size stays at 1 because
+    // no SVS index has attached yet (resize is deferred).
     VecSim_UpdateThreadPoolSize(4);
     ASSERT_EQ(VecSimIndex::asyncWriteMode, VecSim_WriteAsync);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1);
+
+    // Attaching an index applies the deferred size.
+    VecSimSVSThreadPool wrapper{allocator_};
     ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 4);
 
-    // 4 → 8: stay in async mode (N→M, both > 0), pool resizes to 8.
+    // 4 → 8: now that an index is attached, resize is immediate.
     VecSim_UpdateThreadPoolSize(8);
     ASSERT_EQ(VecSimIndex::asyncWriteMode, VecSim_WriteAsync);
     ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 8);


### PR DESCRIPTION
Make initialization of the shared SVS thread pool lazy: OS worker threads are spawned only when the first SVS index is created, not when `VecSim_UpdateThreadPoolSize` is called. This eliminates the cost of pre-allocated SVS workers in deployments that configure RediSearch workers but never create an SVS index (today, every Redis with `WORKERS=N` configured spawns `N-1` SVS worker threads at module init regardless of whether SVS is ever used).

The change extends the existing deferred-resize protocol to cover a second "safe point". `VecSimSVSThreadPoolImpl::resize()` now defers application in two cases:

* **No SVS index attached yet** → recorded; applied on first `onIndexAttached()` (lazy thread spawn).
* **Shrink while jobs are in flight** (`pending_jobs_ > 0`) → recorded; applied when `endScheduledJob()` drops the counter to 0 (existing behaviour).
* **Otherwise** → applied immediately via `resize_locked()`.

The two deferral cases share `deferred_size_` and never overlap (no jobs can be in flight before the first index attaches). One new gate field, `has_attached_index_`, distinguishes the two states. It is set on the first `onIndexAttached()` call from the per-index `VecSimSVSThreadPool` ctor.

`VecSim_UpdateThreadPoolSize` continues to set the write mode (`InPlace`/`Async`) eagerly — only the SVS pool sizing is now deferred. The C API surface is unchanged.

**RediSearch integration impact**: none required — `VecSim_UpdateThreadPoolSize(N)` is still the single entry point for both module init and `CONFIG SET search-workers M`. Pre-index calls now just record the size; post-index calls behave exactly as before.

**Main objects this PR modified**

1. `VecSimSVSThreadPoolImpl::resize()` — now lazy until the first index attaches.
2. `VecSimSVSThreadPoolImpl::onIndexAttached()` — new entry point called from the per-index `VecSimSVSThreadPool` ctor; flips `has_attached_index_` and applies any deferred size.
3. `VecSimSVSThreadPoolImpl::has_attached_index_` — new member field gating spawn vs. defer.
4. `VecSimSVSThreadPoolImpl::resetForTest()` — new `BUILD_TESTS`-only hook that restores the singleton to a clean baseline. Asserts `pending_jobs_ == 0` so misuse fails loudly instead of corrupting the deferred-protocol bookkeeping.
5. `VecSim_UpdateThreadPoolSize()` — comment updated; behaviour now lazy via the new `resize()` semantics.

**Tests**

* `SVSTest.ThreadPoolLazyInit` (new) — verifies `VecSim_UpdateThreadPoolSize` does not allocate worker threads before any SVS index exists, and that the first SVS index creation triggers the deferred spawn at the previously requested size. Post-`VecSimIndex_New` checks use `ASSERT_*` so a regression in the lazy-spawn contract halts the test on the first failure.
* `SVSThreadPoolTest.UpdateThreadPoolSizeModeTransitions` — validates the lazy → eager transition (pool size stays at 1 until an index attaches; subsequent transitions apply immediately).
* `SVSThreadPoolTest` fixture — `SetUp()` calls `onIndexAttached()` so the pool-isolation tests retain eager `resize()` semantics.
* `SVSTest.NumThreadsParamIgnored` — calls `onIndexAttached()` up front (resizes before constructing an index) and restores the singleton via `resetForTest()` so it does not leak `has_attached_index_` to later tests.
* `SVSTest.sharedMemoryTracksThreadPoolResize` — calls `onIndexAttached()` up front so the resize-without-index path applies eagerly and the grow/shrink memory deltas are observable.

**Mark if applicable**

- [X] This PR introduces API changes
- [ ] This PR introduces serialization changes

---

Supersedes #969 — ownership transferred to @dor-forer. Builds on #972 (MOD-15578), now merged to `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared thread-pool lifecycle and when OS threads are created, but the public C API is unchanged and deferred-shrink while jobs are in flight is preserved; risk is mainly regressions in worker count or timing around module init vs first SVS index.
> 
> **Overview**
> **Lazy SVS thread pool sizing** defers spawning OS worker threads until the first SVS index is created. `VecSim_UpdateThreadPoolSize` still switches write mode (`InPlace` / `Async`) immediately; only pool sizing is deferred.
> 
> `VecSimSVSThreadPoolImpl::resize()` now records the requested size in `deferred_size_` when **no index has attached** (`has_attached_index_` is false) instead of calling `resize_locked()` right away. The first per-index `VecSimSVSThreadPool` construction calls **`onIndexAttached()`**, which sets the flag and applies any deferred size—this is where workers are created on the lazy path. After attach, resize behaves as before (immediate grow/shrink, with shrink still deferred while `pending_jobs_ > 0`).
> 
> A **`BUILD_TESTS`-only `resetForTest()`** clears slots, `deferred_size_`, and `has_attached_index_` so unit tests get a clean singleton. Tests add **`ThreadPoolLazyInit`**, call `onIndexAttached()` where tests resize without a real index, and extend **`UpdateThreadPoolSizeModeTransitions`** for the lazy → eager transition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f073fb1e439b3bedabaedab31cf0402ded53d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->