### PR TITLE
[MOD-16696] Use one-byte HNSW node locks

### DIFF
--- a/src/VecSim/algorithms/hnsw/graph_data.h
+++ b/src/VecSim/algorithms/hnsw/graph_data.h
@@ -3,7 +3,6 @@
 
 #include <cassert>
 #include <algorithm>
-#include <mutex>
 #include "VecSim/utils/vec_utils.h"
 
 // Amortized shrink thresholds for incoming edges vectors.
@@ -99,7 +98,6 @@ struct ElementLevelData {
 
 struct ElementGraphData {
     size_t toplevel;
-    std::mutex neighborsGuard;
     ElementLevelData *others;
     ElementLevelData level0;
 

--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -116,6 +116,7 @@ protected:
 
     // Index data
     vecsim_stl::vector<DataBlock> graphDataBlocks;
+    mutable vecsim_stl::vector<vecsim_stl::one_byte_mutex> elementLocks;
     vecsim_stl::vector<ElementMetaData> idToMetaData;
 
     // Used for marking the visited nodes in graph scans (the pool supports parallel graph scans).
@@ -252,8 +253,6 @@ public:
     void unlockSharedIndexDataGuard() const;
     void lockNodeLinks(idType node_id) const;
     void unlockNodeLinks(idType node_id) const;
-    void lockNodeLinks(ElementGraphData *node_data) const;
-    void unlockNodeLinks(ElementGraphData *node_data) const;
     VisitedNodesHandler *getVisitedList() const;
     void returnVisitedList(VisitedNodesHandler *visited_nodes_handler) const;
     VecSimIndexDebugInfo debugInfo() const override;
@@ -482,23 +481,13 @@ void HNSWIndex<DataType, DistType>::unlockSharedIndexDataGuard() const {
 }
 
 template <typename DataType, typename DistType>
-void HNSWIndex<DataType, DistType>::lockNodeLinks(ElementGraphData *node_data) const {
-    node_data->neighborsGuard.lock();
-}
-
-template <typename DataType, typename DistType>
-void HNSWIndex<DataType, DistType>::unlockNodeLinks(ElementGraphData *node_data) const {
-    node_data->neighborsGuard.unlock();
-}
-
-template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::lockNodeLinks(idType node_id) const {
-    lockNodeLinks(getGraphDataByInternalId(node_id));
+    elementLocks[node_id].lock();
 }
 
 template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::unlockNodeLinks(idType node_id) const {
-    unlockNodeLinks(getGraphDataByInternalId(node_id));
+    elementLocks[node_id].unlock();
 }
 
 /**
@@ -528,7 +517,7 @@ void HNSWIndex<DataType, DistType>::processCandidate(
     candidatesMaxHeap<DistType> &candidate_set, DistType &lowerBound) const {
 
     ElementGraphData *cur_element = getGraphDataByInternalId(curNodeId);
-    lockNodeLinks(cur_element);
+    lockNodeLinks(curNodeId);
     ElementLevelData &node_level = getElementLevelData(cur_element, layer);
     linkListSize num_links = node_level.getNumLinks();
     if (num_links > 0) {
@@ -602,7 +591,7 @@ void HNSWIndex<DataType, DistType>::processCandidate(
             }
         }
     }
-    unlockNodeLinks(cur_element);
+    unlockNodeLinks(curNodeId);
 }
 
 template <typename DataType, typename DistType>
@@ -612,7 +601,7 @@ void HNSWIndex<DataType, DistType>::processCandidate_RangeSearch(
     candidatesMaxHeap<DistType> &candidate_set, DistType dyn_range, DistType radius) const {
 
     auto *cur_element = getGraphDataByInternalId(curNodeId);
-    lockNodeLinks(cur_element);
+    lockNodeLinks(curNodeId);
     ElementLevelData &node_level = getElementLevelData(cur_element, layer);
     linkListSize num_links = node_level.getNumLinks();
 
@@ -669,7 +658,7 @@ void HNSWIndex<DataType, DistType>::processCandidate_RangeSearch(
             }
         }
     }
-    unlockNodeLinks(cur_element);
+    unlockNodeLinks(curNodeId);
 }
 
 template <typename DataType, typename DistType>
@@ -904,11 +893,11 @@ idType HNSWIndex<DataType, DistType>::mutuallyConnectNewElement(
         idType selected_neighbor = neighbor_data.second; // neighbor's id
         auto *neighbor_graph_data = getGraphDataByInternalId(selected_neighbor);
         if (new_node_id < selected_neighbor) {
-            lockNodeLinks(new_node_level);
-            lockNodeLinks(neighbor_graph_data);
+            lockNodeLinks(new_node_id);
+            lockNodeLinks(selected_neighbor);
         } else {
-            lockNodeLinks(neighbor_graph_data);
-            lockNodeLinks(new_node_level);
+            lockNodeLinks(selected_neighbor);
+            lockNodeLinks(new_node_id);
         }
 
         // validations...
@@ -921,15 +910,15 @@ idType HNSWIndex<DataType, DistType>::mutuallyConnectNewElement(
             // The new node cannot add more neighbors
             this->log(VecSimCommonStrings::LOG_DEBUG_STRING,
                       "Couldn't add all chosen neighbors upon inserting a new node");
-            unlockNodeLinks(new_node_level);
-            unlockNodeLinks(neighbor_graph_data);
+            unlockNodeLinks(new_node_id);
+            unlockNodeLinks(selected_neighbor);
             break;
         }
 
         // If one of the two nodes has already deleted - skip the operation.
         if (isMarkedDeleted(new_node_id) || isMarkedDeleted(selected_neighbor)) {
-            unlockNodeLinks(new_node_level);
-            unlockNodeLinks(neighbor_graph_data);
+            unlockNodeLinks(new_node_id);
+            unlockNodeLinks(selected_neighbor);
             continue;
         }
 
@@ -940,8 +929,8 @@ idType HNSWIndex<DataType, DistType>::mutuallyConnectNewElement(
         if (neighbor_level_data.getNumLinks() < max_M_cur) {
             new_node_level_data.appendLink(selected_neighbor);
             neighbor_level_data.appendLink(new_node_id);
-            unlockNodeLinks(new_node_level);
-            unlockNodeLinks(neighbor_graph_data);
+            unlockNodeLinks(new_node_id);
+            unlockNodeLinks(selected_neighbor);
             continue;
         }
 
@@ -1068,7 +1057,7 @@ void HNSWIndex<DataType, DistType>::replaceEntryPoint() {
         volatile idType candidate_in_process = INVALID_ID;
 
         // Go over the entry point's neighbors at the top level.
-        lockNodeLinks(old_entry_point);
+        lockNodeLinks(old_entry_point_id);
         ElementLevelData &old_ep_level = getElementLevelData(old_entry_point, maxLevel);
         // Tries to set the (arbitrary) first neighbor as the entry point which is not deleted,
         // if exists.
@@ -1076,7 +1065,7 @@ void HNSWIndex<DataType, DistType>::replaceEntryPoint() {
             if (!isMarkedDeleted(old_ep_level.getLinkAtPos(i))) {
                 if (!isInProcess(old_ep_level.getLinkAtPos(i))) {
                     entrypointNode = old_ep_level.getLinkAtPos(i);
-                    unlockNodeLinks(old_entry_point);
+                    unlockNodeLinks(old_entry_point_id);
                     return;
                 } else {
                     // Store this candidate which is currently being inserted into the graph in
@@ -1085,7 +1074,7 @@ void HNSWIndex<DataType, DistType>::replaceEntryPoint() {
                 }
             }
         }
-        unlockNodeLinks(old_entry_point);
+        unlockNodeLinks(old_entry_point_id);
 
         // If there is no neighbors in the current level, check for any vector at
         // this level to be the new entry point.
@@ -1219,8 +1208,9 @@ void HNSWIndex<DataType, DistType>::greedySearchLevel(const void *vector_data, s
         }
 
         changed = false;
+        idType locked_id = bestCand;
         auto *element = getGraphDataByInternalId(bestCand);
-        lockNodeLinks(element);
+        lockNodeLinks(locked_id);
         ElementLevelData &node_level_data = getElementLevelData(element, level);
 
         for (int i = 0; i < node_level_data.getNumLinks(); i++) {
@@ -1242,7 +1232,7 @@ void HNSWIndex<DataType, DistType>::greedySearchLevel(const void *vector_data, s
                 }
             }
         }
-        unlockNodeLinks(element);
+        unlockNodeLinks(locked_id);
     } while (changed);
     if (!running_query) {
         bestCand = bestNonDeletedCand;
@@ -1257,17 +1247,17 @@ HNSWIndex<DataType, DistType>::safeCollectAllNodeIncomingNeighbors(idType node_i
     auto element = getGraphDataByInternalId(node_id);
     for (size_t level = 0; level <= element->toplevel; level++) {
         // Save the node neighbor's in the current level while holding its neighbors lock.
-        lockNodeLinks(element);
+        lockNodeLinks(node_id);
         auto &node_level_data = getElementLevelData(element, level);
         // Store the deleted element's neighbours.
         auto neighbors_copy = node_level_data.copyLinks();
-        unlockNodeLinks(element);
+        unlockNodeLinks(node_id);
 
         // Go over the neighbours and collect tho ones that also points back to the removed node.
         for (auto neighbour_id : neighbors_copy) {
             // Hold the neighbor's lock while we are going over its neighbors.
             auto *neighbor = getGraphDataByInternalId(neighbour_id);
-            lockNodeLinks(neighbor);
+            lockNodeLinks(neighbour_id);
             ElementLevelData &neighbour_level_data = getElementLevelData(neighbor, level);
 
             for (size_t j = 0; j < neighbour_level_data.getNumLinks(); j++) {
@@ -1277,16 +1267,16 @@ HNSWIndex<DataType, DistType>::safeCollectAllNodeIncomingNeighbors(idType node_i
                     break;
                 }
             }
-            unlockNodeLinks(neighbor);
+            unlockNodeLinks(neighbour_id);
         }
 
         // Next, collect the rest of incoming edges (the ones that are not bidirectional) in the
         // current level to repair them.
-        lockNodeLinks(element);
+        lockNodeLinks(node_id);
         for (auto incoming_edge : node_level_data.getIncomingEdges()) {
             incoming_neighbors.emplace_back(incoming_edge, (unsigned short)level);
         }
-        unlockNodeLinks(element);
+        unlockNodeLinks(node_id);
     }
     return incoming_neighbors;
 }
@@ -1299,6 +1289,8 @@ void HNSWIndex<DataType, DistType>::resizeIndexCommon(size_t new_max_elements) {
               idToMetaData.capacity(), new_max_elements);
     resizeLabelLookup(new_max_elements);
     visitedNodesHandlerPool.resize(new_max_elements);
+    elementLocks.resize(new_max_elements);
+    elementLocks.shrink_to_fit();
     assert(idToMetaData.capacity() == idToMetaData.size());
     idToMetaData.resize(new_max_elements);
     idToMetaData.shrink_to_fit();
@@ -1447,7 +1439,7 @@ void HNSWIndex<DataType, DistType>::repairNodeConnections(idType node_id, size_t
     // Go over the repaired node neighbors, collect the non-deleted ones to be neighbors candidates
     // after the repair as well.
     auto *element = getGraphDataByInternalId(node_id);
-    lockNodeLinks(element);
+    lockNodeLinks(node_id);
     ElementLevelData &node_level_data = getElementLevelData(element, level);
     for (size_t j = 0; j < node_level_data.getNumLinks(); j++) {
         node_orig_neighbours_set[node_level_data.getLinkAtPos(j)] = true;
@@ -1459,7 +1451,7 @@ void HNSWIndex<DataType, DistType>::repairNodeConnections(idType node_id, size_t
         neighbors_candidates_set[node_level_data.getLinkAtPos(j)] = true;
         neighbors_candidate_ids.push_back(node_level_data.getLinkAtPos(j));
     }
-    unlockNodeLinks(element);
+    unlockNodeLinks(node_id);
 
     // If there are not deleted neighbors at that point the repair job has already been made by
     // another parallel job, and there is no need to repair the node anymore.
@@ -1478,7 +1470,7 @@ void HNSWIndex<DataType, DistType>::repairNodeConnections(idType node_id, size_t
         nodes_to_update.push_back(deleted_neighbor_id);
 
         auto *neighbor = getGraphDataByInternalId(deleted_neighbor_id);
-        lockNodeLinks(neighbor);
+        lockNodeLinks(deleted_neighbor_id);
         ElementLevelData &neighbor_level_data = getElementLevelData(neighbor, level);
 
         for (size_t j = 0; j < neighbor_level_data.getNumLinks(); j++) {
@@ -1492,7 +1484,7 @@ void HNSWIndex<DataType, DistType>::repairNodeConnections(idType node_id, size_t
             neighbors_candidates_set[neighbor_level_data.getLinkAtPos(j)] = true;
             neighbors_candidate_ids.push_back(neighbor_level_data.getLinkAtPos(j));
         }
-        unlockNodeLinks(neighbor);
+        unlockNodeLinks(deleted_neighbor_id);
     }
 
     size_t max_M_cur = level ? M : M0;
@@ -1611,7 +1603,8 @@ HNSWIndex<DataType, DistType>::HNSWIndex(const HNSWParams *params,
                                          size_t random_seed)
     : VecSimIndexAbstract<DataType, DistType>(abstractInitParams, components),
       VecSimIndexTombstone(), maxElements(0), graphDataBlocks(this->allocator),
-      idToMetaData(this->allocator), visitedNodesHandlerPool(0, this->allocator) {
+      elementLocks(this->allocator), idToMetaData(this->allocator),
+      visitedNodesHandlerPool(0, this->allocator) {
 
     M = params->M ? params->M : HNSW_DEFAULT_M;
     M0 = M * 2;
@@ -2335,7 +2328,7 @@ HNSWIndex<DataType, DistType>::getHNSWElementNeighbors(size_t label, int ***neig
     }
     idType id = ids[0];
     auto graph_data = this->getGraphDataByInternalId(id);
-    lockNodeLinks(graph_data);
+    lockNodeLinks(id);
     *neighborsData = new int *[graph_data->toplevel + 2];
     for (size_t level = 0; level <= graph_data->toplevel; level++) {
         auto &level_data = this->getElementLevelData(graph_data, level);
@@ -2347,7 +2340,7 @@ HNSWIndex<DataType, DistType>::getHNSWElementNeighbors(size_t label, int ***neig
         }
     }
     (*neighborsData)[graph_data->toplevel + 1] = nullptr;
-    unlockNodeLinks(graph_data);
+    unlockNodeLinks(id);
     return VecSimDebugCommandCode_OK;
 }
 

--- a/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_batch_iterator.h
@@ -115,7 +115,7 @@ VecSimQueryReply_Code HNSW_BatchIterator<DataType, DistType>::scanGraphInternal(
         // Take the current node out of the candidates queue and go over his neighbours.
         candidates.pop();
         auto *node_graph_data = this->index->getGraphDataByInternalId(curr_node_id);
-        this->index->lockNodeLinks(node_graph_data);
+        this->index->lockNodeLinks(curr_node_id);
         ElementLevelData &node_level_data = this->index->getElementLevelData(node_graph_data, 0);
         if (node_level_data.numLinks > 0) {
 

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
@@ -18,7 +18,8 @@ HNSWIndex<DataType, DistType>::HNSWIndex(std::ifstream &input, const HNSWParams 
                                          HNSWSerializer::EncodingVersion version)
     : VecSimIndexAbstract<DataType, DistType>(abstractInitParams, components),
       HNSWSerializer(version), epsilon(params->epsilon), graphDataBlocks(this->allocator),
-      idToMetaData(this->allocator), visitedNodesHandlerPool(0, this->allocator) {
+      elementLocks(this->allocator), idToMetaData(this->allocator),
+      visitedNodesHandlerPool(0, this->allocator) {
 
     this->restoreIndexFields(input);
     this->fieldsValidation();
@@ -30,6 +31,7 @@ HNSWIndex<DataType, DistType>::HNSWIndex(std::ifstream &input, const HNSWParams 
 
     // Set the initial capacity based on the number of elements in the loaded index.
     maxElements = RoundUpInitialCapacity(this->curElementCount, this->blockSize);
+    this->elementLocks.resize(maxElements);
     this->idToMetaData.resize(maxElements);
     this->visitedNodesHandlerPool.resize(maxElements);
 

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -133,9 +133,10 @@ size_t EstimateElementSize(const HNSWParams *params) {
     // label node (bucket).
     size_t size_label_lookup_entry = sizeof(void *);
 
-    // 1 entry in visited nodes + 1 entry in element metadata map + (approximately) 1 bucket in
-    // labels lookup hash map.
-    size_t size_meta_data = sizeof(tag_t) + sizeof(ElementMetaData) + size_label_lookup_entry;
+    // 1 entry in visited nodes + 1 entry in element metadata map + 1 node lock + (approximately)
+    // 1 bucket in labels lookup hash map.
+    size_t size_meta_data = sizeof(tag_t) + sizeof(ElementMetaData) +
+                            sizeof(vecsim_stl::one_byte_mutex) + size_label_lookup_entry;
 
     /* Disclaimer: we are neglecting two additional factors that consume memory:
      * 1. The overall bucket size in labels_lookup hash table is usually higher than the number of

--- a/src/VecSim/utils/vecsim_stl.h
+++ b/src/VecSim/utils/vecsim_stl.h
@@ -112,38 +112,41 @@ public:
 
 struct one_byte_mutex {
     one_byte_mutex() noexcept = default;
-    one_byte_mutex(const one_byte_mutex &) noexcept : state(unlocked) {}
-    one_byte_mutex(one_byte_mutex &&) noexcept : state(unlocked) {}
+    one_byte_mutex(const one_byte_mutex &) noexcept : state(State::unlocked) {}
+    one_byte_mutex(one_byte_mutex &&) noexcept : state(State::unlocked) {}
     one_byte_mutex &operator=(const one_byte_mutex &) noexcept {
-        state.store(unlocked, std::memory_order_relaxed);
+        state.store(State::unlocked, std::memory_order_relaxed);
         return *this;
     }
     one_byte_mutex &operator=(one_byte_mutex &&) noexcept {
-        state.store(unlocked, std::memory_order_relaxed);
+        state.store(State::unlocked, std::memory_order_relaxed);
         return *this;
     }
 
     void lock() {
-        if (state.exchange(locked, std::memory_order_acquire) == unlocked) {
+        if (state.exchange(State::locked, std::memory_order_acquire) == State::unlocked) {
             return;
         }
-        while (state.exchange(sleeper, std::memory_order_acquire) != unlocked) {
-            state.wait(sleeper, std::memory_order_relaxed);
+        while (state.exchange(State::sleeper, std::memory_order_acquire) != State::unlocked) {
+            state.wait(State::sleeper, std::memory_order_relaxed);
         }
     }
 
     void unlock() {
-        if (state.exchange(unlocked, std::memory_order_release) == sleeper) {
+        if (state.exchange(State::unlocked, std::memory_order_release) == State::sleeper) {
             state.notify_one();
         }
     }
 
 private:
-    std::atomic<uint8_t> state{unlocked};
+    enum class State : uint8_t { unlocked, locked, sleeper };
 
-    static constexpr uint8_t unlocked = 0;
-    static constexpr uint8_t locked = 0b01;
-    static constexpr uint8_t sleeper = 0b10;
+    static_assert(sizeof(std::atomic<State>) == sizeof(uint8_t),
+                  "one_byte_mutex state must stay one byte");
+    std::atomic<State> state{State::unlocked};
 };
+static_assert(sizeof(one_byte_mutex) == sizeof(uint8_t), "one_byte_mutex must stay one byte");
+static_assert(alignof(one_byte_mutex) == alignof(uint8_t),
+              "one_byte_mutex alignment must stay one byte");
 
 } // namespace vecsim_stl

--- a/src/VecSim/utils/vecsim_stl.h
+++ b/src/VecSim/utils/vecsim_stl.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "VecSim/memory/vecsim_base.h"
+#include <atomic>
+#include <cstdint>
 #include <vector>
 #include <algorithm>
 #include <set>
@@ -106,6 +108,42 @@ public:
         : VecsimBaseObject(alloc),
           std::unordered_set<T, std::hash<T>, std::equal_to<T>, VecsimSTLAllocator<T>>(n_bucket,
                                                                                        alloc) {}
+};
+
+struct one_byte_mutex {
+    one_byte_mutex() noexcept = default;
+    one_byte_mutex(const one_byte_mutex &) noexcept : state(unlocked) {}
+    one_byte_mutex(one_byte_mutex &&) noexcept : state(unlocked) {}
+    one_byte_mutex &operator=(const one_byte_mutex &) noexcept {
+        state.store(unlocked, std::memory_order_relaxed);
+        return *this;
+    }
+    one_byte_mutex &operator=(one_byte_mutex &&) noexcept {
+        state.store(unlocked, std::memory_order_relaxed);
+        return *this;
+    }
+
+    void lock() {
+        if (state.exchange(locked, std::memory_order_acquire) == unlocked) {
+            return;
+        }
+        while (state.exchange(sleeper, std::memory_order_acquire) != unlocked) {
+            state.wait(sleeper, std::memory_order_relaxed);
+        }
+    }
+
+    void unlock() {
+        if (state.exchange(unlocked, std::memory_order_release) == sleeper) {
+            state.notify_one();
+        }
+    }
+
+private:
+    std::atomic<uint8_t> state{unlocked};
+
+    static constexpr uint8_t unlocked = 0;
+    static constexpr uint8_t locked = 0b01;
+    static constexpr uint8_t sleeper = 0b10;
 };
 
 } // namespace vecsim_stl

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -573,7 +573,9 @@ TYPED_TEST(IndexAllocatorTest, test_hnsw_reclaim_memory) {
     data_containers_block_mem += size_total_data_per_element * block_size;
     // account for idToMetaData and visitedNodesHandlerPool entries.
     expected_mem_delta +=
-        (sizeof(tag_t) + sizeof(ElementMetaData)) * block_size + data_containers_block_mem;
+        (sizeof(tag_t) + sizeof(ElementMetaData) + sizeof(vecsim_stl::one_byte_mutex)) *
+            block_size +
+        data_containers_block_mem;
     // Account for the allocation of a new bucket in the labels_lookup hash table.
     expected_mem_delta +=
         (hnswIndex->labelLookup.bucket_count() - one_block_buckets) * sizeof(size_t);


### PR DESCRIPTION
## Summary

Revives the old one-byte mutex idea on top of current `main`, but keeps the graph-data layout natural by moving per-node HNSW locks into an index-owned lock vector.

Changes:
- Adds `vecsim_stl::one_byte_mutex`, backed by `std::atomic<uint8_t>::wait/notify_one`.
- Removes `std::mutex neighborsGuard` from `ElementGraphData`.
- Adds `elementLocks`, a per-internal-id lock vector owned by `HNSWIndex` and resized with index capacity.
- Updates HNSW lock sites to lock by internal id instead of graph-data pointer.
- Updates HNSW memory estimation and allocator test accounting for the new 1-byte-per-node lock vector.

Expected memory effect:
- `ElementGraphData` no longer carries a `std::mutex` per vector.
- The replacement storage is one byte per capacity slot, in a separate vector.
- This avoids extending packed struct layout over graph-data pointers/flexible link arrays.

## Validation

Local validation in a fresh worktree from `origin/main`:
- `make build`
- `ctest --output-on-failure -R 'test_allocator|test_hnsw|test_hnsw_parallel' -j$(nproc)`
- `./test_hnsw_parallel`
- `./test_allocator --gtest_filter='*hnsw*'`
- `ROOT=/home/guy/Code/VectorSimilarity-hnsw-one-byte-locks ./test_hnsw --gtest_brief=1`

Note: `make check-format` currently reports pre-existing unrelated formatting violations in files outside this change (for example `batch_iterator.h`, benchmark headers, and existing constructors in `test_allocator.cpp`). The files touched in this PR were formatted selectively.

## Benchmark request

Please run benchmark comparison for this PR. I am adding the `benchmarks-all` label to trigger the benchmark workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core HNSW concurrency on graph mutations and parallel search; correctness depends on the new lock primitive and id-indexed locking staying aligned with existing deadlock ordering.
> 
> **Overview**
> HNSW neighbor-link locking moves out of packed graph nodes into an index-owned **`elementLocks`** vector keyed by internal id, with a new compact **`vecsim_stl::one_byte_mutex`** (atomic wait/notify) instead of **`std::mutex`** on each **`ElementGraphData`**.
> 
> **`lockNodeLinks` / `unlockNodeLinks`** now take only **`idType`**; search, insert, delete/repair, batch iteration, and debug paths were updated accordingly. **`elementLocks`** is initialized on construct/load and grows with **`resizeIndexCommon`**. Memory estimation and allocator tests count one byte per capacity slot for the lock vector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6da02b84eb84f9359645e55545e3a4a6b1645f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->