### PR TITLE
Fix build on powerpc*

### DIFF
--- a/src/VecSim/spaces/space_includes.h
+++ b/src/VecSim/spaces/space_includes.h
@@ -17,6 +17,9 @@
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #include "cpuinfo_aarch64.h"
 #endif // CPU_FEATURES_ARCH_AARCH64
+#ifdef CPU_FEATURES_ARCH_PPC
+#include "cpuinfo_ppc.h"
+#endif // CPU_FEATURES_ARCH_PPC
 
 #if defined(__AVX512F__) || defined(__AVX__) || defined(__SSE__)
 #if defined(__GNUC__)

--- a/src/VecSim/spaces/spaces.h
+++ b/src/VecSim/spaces/spaces.h
@@ -57,6 +57,9 @@ static inline auto getCpuOptimizationFeatures(const void *arch_opt = nullptr) {
 #if defined(CPU_FEATURES_ARCH_AARCH64)
     using FeaturesType = cpu_features::Aarch64Features;
     constexpr auto getFeatures = cpu_features::GetAarch64Info;
+#elif defined(CPU_FEATURES_ARCH_PPC)
+    using FeaturesType = cpu_features::PPCFeatures;
+    constexpr auto getFeatures = cpu_features::GetPPCInfo;
 #else
     using FeaturesType = cpu_features::X86Features; // Fallback
     constexpr auto getFeatures = cpu_features::GetX86Info;


### PR DESCRIPTION
Two simple patches to fix powerpc* builds.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, build-target-specific wiring with no API or behavior change on x86_64/AArch64; PPC continues to use scalar distance paths guarded by existing arch macros.
> 
> **Overview**
> Fixes **powerpc\*** compilation and runtime CPU feature detection in VecSim by treating PPC like the existing x86_64 and AArch64 paths.
> 
> **`space_includes.h`** now includes `cpuinfo_ppc.h` when `CPU_FEATURES_ARCH_PPC` is defined. **`getCpuOptimizationFeatures`** in `spaces.h` selects `cpu_features::PPCFeatures` and `GetPPCInfo` on PPC instead of falling through to the x86 types and `GetX86Info`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f03391281c9ba09a139fab946bc3361bcc69e126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->