### PR TITLE
[MOD-16610] SVS shared pool: rent() waits for occupied slots instead of dropping work

### DIFF
--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -22,9 +22,11 @@
 #endif
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <utility>
@@ -368,20 +370,26 @@ struct ThreadSlot {
 // * Pool is physically resizable (creates/destroys OS threads)
 // * Threads are rented for the duration of a parallel_for call
 // * Multiple callers can rent disjoint subsets of threads concurrently
+// * A renter that finds too few free slots waits for them to be released
 // * Shrinking while threads are rented is safe (shared_ptr lifecycle)
 class VecSimSVSThreadPoolImpl {
     // RAII guard for threads rented from the shared pool. On destruction, marks all
-    // rented slots as unoccupied (lock-free atomic stores). Uses raw pointers to
-    // avoid shared_ptr ref-counting overhead on the hot path.
+    // rented slots as unoccupied (lock-free atomic stores) and wakes renters waiting
+    // for slots. Uses raw pointers to avoid shared_ptr ref-counting overhead on the
+    // hot path.
     // Safety: raw pointers are safe because the deferred-resize protocol ensures the
     // pool cannot shrink (destroy slots) while scheduled jobs are in flight, and all
     // multi-threaded SVS operations run within scheduled jobs.
     class RentedThreads {
     public:
         RentedThreads() = default;
+        explicit RentedThreads(VecSimSVSThreadPoolImpl *pool) : pool_(pool) {}
 
         // Move-only
-        RentedThreads(RentedThreads &&other) noexcept : slots_(std::move(other.slots_)) {}
+        RentedThreads(RentedThreads &&other) noexcept
+            : pool_(other.pool_), slots_(std::move(other.slots_)) {
+            other.pool_ = nullptr;
+        }
         RentedThreads(const RentedThreads &) = delete;
         RentedThreads &operator=(const RentedThreads &) = delete;
         RentedThreads &operator=(RentedThreads &&) = delete;
@@ -399,12 +407,17 @@ class VecSimSVSThreadPoolImpl {
 
     private:
         void release() {
+            if (slots_.empty()) {
+                return;
+            }
             for (auto *slot : slots_) {
                 slot->occupied.store(false, std::memory_order_release);
             }
             slots_.clear();
+            pool_->notifySlotsReleased();
         }
 
+        VecSimSVSThreadPoolImpl *pool_ = nullptr;
         std::vector<ThreadSlot *> slots_;
     };
 
@@ -592,40 +605,78 @@ public:
     }
 
 private:
-    // Rent up to `count` worker threads from the pool. Returns an RAII guard that
-    // automatically releases the threads when destroyed.
-    // The SVS pool is sized to match the RediSearch thread pool, and RediSearch controls
-    // scheduling via reserve jobs, so all requested slots should always be available.
-    // Getting fewer threads than requested indicates a bug in the scheduling logic.
+    // Rent `count` worker threads from the pool, waiting for occupied slots to be
+    // released when fewer than `count` are currently free. Returns an RAII guard that
+    // automatically releases the threads (and wakes waiting renters) when destroyed.
+    //
+    // Waiting is required because the pool can be smaller than the RediSearch worker
+    // pool (it is capped at the available CPU count, MOD-16610), so scheduled jobs of
+    // two indexes can execute concurrently and contend for the same slots. Acquisition
+    // is all-or-nothing — a renter never holds a partial set of slots while waiting —
+    // so concurrent renters cannot deadlock each other; and slot holders never block
+    // on waiters (slots are always released via RAII when their parallel_for ends),
+    // so the wait always terminates.
+    //
+    // If `count` exceeds the pool's slot count (the pool shrank under a non-scheduled
+    // caller), waiting could never succeed: rent whatever is free, warn, and assert —
+    // that indicates a bug in the scheduling logic.
     RentedThreads rent(size_t count, void *log_ctx = nullptr) {
-        RentedThreads rented;
+        RentedThreads rented{this};
         if (count == 0) {
             return rented;
         }
 
-        std::lock_guard lock{pool_mutex_};
-        size_t rented_count = 0;
+        std::unique_lock lock{pool_mutex_};
+        while (count <= slots_.size()) {
+            size_t free_count = 0;
+            for (auto &slot : slots_) {
+                if (!slot->occupied.load(std::memory_order_acquire)) {
+                    ++free_count;
+                }
+            }
+            if (free_count >= count) {
+                claimFreeSlotsLocked(count, rented);
+                // Renting is serialized by pool_mutex_ and releases only add free
+                // slots, so the claim cannot come up short here.
+                assert(rented.count() == count);
+                return rented;
+            }
+            slots_released_.wait(lock);
+        }
+
+        claimFreeSlotsLocked(count, rented);
+        auto msg = fmt::format("SVS thread pool: rented {} threads out of {} requested "
+                               "(pool has {} slots). This should not happen.",
+                               rented.count(), count, slots_.size());
+        if (VecSimIndexInterface::logCallback) {
+            assert(log_ctx && "Log context must be provided when logging is available");
+            VecSimIndexInterface::logCallback(log_ctx, "warning", msg.c_str());
+        }
+        assert(false && "Failed to rent the expected number of SVS threads");
+        return rented;
+    }
+
+    // Claim up to `count` free slots into `rented`. Caller must hold pool_mutex_.
+    void claimFreeSlotsLocked(size_t count, RentedThreads &rented) {
         for (auto &slot : slots_) {
             bool expected = false;
             if (slot->occupied.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
                 rented.add(slot.get());
-                if (++rented_count >= count) {
-                    break;
+                if (rented.count() >= count) {
+                    return;
                 }
             }
         }
+    }
 
-        if (rented.count() < count) {
-            auto msg = fmt::format("SVS thread pool: rented {} threads out of {} requested "
-                                   "(pool has {} slots). This should not happen.",
-                                   rented.count(), count, slots_.size());
-            if (VecSimIndexInterface::logCallback) {
-                assert(log_ctx && "Log context must be provided when logging is available");
-                VecSimIndexInterface::logCallback(log_ctx, "warning", msg.c_str());
-            }
-            assert(false && "Failed to rent the expected number of SVS threads");
-        }
-        return rented;
+    // Wake renters waiting in rent(). Called by RentedThreads::release() after marking
+    // the slots unoccupied, without holding pool_mutex_. The empty lock/unlock pairs
+    // with the waiter's condition wait: a waiter that saw the slots still occupied is
+    // guaranteed to already be inside wait() when the notification fires, so the
+    // wakeup cannot be missed.
+    void notifySlotsReleased() {
+        { std::lock_guard lock{pool_mutex_}; }
+        slots_released_.notify_all();
     }
 
     // Wait for all rented workers to finish. If any worker (or the main thread) threw,
@@ -684,10 +735,16 @@ private:
                 slots_.resize(target_workers);
             }
         }
+        // The slot count may have changed: wake waiting renters so they re-evaluate
+        // (new free slots after a grow; an impossible request after a shrink).
+        slots_released_.notify_all();
     }
 
     std::shared_ptr<VecSimAllocator> allocator_; // pool's own allocator for memory tracking
     mutable std::mutex pool_mutex_;
+    // Signaled whenever slots are released or the slot count changes; rent() waits on
+    // this when fewer free slots are available than requested.
+    std::condition_variable slots_released_;
     vecsim_stl::vector<SlotPtr> slots_;
     size_t pending_jobs_ = 0; // jobs currently scheduled / in-flight
     // Pending pool size to apply at the next safe point: either the first SVS index

--- a/tests/unit/test_svs_threadpool.cpp
+++ b/tests/unit/test_svs_threadpool.cpp
@@ -452,15 +452,16 @@ TEST_F(SVSThreadPoolTest, ConcurrentRentalFromTwoIndexes) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 8: All threads occupied — graceful degradation
+// Test 8: All threads occupied — rent() waits instead of dropping work
 // When all pool threads are rented by wrapper A, wrapper B's parallel_for
-// cannot rent any workers. In debug builds, rent() asserts. In release
-// builds, parallel_for uses rented.count() (0 workers) and runs only
-// partition 0 on the calling thread.
+// must WAIT for A to release its slots, then run ALL of its partitions.
 //
-// NOTE: This should never happen in production. RediSearch's reserve job
-// mechanism guarantees that the number of concurrent renters never exceeds
-// the pool size. This test exercises the defensive fallback path.
+// This is reachable in production once the shared pool is capped at the CPU
+// count (MOD-16610): the RediSearch worker pool can then be larger than the
+// SVS pool, so a second index's scheduled job starts on spare workers while
+// the first index holds every slot. Before the wait semantics, rent() came up
+// short here — assert in debug, silent partition drop (incomplete update) in
+// release.
 // ---------------------------------------------------------------------------
 TEST_F(SVSThreadPoolTest, AllThreadsOccupied) {
     // Pool size 4 (3 worker slots). Wrapper A rents all 3.
@@ -474,7 +475,7 @@ TEST_F(SVSThreadPoolTest, AllThreadsOccupied) {
     std::atomic_int resultA{0};
 
     // Spawned thread: wrapper A grabs all 3 worker slots and blocks.
-    std::thread t([&] {
+    std::thread tA([&] {
         wrapperA.parallel_for(
             [&](size_t tid) {
                 if (tid > 0) {
@@ -491,26 +492,35 @@ TEST_F(SVSThreadPoolTest, AllThreadsOccupied) {
            "resultA="
         << resultA << ", pool_size=" << wrapperA.poolSize();
 
-    // All 3 worker slots are occupied. Wrapper B tries to rent 1 worker.
+    // All 3 worker slots are occupied. Wrapper B needs 1 worker; it must wait
+    // for A instead of proceeding with fewer threads than requested.
     VecSimSVSThreadPool wrapperB{allocator_};
     wrapperB.setParallelism(2);
-
-#ifdef NDEBUG
-    // Release: graceful degradation — rent() returns 0 workers, parallel_for
-    // runs only partition 0 on the calling thread. Work is silently dropped.
     std::atomic_int resultB{0};
-    wrapperB.parallel_for([&](size_t) { resultB++; }, 2);
-    ASSERT_EQ(resultB, 1); // only partition 0 ran
-#else
-    // Debug: rent() asserts because it can't fulfill the request.
-    ASSERT_DEATH(wrapperB.parallel_for([&](size_t) {}, 2),
-                 "Failed to rent the expected number of SVS threads");
-#endif
 
-    // Clean up: release wrapper A's blocked threads.
+    std::thread tB([&] {
+        wrapperB.parallel_for(
+            [&](size_t) {
+                // Slots are released only after all of A's partitions finished,
+                // so by the time B runs anything, A's work must be complete.
+                EXPECT_EQ(resultA.load(), 4) << "B ran while A still held the pool";
+                resultB++;
+            },
+            2);
+    });
+
+    // Give B ample time to reach rent(). It must be parked there having
+    // executed nothing — not degrading to "partition 0 only".
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    ASSERT_EQ(resultB.load(), 0)
+        << "wrapper B executed work while all slots were rented — rent() did not wait";
+
+    // Release A. B must then acquire a slot and run BOTH of its partitions.
     hold.count_down();
-    t.join();
+    tA.join();
+    tB.join();
     ASSERT_EQ(resultA, 4);
+    ASSERT_EQ(resultB, 2) << "wrapper B dropped partitions";
 }
 
 #endif // HAVE_SVS


### PR DESCRIPTION
**Describe the changes in the pull request**

Follow-up to RediSearch/RediSearch#10419 (cap the shared SVS pool at the available CPU count), addressing the concurrency gap flagged in [its review](https://github.com/RediSearch/RediSearch/pull/10419#discussion_r3566495192).

**The problem.** Cross-index exclusion of SVS scheduled jobs was an *accident* of the pool sizes being equal: with the SVS pool sized to `WORKERS`, one scheduled job's reserve jobs saturated the entire RediSearch worker pool, so a second index's update/GC could not start, and `rent()` could provably never come up short (total rented = total reserved − #jobs ≤ WORKERS − 1 = slots). Once the SVS pool is capped at the CPU count while `WORKERS` stays larger, a scheduled job reserves only pool-size workers, spare workers pick up a second index's jobs immediately, and both jobs rent from the same slots. The loser's `rent()` came up short: warning + `assert(false)` in debug builds (shard abort), and in release builds `parallel_for` silently dropped the un-rented partitions — an incomplete update/GC that reports success. Reachable even in OSS, e.g. `WORKERS 16` on an 8-CPU host with two SVS indexes.

**The fix.** Make slot acquisition in `rent()` all-or-nothing and blocking:

- A renter that finds fewer free slots than requested sleeps on a new condition variable (`slots_released_`) until slots are released or the pool is resized. It never holds a partial set of slots while waiting, so concurrent renters cannot deadlock each other.
- Slot holders never block on waiters — slots are always released via RAII (`RentedThreads` destructor) when their `parallel_for` ends — so the wait always terminates. The waiter's job keeps holding its reserved RediSearch workers meanwhile, same as any long-running job.
- `RentedThreads::release()` wakes waiters via an empty lock/unlock of `pool_mutex_` + `notify_all`, pairing with the waiter's condition wait so a wakeup cannot be missed.
- `resize_locked()` wakes waiters when the slot count changes (new free slots after a grow; an impossible request after a shrink).
- Requests larger than the whole pool (only possible if the pool shrinks under a non-scheduled caller) keep the legacy best-effort + warn + assert path.

Concurrent *disjoint* rentals (two indexes whose parallelism sums to ≤ pool size) are unchanged and still run in parallel (`ConcurrentRentalFromTwoIndexes` still passes). The Redis main thread is never affected: it only enqueues jobs; renting happens on worker threads (in write-in-place mode the pool has 0 worker slots and `parallel_for(f, 1)` never rents).

**Testing.** Rewrote `SVSThreadPoolTest.AllThreadsOccupied`, which previously asserted the degradation as a "defensive fallback" (`resultB == 1` / `ASSERT_DEATH`), to assert the new semantics: wrapper B arriving at a fully-occupied pool executes nothing while A holds the slots, then runs **all** of its partitions after A finishes, observing A's completed work. Written TDD-style: the test aborts on the previous code at the `rent()` assert; passes with the fix. Full `test_svs` suite: 465 passed.

**Which issues this PR fixes**
1. MOD-16610 (together with RediSearch/RediSearch#10419)

**Main objects this PR modified**
1. `VecSimSVSThreadPoolImpl::rent()` — waits (all-or-nothing) instead of returning short
2. `VecSimSVSThreadPoolImpl::RentedThreads` — release now wakes waiting renters
3. `VecSimSVSThreadPoolImpl::resize_locked()` — wakes waiting renters on slot-count changes
4. `tests/unit/test_svs_threadpool.cpp::AllThreadsOccupied` — asserts wait-then-complete semantics

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes