### PR TITLE
[MOD-16730] Repro: SIGSEGV in FP32/L2 SSE kernel (_mm_loadr_ps on unaligned allocator-placed vectors)

### DIFF
--- a/.github/workflows/event-sse-only-repro.yml
+++ b/.github/workflows/event-sse-only-repro.yml
@@ -1,0 +1,43 @@
+name: SSE-only unit tests (loadr alignment repro)
+
+# Demonstrates MOD-16730: builds the library with the AVX-family instruction flags disabled,
+# which is the build any x86-64 machine without AVX gets. The dispatcher then selects the SSE
+# tier, and the FP32/L2 kernel's _mm_loadr_ps residual path (dim % 4 == 3) executes movaps on
+# the unaligned pointers produced by VecSimAllocator - crashing test_spaces / test_bruteforce.
+# This job is EXPECTED TO FAIL until the kernel is fixed.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  sse-only-unit-tests:
+    name: SSE-only build (AVX flags off) unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: install dependencies
+        run: .install/install_script.sh sudo
+      - name: Print CPU information
+        run: lscpu
+      - name: unit tests (SSE-only build)
+        env:
+          # Force the compiler-flag detection results off for every AVX-family tier, so no
+          # OPT_AVX*/OPT_F16C code is compiled and the dispatcher falls through to the SSE tiers
+          # at runtime - equivalent to running on a pre-AVX machine.
+          CMAKE_FLAGS: >-
+            -DCXX_AVX512VL=FALSE
+            -DCXX_AVX512BF16=FALSE
+            -DCXX_AVX512BW=FALSE
+            -DCXX_AVX512VBMI2=FALSE
+            -DCXX_AVX512FP16=FALSE
+            -DCXX_AVX512F=FALSE
+            -DCXX_AVX512VNNI=FALSE
+            -DCXX_AVX2=FALSE
+            -DCXX_AVX=FALSE
+            -DCXX_F16C=FALSE
+            -DCXX_FMA=FALSE
+        run: make unit_test CTEST_ARGS="-R 'spaces|bruteforce' --output-on-failure"

--- a/.github/workflows/event-sse-only-repro.yml
+++ b/.github/workflows/event-sse-only-repro.yml
@@ -40,4 +40,7 @@ jobs:
             -DCXX_AVX=FALSE
             -DCXX_F16C=FALSE
             -DCXX_FMA=FALSE
-        run: make unit_test CTEST_ARGS="-R 'spaces|bruteforce' --output-on-failure"
+        # ctest test names come from gtest_discover_tests, i.e. gtest case names like
+        # "SpacesTest.*" / "BruteForceTest/0.*". --no-tests=error guards against a regex
+        # matching nothing and silently passing.
+        run: make unit_test CTEST_ARGS="-R 'SpacesTest|BruteForce' --no-tests=error --output-on-failure"

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -39,6 +39,34 @@ protected:
 
 TYPED_TEST_SUITE(BruteForceTest, DataTypeSet);
 
+// End-to-end repro for the _mm_loadr_ps alignment fault: full index flow - factory, dispatcher,
+// preprocessor, allocator-placed vectors, TopK query. On a build/machine where the dispatcher
+// selects the SSE tier for FP32/L2 (no AVX), dim 19 routes to the _mm_loadr_ps residual path
+// with the allocator's 8-mod-16 pointers and crashes with SIGSEGV.
+TEST(BruteForceFlowRepro, fp32_l2_dim19_sse_loadr_flow) {
+    constexpr size_t dim = 19; // dim % 16 == 3 -> residual 3 -> _mm_loadr_ps path on SSE tier
+    BFParams bfParams = {.type = VecSimType_FLOAT32, .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams params = CreateParams(bfParams);
+    VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_NE(index, nullptr);
+
+    float v[dim];
+    for (size_t label = 0; label < 4; label++) {
+        for (size_t i = 0; i < dim; i++)
+            v[i] = float(label + i);
+        VecSimIndex_AddVector(index, v, label);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 4);
+
+    float q[dim];
+    for (size_t i = 0; i < dim; i++)
+        q[i] = float(i) + 0.5f;
+    VecSimQueryReply *res = VecSimIndex_TopKQuery(index, q, 2, nullptr, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(res), 2);
+    VecSimQueryReply_Free(res);
+    VecSimIndex_Free(index);
+}
+
 TYPED_TEST(BruteForceTest, brute_force_vector_add_test) {
 
     size_t dim = 4;

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -581,6 +581,28 @@ TEST_F(SpacesTest, GetDistFuncSQ8FP16Asymmetric) {
 }
 
 #ifdef CPU_FEATURES_ARCH_X86_64
+#ifdef OPT_SSE
+// Reproduces the _mm_loadr_ps alignment fault in the FP32 L2 SSE kernel (residual % 4 == 3
+// path). Buffers are placed at (16-aligned base) + 8 - exactly where VecSimAllocator::allocate()
+// puts vector data when no alignment hint is set, which is always the case on this path since
+// the dispatcher only sets a hint when dim % 4 == 0 and this path requires dim % 4 == 3.
+TEST_F(SpacesTest, FP32_L2Sqr_SSE_loadr_misaligned) {
+    constexpr size_t dim = 19; // dim % 16 == 3 -> residual 3 -> _mm_loadr_ps path
+    alignas(16) static char raw1[16 + dim * sizeof(float)];
+    alignas(16) static char raw2[16 + dim * sizeof(float)];
+    float *v1 = reinterpret_cast<float *>(raw1 + 8); // address == 8 (mod 16)
+    float *v2 = reinterpret_cast<float *>(raw2 + 8);
+    for (size_t i = 0; i < dim; i++) {
+        v1[i] = float(i);
+        v2[i] = float(i) + 1.5f;
+    }
+    float baseline = FP32_L2Sqr(v1, v2, dim);
+    dist_func_t<float> arch_opt_func = spaces::Choose_FP32_L2_implementation_SSE(dim);
+    // SIGSEGV here: the kernel's residual path executes movaps on the 8-mod-16 addresses.
+    ASSERT_EQ(baseline, arch_opt_func(v1, v2, dim));
+}
+#endif // OPT_SSE
+
 TEST_F(SpacesTest, smallDimChooser) {
     // Verify that small dimensions gets the no optimization function.
     for (size_t dim = 1; dim < 8; dim++) {


### PR DESCRIPTION
**Do not merge — reproduction PR for [MOD-16730](https://redislabs.atlassian.net/browse/MOD-16730). CI is EXPECTED TO FAIL.**

## What this shows

The FP32 L2 SSE kernel (`src/VecSim/spaces/L2/L2_SSE_FP32.h`) handles `residual % 4 == 3` with `_mm_loadr_ps`, which compiles to `movaps` — a load that requires a 16-byte-aligned address. Production vectors are never guaranteed that alignment: `VecSimAllocator::allocate()` returns `malloc + 8` (allocation header), and the dispatcher only sets an alignment hint when `dim % 4 == 0`, while this path requires `dim % 4 == 3`. Result: any FP32/L2 query with `dim % 16 ∈ {3,7,11,15}` segfaults on machines whose dispatcher selects the SSE tier (no AVX).

## What's in the PR

1. **Kernel-level test** (`test_spaces`): calls `Choose_FP32_L2_implementation_SSE(19)` with buffers at `16-aligned + 8` — the allocator's exact placement. Crashes on **any** x86-64 machine (the SSE TU always compiles `movaps`), so the regular unit-test jobs fail too.
2. **End-to-end test** (`test_bruteforce`): plain public API — create BF index (FP32, dim 19, L2), add vectors, TopK query. Passes on AVX machines, **SIGSEGVs inside `VecSimIndex_TopKQuery`** when the SSE tier is selected.
3. **New CI job** (`event-sse-only-repro.yml`): builds with the AVX-family compile flags disabled (the build an AVX-less machine gets; binary links no `Choose_*_AVX*` symbols) and runs the spaces/bruteforce suites — demonstrating the crash through the full dispatch path.

## Why existing CI never caught it

Unit-test/benchmark buffers are stack arrays / plain `new` allocations that happen to be 16-byte aligned, and every CI runner has AVX, so index-level tests never route to the SSE kernel. The crash needs both conditions at once: SSE tier selection + the allocator's 8-mod-16 placement.

## Fix (not included — this PR only demonstrates)

Replace the reversed aligned load with the element-wise pattern the IP twin (`IP_SSE_FP32.h`) already uses for the same residual: `_mm_load_ss` + `_mm_loadh_pi` (both alignment-free). Two-line change. Details, disassembly evidence, and affected-dims analysis in MOD-16730. Related: PR #984 review (the PR lowers the FP32 SIMD floor from 16 to 8, extending the affected dims to 11 and 15, and its new comment claims the load is "(aligned)").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOD-16730]: https://redislabs.atlassian.net/browse/MOD-16730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ