### PR TITLE
MOD-15579 Report 0 shared SVS memory until first index attaches

### DIFF
--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -462,15 +462,25 @@ public:
     // outside of the pool, nor per-index wrapper state.
     size_t getAllocationSize() const { return allocator_->getAllocationSize(); }
 
-    // Bytes allocated by the shared pool singleton. Returns 0 if the singleton has
-    // never been constructed (e.g., no SVS index was ever created and
-    // VecSim_UpdateThreadPoolSize was never called). Safe to call from any context;
-    // does not force singleton construction.
+    // Bytes allocated by the shared pool singleton. Returns 0 until the first SVS index
+    // attaches, for either reason:
+    //   * the singleton was never constructed (no SVS index created and
+    //     VecSim_UpdateThreadPoolSize never called), or
+    //   * it was constructed to record a requested size (VecSim_UpdateThreadPoolSize at
+    //     module init) but no SVS index has attached yet.
+    // This keeps process-wide vector memory reported as 0 on deployments that only use
+    // non-SVS indexes (or none at all). Safe to call from any context; does not force
+    // singleton construction.
     static size_t getSharedAllocationSize() {
         if (!isInitialized()) {
             return 0;
         }
-        return instance()->getAllocationSize();
+        auto pool = instance();
+        std::lock_guard lock{pool->pool_mutex_};
+        if (!pool->has_attached_index_) {
+            return 0;
+        }
+        return pool->getAllocationSize();
     }
 
     // Resize the shared pool. in all cases the requested size is stored in

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -3445,12 +3445,13 @@ TYPED_TEST(SVSTest, sharedMemoryTracksThreadPoolResize) {
 // ---------------------------------------------------------------------------
 TEST(SVSTest, ThreadPoolLazyInit) {
     // Reset the shared singleton to a clean state — earlier tests may have
-    // attached indexes and resized the pool. After reset, getAllocationSize()
-    // still reports sizeof(VecSimAllocator) (the allocator's self-accounting,
-    // see VecSimAllocator() ctor); assertions below compare against this
-    // baseline rather than absolute zero.
+    // attached indexes and resized the pool. resetForTest() clears
+    // has_attached_index_, so VecSim_GetSharedMemory() reports 0 even though the
+    // singleton object (and its self-accounting allocator) still exist: shared
+    // memory is only attributed once an SVS index attaches.
     VecSimSVSThreadPoolImpl::instance()->resetForTest();
     const size_t baseline_mem = VecSim_GetSharedMemory();
+    EXPECT_EQ(baseline_mem, 0u) << "shared memory must be 0 before any SVS index attaches";
 
     // Recording a non-trivial requested size before any SVS index exists must
     // not allocate any worker slots.


### PR DESCRIPTION
**Describe the changes in the pull request**

`VecSim_GetSharedMemory()` returned the shared SVS thread-pool allocator's self-accounting baseline (~8 bytes) as soon as the singleton was constructed. The singleton is constructed at module init via `VecSim_UpdateThreadPoolSize` (RediSearch's `workersThreadPool_CreatePool`), so the baseline was reported even on deployments that never create an SVS index.

RediSearch folds `VecSim_GetSharedMemory()` into the `FT.INFO` `vector_index_sz_mb` field, so this surfaced as a nonzero vector-memory figure on indexes (or whole servers) with no vector index at all — see the discussion on [RediSearch#9859](https://github.com/RediSearch/RediSearch/pull/9859).

This gates `VecSimSVSThreadPoolImpl::getSharedAllocationSize()` on `has_attached_index_` (read under `pool_mutex_`) so it reports `0` until the first SVS index attaches, for both ways the singleton can be touched early:
- never constructed (no SVS index created, `VecSim_UpdateThreadPoolSize` never called), or
- constructed only to record a requested pool size at module init, with no SVS index attached yet.

Thread-spawn timing is unchanged — only the reported size changes — so there is no `CONFIG SET WORKERS`-vs-first-attach race. `getAllocationSize()` is a lockless atomic read, called under the existing `pool_mutex_` with no nested locking.

`ThreadPoolLazyInit` now asserts the baseline is exactly `0` before any SVS index attaches.

**Which issues this PR fixes**
1. MOD-15579

**Main objects this PR modified**
1. `src/VecSim/algorithms/svs/svs_utils.h` — `VecSimSVSThreadPoolImpl::getSharedAllocationSize()`
2. `tests/unit/test_svs.cpp` — `ThreadPoolLazyInit`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting-only change to shared memory accounting; thread-pool behavior and allocation timing are unchanged.
> 
> **Overview**
> **`VecSim_GetSharedMemory()`** (and RediSearch **`FT.INFO`** **`vector_index_sz_mb`**) no longer reports the shared SVS thread-pool allocator’s tiny baseline as soon as the pool singleton exists at module init.
> 
> **`VecSimSVSThreadPoolImpl::getSharedAllocationSize()`** now returns **0** until the first SVS index attaches (`has_attached_index_`, read under **`pool_mutex_`**), including when **`VecSim_UpdateThreadPoolSize`** only constructed the singleton to record a deferred size. Actual pool allocation and thread spawn timing are unchanged—only reporting.
> 
> **`ThreadPoolLazyInit`** expects shared memory **0** after **`resetForTest()`** clears **`has_attached_index_`**, before any index attaches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58302a247f3395ab738a219430cffa240291a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->