### PR TITLE
[SVS] Add SVS Index TopK benchmark

### DIFF
--- a/tests/benchmark/bm_initialization/bm_basics_svs_initialize_fp32.h
+++ b/tests/benchmark/bm_initialization/bm_basics_svs_initialize_fp32.h
@@ -54,3 +54,17 @@ BENCHMARK_REGISTER_F(BM_VecSimSVS, BM_FUNC_NAME(BM_AddVectorsDuringTraining))
                    {2, 4}})
     ->ArgNames({"training_threshold", "thread_count"})
     ->UseRealTime();
+
+// TopK search on the loaded SVS index, using the search window_size and k defined below.
+// {window_size, k} (recall that always window_size >= k)
+BENCHMARK_TEMPLATE_DEFINE_F(BM_VecSimSVS, BM_FUNC_NAME(BM_TopK), DATA_TYPE_INDEX_T)
+(benchmark::State &st) { TopK_SVS(st); }
+BENCHMARK_REGISTER_F(BM_VecSimSVS, BM_FUNC_NAME(BM_TopK))
+    ->Unit(benchmark::kMillisecond)
+    ->Iterations(10)
+    ->Args({10, 10})
+    ->Args({200, 10})
+    ->Args({100, 100})
+    ->Args({200, 100})
+    ->Args({500, 500})
+    ->ArgNames({"window_size", "k"});

--- a/tests/benchmark/bm_vecsim_svs.h
+++ b/tests/benchmark/bm_vecsim_svs.h
@@ -477,7 +477,9 @@ void BM_VecSimSVS<index_type_t>::TopK_SVS(benchmark::State &st) {
     // Load the SVS index from file (update_threshold is irrelevant for a search-only benchmark).
     auto *index = CreateSVSIndexFromFile(1);
 
-    VecSimQueryParams query_params = {.svsRuntimeParams = {.windowSize = window_size}};
+    SVSRuntimeParams svs_params = {.windowSize = window_size};
+
+    VecSimQueryParams query_params = {.svsRuntimeParams = svs_params};
 
     size_t iter = 0;
     for (auto _ : st) {

--- a/tests/benchmark/bm_vecsim_svs.h
+++ b/tests/benchmark/bm_vecsim_svs.h
@@ -54,6 +54,10 @@ public:
     // Deletes an amount of labels from the index that triggers inplace consolidation.
     void RunGC(benchmark::State &st);
 
+    // TopK search benchmark. The search window size and k are provided by the benchmark
+    // registration.
+    void TopK_SVS(benchmark::State &st);
+
 private:
     static const char *svs_index_tar_file;
     static std::string base_path;
@@ -461,6 +465,29 @@ void BM_VecSimSVS<index_type_t>::RunGC(benchmark::State &st) {
     ASSERT_EQ(info.svsInfo.numberOfMarkedDeletedNodes, 0);
 
     ASSERT_EQ(VecSimIndex_IndexSize(tiered_index), N_VECTORS - num_deletions);
+}
+
+template <typename index_type_t>
+void BM_VecSimSVS<index_type_t>::TopK_SVS(benchmark::State &st) {
+    // Search window size (Vamana graph accuracy/latency tuning) and number of results, as
+    // defined by the benchmark registration.
+    size_t window_size = st.range(0);
+    size_t k = st.range(1);
+
+    // Load the SVS index from file (update_threshold is irrelevant for a search-only benchmark).
+    auto *index = CreateSVSIndexFromFile(1);
+
+    VecSimQueryParams query_params = {.svsRuntimeParams = {.windowSize = window_size}};
+
+    size_t iter = 0;
+    for (auto _ : st) {
+        auto results = VecSimIndex_TopKQuery(index, test_vectors[iter % N_QUERIES].data(), k,
+                                             &query_params, BY_SCORE);
+        VecSimQueryReply_Free(results);
+        iter++;
+    }
+
+    VecSimIndex_Free(index);
 }
 
 #define UNIT_AND_ITERATIONS Unit(benchmark::kMillisecond)->Iterations(2)


### PR DESCRIPTION
**Add TopK search benchmark for SVS Vamana index**

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only changes with no production or API impact.
> 
> **Overview**
> Adds **TopK search** coverage for the SVS Vamana index in the benchmark suite, parallel to existing HNSW/flat TopK tests.
> 
> **`TopK_SVS`** loads a prebuilt SVS index via `CreateSVSIndexFromFile`, runs `VecSimIndex_TopKQuery` with **`SVSRuntimeParams.windowSize`** (search window) and **`k`** from benchmark args, rotates through loaded query vectors, and frees the index after the run.
> 
> **`BM_TopK`** is registered for fp32 SVS with millisecond timing, 10 iterations, and five **`{window_size, k}`** pairs (e.g. 10/10 through 500/500) to sweep accuracy/latency tradeoffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 225902cd30bb8ecb748b7b06fc2034dfbf13a182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->