### PR TITLE
Bump documented minimum GCC to 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The tables below detail the supported SIMD instruction sets (CPU flags) used for
 ## Build
 For building you will need:
 1. Python 3 as `python` (either by creating a virtual environment or setting your system python to point to the right python distribution)
-2. gcc >= 10
+2. gcc >= 11
 3. cmake version >= 3.10. (To build the `python bindings` you will need cmake < 3.26 due to `pybind11` policy version handling).
 
 To build the main library and unit tests in one command run


### PR DESCRIPTION
#983 introduced `vecsim_stl::one_byte_mutex`, which uses C++20 `std::atomic::wait`/`notify_one`. libstdc++ only implements these from GCC 11 (P1135), so GCC 10 no longer builds the library. Update the README build requirement accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to build requirements; no runtime or library code is modified.
> 
> **Overview**
> Updates the **Build** prerequisites in `README.md` so the documented compiler requirement is **gcc >= 11** instead of **gcc >= 10**.
> 
> This aligns the README with the library’s use of C++20 `std::atomic::wait` / `notify_one` in `vecsim_stl::one_byte_mutex` (libstdc++ support from GCC 11 onward), so builders on GCC 10 are not told they can compile when the toolchain no longer matches the code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342e84d9ea966f69ca8ead18913a5ba9291d7e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->