### PR TITLE
[MOD-17102] Add cosine-family support for COSINE_SIMILARITY

### DIFF
--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -66,11 +66,6 @@ inline double toVecSimDistance<svs::distance::DistanceIP>(float v) {
     return 1.0 - static_cast<double>(v);
 }
 
-template <>
-inline double toVecSimDistance<svs::distance::DistanceCosineSimilarity>(float v) {
-    return 1.0 - static_cast<double>(v);
-}
-
 // VecSim allocator wrapper for SVS containers
 template <typename T>
 using SVSAllocator = VecsimSTLAllocator<T>;

--- a/src/VecSim/index_factories/components/preprocessors_factory.h
+++ b/src/VecSim/index_factories/components/preprocessors_factory.h
@@ -44,7 +44,7 @@ CreatePreprocessorsContainerParams(VecSimMetric metric, size_t dim, bool is_norm
     size_t processed_bytes_count = dim * sizeof(DataType);
 
     VecSimMetric pp_metric = metric;
-    if (metric == VecSimMetric_Cosine) {
+    if (VecSimMetric_IsCosineFamily(metric)) {
         // if metric is cosine and DataType is integral, the processed_bytes_count includes the
         // norm appended to the vector.
         if (std::is_integral<DataType>::value) {
@@ -78,7 +78,7 @@ PreprocessorsContainerAbstract *
 CreatePreprocessorsContainer(std::shared_ptr<VecSimAllocator> allocator,
                              PreprocessorsContainerParams params) {
 
-    if (params.metric == VecSimMetric_Cosine) {
+    if (VecSimMetric_IsCosineFamily(params.metric)) {
         auto multiPPContainer = new (allocator) MultiPreprocessorsContainer<DataType, 1>(
             allocator, params.query_alignment, params.storage_alignment);
         auto cosine_preprocessor = new (allocator)
@@ -118,13 +118,13 @@ template <typename DataType>
 size_t EstimatePreprocessorsContainerMemory(VecSimMetric metric, bool is_normalized = false) {
     size_t allocations_overhead = VecSimAllocator::getAllocationOverheadSize();
     VecSimMetric pp_metric;
-    if (is_normalized && metric == VecSimMetric_Cosine) {
+    if (is_normalized && VecSimMetric_IsCosineFamily(metric)) {
         pp_metric = VecSimMetric_IP;
     } else {
         pp_metric = metric;
     }
 
-    if (pp_metric == VecSimMetric_Cosine) {
+    if (VecSimMetric_IsCosineFamily(pp_metric)) {
         constexpr size_t n_preprocessors = 1;
         // One entry in preprocessors array
         size_t est =

--- a/src/VecSim/index_factories/svs_factory.cpp
+++ b/src/VecSim/index_factories/svs_factory.cpp
@@ -48,7 +48,7 @@ VecSimIndex *NewIndexImpl(const VecSimParams *params, bool is_normalized) {
         abstractInitParams.allocator, svsParams.metric, svsParams.dim, is_normalized, 0);
     IndexComponents<svs_details::vecsim_dt<DataType>, float> components = {
         nullptr, preprocessors}; // calculator is not in use in svs.
-    bool forcePreprocessing = !is_normalized && svsParams.metric == VecSimMetric_Cosine;
+    bool forcePreprocessing = !is_normalized && VecSimMetric_IsCosineFamily(svsParams.metric);
     if (svsParams.multi) {
         return new (abstractInitParams.allocator)
             SVSIndex<MetricType, DataType, true, QuantBits, ResidualBits, IsLeanVec>(
@@ -113,6 +113,7 @@ VecSimIndex *NewIndexImpl(const VecSimParams *params, bool is_normalized) {
         return NewIndexImpl<svs::distance::DistanceL2>(params, is_normalized);
     case VecSimMetric_IP:
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
         return NewIndexImpl<svs::distance::DistanceIP>(params, is_normalized);
     default:
         // If we got here something is wrong.

--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -256,9 +256,10 @@ class QuantPreprocessor : public PreprocessorInterface {
     using sq8 = vecsim_types::sq8;
 
     static_assert(Metric == VecSimMetric_L2 || Metric == VecSimMetric_IP ||
-                      Metric == VecSimMetric_Cosine,
-                  "QuantPreprocessor only supports L2, IP and Cosine metrics");
-    static_assert(!WithNorm || Metric != VecSimMetric_Cosine,
+                      Metric == VecSimMetric_Cosine || Metric == VecSimMetric_CosineSimilarity,
+                  "QuantPreprocessor only supports L2, IP and cosine-based metrics");
+    static_assert(!WithNorm ||
+                      (Metric != VecSimMetric_Cosine && Metric != VecSimMetric_CosineSimilarity),
                   "WithNorm does not support Cosine metric.");
 
     // Helper function to perform quantization. This function is used by the storage preprocessing

--- a/src/VecSim/spaces/spaces.cpp
+++ b/src/VecSim/spaces/spaces.cpp
@@ -26,6 +26,7 @@ dist_func_t<float> GetDistFunc<vecsim_types::bfloat16, float>(VecSimMetric metri
                                                               unsigned char *alignment) {
     switch (metric) {
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
     case VecSimMetric_IP:
         return IP_BF16_GetDistFunc(dim, alignment);
     case VecSimMetric_L2:
@@ -39,6 +40,7 @@ dist_func_t<float> GetDistFunc<vecsim_types::float16, float>(VecSimMetric metric
                                                              unsigned char *alignment) {
     switch (metric) {
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
     case VecSimMetric_IP:
         return IP_FP16_GetDistFunc(dim, alignment);
     case VecSimMetric_L2:
@@ -52,6 +54,7 @@ dist_func_t<float> GetDistFunc<float, float>(VecSimMetric metric, size_t dim,
                                              unsigned char *alignment) {
     switch (metric) {
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
     case VecSimMetric_IP:
         return IP_FP32_GetDistFunc(dim, alignment);
     case VecSimMetric_L2:
@@ -65,6 +68,7 @@ dist_func_t<double> GetDistFunc<double, double>(VecSimMetric metric, size_t dim,
                                                 unsigned char *alignment) {
     switch (metric) {
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
     case VecSimMetric_IP:
         return IP_FP64_GetDistFunc(dim, alignment);
     case VecSimMetric_L2:
@@ -78,6 +82,7 @@ dist_func_t<float> GetDistFunc<int8_t, float>(VecSimMetric metric, size_t dim,
                                               unsigned char *alignment) {
     switch (metric) {
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
         return Cosine_INT8_GetDistFunc(dim, alignment);
     case VecSimMetric_IP:
         return IP_INT8_GetDistFunc(dim, alignment);
@@ -92,6 +97,7 @@ dist_func_t<float> GetDistFunc<uint8_t, float>(VecSimMetric metric, size_t dim,
                                                unsigned char *alignment) {
     switch (metric) {
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
         return Cosine_UINT8_GetDistFunc(dim, alignment);
     case VecSimMetric_IP:
         return IP_UINT8_GetDistFunc(dim, alignment);
@@ -106,6 +112,7 @@ dist_func_t<float> GetDistFunc<vecsim_types::sq8, float>(VecSimMetric metric, si
                                                          unsigned char *alignment) {
     switch (metric) {
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
         return Cosine_SQ8_SQ8_GetDistFunc(dim, alignment);
     case VecSimMetric_IP:
         return IP_SQ8_SQ8_GetDistFunc(dim, alignment);
@@ -120,6 +127,7 @@ dist_func_t<float> GetDistFunc<vecsim_types::sq8, float, float>(VecSimMetric met
                                                                 unsigned char *alignment) {
     switch (metric) {
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
         return Cosine_SQ8_FP32_GetDistFunc(dim, alignment);
     case VecSimMetric_IP:
         return IP_SQ8_FP32_GetDistFunc(dim, alignment);
@@ -135,6 +143,7 @@ GetDistFunc<vecsim_types::sq8, float, vecsim_types::float16>(VecSimMetric metric
                                                              unsigned char *alignment) {
     switch (metric) {
     case VecSimMetric_Cosine:
+    case VecSimMetric_CosineSimilarity:
         return Cosine_SQ8_FP16_GetDistFunc(dim, alignment);
     case VecSimMetric_IP:
         return IP_SQ8_FP16_GetDistFunc(dim, alignment);

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -223,6 +223,8 @@ const char *VecSimMetric_ToString(VecSimMetric vecsimMetric) {
     switch (vecsimMetric) {
     case VecSimMetric_Cosine:
         return "COSINE";
+    case VecSimMetric_CosineSimilarity:
+        return "COSINE_SIMILARITY";
     case VecSimMetric_IP:
         return "IP";
     case VecSimMetric_L2:
@@ -295,7 +297,8 @@ size_t VecSimType_sizeof(VecSimType type) {
 
 size_t VecSimParams_GetStoredDataSize(VecSimType type, size_t dim, VecSimMetric metric) {
     size_t storedDataSize = VecSimType_sizeof(type) * dim;
-    if (metric == VecSimMetric_Cosine && (type == VecSimType_INT8 || type == VecSimType_UINT8)) {
+    if (VecSimMetric_IsCosineFamily(metric) &&
+        (type == VecSimType_INT8 || type == VecSimType_UINT8)) {
         storedDataSize += sizeof(float); // For the norm
     }
     return storedDataSize;

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -259,7 +259,8 @@ extern "C" size_t VecSimParams_GetQueryBlobSize(VecSimType type, size_t dim, Vec
            type == VecSimType_BFLOAT16 || type == VecSimType_FLOAT16 || type == VecSimType_INT8 ||
            type == VecSimType_UINT8);
     size_t blobSize = VecSimType_sizeof(type) * dim;
-    if (metric == VecSimMetric_Cosine && (type == VecSimType_INT8 || type == VecSimType_UINT8)) {
+    if (VecSimMetric_IsCosineFamily(metric) &&
+        (type == VecSimType_INT8 || type == VecSimType_UINT8)) {
         blobSize += sizeof(float); // For the norm
     }
     return blobSize;

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -84,7 +84,18 @@ typedef enum {
 } VecSimBool;
 
 // Distance metric
-typedef enum { VecSimMetric_L2, VecSimMetric_IP, VecSimMetric_Cosine } VecSimMetric;
+typedef enum {
+    VecSimMetric_L2,
+    VecSimMetric_IP,
+    VecSimMetric_Cosine,
+    VecSimMetric_CosineSimilarity
+} VecSimMetric;
+
+// Returns true for any metric whose internal execution path uses cosine distance,
+// regardless of how scores are presented at the API boundary.
+static inline bool VecSimMetric_IsCosineFamily(VecSimMetric metric) {
+    return metric == VecSimMetric_Cosine || metric == VecSimMetric_CosineSimilarity;
+}
 
 typedef size_t labelType;
 typedef unsigned int idType;

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -679,6 +679,7 @@ PYBIND11_MODULE(VecSim, m) {
         .value("VecSimMetric_L2", VecSimMetric_L2)
         .value("VecSimMetric_IP", VecSimMetric_IP)
         .value("VecSimMetric_Cosine", VecSimMetric_Cosine)
+        .value("VecSimMetric_CosineSimilarity", VecSimMetric_CosineSimilarity)
         .export_values();
 
     py::enum_<VecSimOptionMode>(m, "VecSimOptionMode")

--- a/tests/unit/test_components.cpp
+++ b/tests/unit/test_components.cpp
@@ -1394,11 +1394,15 @@ TEST_P(QuantPreprocessorMetricTest, QuantizationBlobSizeAndMetadata) {
     case VecSimMetric_Cosine:
         runQuantizationTest<VecSimMetric_Cosine>();
         break;
+    case VecSimMetric_CosineSimilarity:
+        runQuantizationTest<VecSimMetric_CosineSimilarity>();
+        break;
     }
 }
 
 INSTANTIATE_TEST_SUITE_P(QuantPreprocessorTests, QuantPreprocessorMetricTest,
-                         testing::Values(VecSimMetric_L2, VecSimMetric_IP, VecSimMetric_Cosine),
+                         testing::Values(VecSimMetric_L2, VecSimMetric_IP, VecSimMetric_Cosine,
+                                         VecSimMetric_CosineSimilarity),
                          [](const testing::TestParamInfo<VecSimMetric> &info) {
                              return VecSimMetric_ToString(info.param);
                          });
@@ -1558,11 +1562,15 @@ TEST_P(QuantPreprocessorFP16MetricTest, QuantizationBlobSizeAndMetadata) {
     case VecSimMetric_Cosine:
         runQuantizationTest<VecSimMetric_Cosine>();
         break;
+    case VecSimMetric_CosineSimilarity:
+        runQuantizationTest<VecSimMetric_CosineSimilarity>();
+        break;
     }
 }
 
 INSTANTIATE_TEST_SUITE_P(QuantPreprocessorFP16Tests, QuantPreprocessorFP16MetricTest,
-                         testing::Values(VecSimMetric_L2, VecSimMetric_IP, VecSimMetric_Cosine),
+                         testing::Values(VecSimMetric_L2, VecSimMetric_IP, VecSimMetric_Cosine,
+                                         VecSimMetric_CosineSimilarity),
                          [](const testing::TestParamInfo<VecSimMetric> &info) {
                              return VecSimMetric_ToString(info.param);
                          });

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -531,51 +531,51 @@ TEST_F(SpacesTest, SQ8_FP16_l2sqr_odd_dim_unaligned_metadata_test) {
 /* ======================== Test Getters ======================== */
 
 TEST_F(SpacesTest, GetDistFuncInvalidMetricFP32) {
-    EXPECT_THROW(
-        (spaces::GetDistFunc<float, float>((VecSimMetric)(VecSimMetric_Cosine + 1), 10, nullptr)),
-        std::invalid_argument);
+    EXPECT_THROW((spaces::GetDistFunc<float, float>(
+                     (VecSimMetric)(VecSimMetric_CosineSimilarity + 1), 10, nullptr)),
+                 std::invalid_argument);
 }
 TEST_F(SpacesTest, GetDistFuncInvalidMetricFP64) {
-    EXPECT_THROW(
-        (spaces::GetDistFunc<double, double>((VecSimMetric)(VecSimMetric_Cosine + 1), 10, nullptr)),
-        std::invalid_argument);
+    EXPECT_THROW((spaces::GetDistFunc<double, double>(
+                     (VecSimMetric)(VecSimMetric_CosineSimilarity + 1), 10, nullptr)),
+                 std::invalid_argument);
 }
 TEST_F(SpacesTest, GetDistFuncInvalidMetricBF16) {
-    EXPECT_THROW((spaces::GetDistFunc<bfloat16, float>((VecSimMetric)(VecSimMetric_Cosine + 1), 10,
-                                                       nullptr)),
+    EXPECT_THROW((spaces::GetDistFunc<bfloat16, float>(
+                     (VecSimMetric)(VecSimMetric_CosineSimilarity + 1), 10, nullptr)),
                  std::invalid_argument);
 }
 TEST_F(SpacesTest, GetDistFuncInvalidMetricFP16) {
-    EXPECT_THROW(
-        (spaces::GetDistFunc<float16, float>((VecSimMetric)(VecSimMetric_Cosine + 1), 10, nullptr)),
-        std::invalid_argument);
+    EXPECT_THROW((spaces::GetDistFunc<float16, float>(
+                     (VecSimMetric)(VecSimMetric_CosineSimilarity + 1), 10, nullptr)),
+                 std::invalid_argument);
 }
 TEST_F(SpacesTest, GetDistFuncInvalidMetricINT8) {
-    EXPECT_THROW(
-        (spaces::GetDistFunc<int8_t, float>((VecSimMetric)(VecSimMetric_Cosine + 1), 10, nullptr)),
-        std::invalid_argument);
+    EXPECT_THROW((spaces::GetDistFunc<int8_t, float>(
+                     (VecSimMetric)(VecSimMetric_CosineSimilarity + 1), 10, nullptr)),
+                 std::invalid_argument);
 }
 TEST_F(SpacesTest, GetDistFuncInvalidMetricUINT8) {
-    EXPECT_THROW(
-        (spaces::GetDistFunc<uint8_t, float>((VecSimMetric)(VecSimMetric_Cosine + 1), 10, nullptr)),
-        std::invalid_argument);
+    EXPECT_THROW((spaces::GetDistFunc<uint8_t, float>(
+                     (VecSimMetric)(VecSimMetric_CosineSimilarity + 1), 10, nullptr)),
+                 std::invalid_argument);
 }
 TEST_F(SpacesTest, GetDistFuncInvalidMetricSQ8) {
     // SQ8 to SQ8 (symmetric)
-    EXPECT_THROW(
-        (spaces::GetDistFunc<sq8, float>((VecSimMetric)(VecSimMetric_Cosine + 1), 10, nullptr)),
-        std::invalid_argument);
+    EXPECT_THROW((spaces::GetDistFunc<sq8, float>((VecSimMetric)(VecSimMetric_CosineSimilarity + 1),
+                                                  10, nullptr)),
+                 std::invalid_argument);
 }
 TEST_F(SpacesTest, GetDistFuncInvalidMetricSQ8ToFloat) {
     // SQ8 to float (asymmetric)
-    EXPECT_THROW((spaces::GetDistFunc<sq8, float, float>((VecSimMetric)(VecSimMetric_Cosine + 1),
-                                                         10, nullptr)),
+    EXPECT_THROW((spaces::GetDistFunc<sq8, float, float>(
+                     (VecSimMetric)(VecSimMetric_CosineSimilarity + 1), 10, nullptr)),
                  std::invalid_argument);
 }
 TEST_F(SpacesTest, GetDistFuncInvalidMetricSQ8ToFP16) {
     // SQ8 storage with FP16 query (asymmetric)
-    EXPECT_THROW((spaces::GetDistFunc<sq8, float, float16>((VecSimMetric)(VecSimMetric_Cosine + 1),
-                                                           10, nullptr)),
+    EXPECT_THROW((spaces::GetDistFunc<sq8, float, float16>(
+                     (VecSimMetric)(VecSimMetric_CosineSimilarity + 1), 10, nullptr)),
                  std::invalid_argument);
 }
 
@@ -586,9 +586,12 @@ TEST_F(SpacesTest, GetDistFuncSQ8Symmetric) {
     auto l2_func = spaces::GetDistFunc<sq8, float>(VecSimMetric_L2, dim, nullptr);
     auto ip_func = spaces::GetDistFunc<sq8, float>(VecSimMetric_IP, dim, nullptr);
     auto cosine_func = spaces::GetDistFunc<sq8, float>(VecSimMetric_Cosine, dim, nullptr);
+    auto cosine_similarity_func =
+        spaces::GetDistFunc<sq8, float>(VecSimMetric_CosineSimilarity, dim, nullptr);
     ASSERT_EQ(l2_func, L2_SQ8_SQ8_GetDistFunc(dim, nullptr));
     ASSERT_EQ(ip_func, IP_SQ8_SQ8_GetDistFunc(dim, nullptr));
     ASSERT_EQ(cosine_func, Cosine_SQ8_SQ8_GetDistFunc(dim, nullptr));
+    ASSERT_EQ(cosine_similarity_func, Cosine_SQ8_SQ8_GetDistFunc(dim, nullptr));
 }
 
 TEST_F(SpacesTest, GetDistFuncSQ8Asymmetric) {
@@ -597,9 +600,12 @@ TEST_F(SpacesTest, GetDistFuncSQ8Asymmetric) {
     auto l2_func = spaces::GetDistFunc<sq8, float, float>(VecSimMetric_L2, dim, nullptr);
     auto ip_func = spaces::GetDistFunc<sq8, float, float>(VecSimMetric_IP, dim, nullptr);
     auto cosine_func = spaces::GetDistFunc<sq8, float, float>(VecSimMetric_Cosine, dim, nullptr);
+    auto cosine_similarity_func =
+        spaces::GetDistFunc<sq8, float, float>(VecSimMetric_CosineSimilarity, dim, nullptr);
     ASSERT_EQ(l2_func, L2_SQ8_FP32_GetDistFunc(dim, nullptr));
     ASSERT_EQ(ip_func, IP_SQ8_FP32_GetDistFunc(dim, nullptr));
     ASSERT_EQ(cosine_func, Cosine_SQ8_FP32_GetDistFunc(dim, nullptr));
+    ASSERT_EQ(cosine_similarity_func, Cosine_SQ8_FP32_GetDistFunc(dim, nullptr));
 }
 
 TEST_F(SpacesTest, GetDistFuncSQ8FP16Asymmetric) {
@@ -609,9 +615,12 @@ TEST_F(SpacesTest, GetDistFuncSQ8FP16Asymmetric) {
     auto l2_func = spaces::GetDistFunc<sq8, float, float16>(VecSimMetric_L2, dim, nullptr);
     auto ip_func = spaces::GetDistFunc<sq8, float, float16>(VecSimMetric_IP, dim, nullptr);
     auto cosine_func = spaces::GetDistFunc<sq8, float, float16>(VecSimMetric_Cosine, dim, nullptr);
+    auto cosine_similarity_func =
+        spaces::GetDistFunc<sq8, float, float16>(VecSimMetric_CosineSimilarity, dim, nullptr);
     ASSERT_EQ(l2_func, L2_SQ8_FP16_GetDistFunc(dim, nullptr));
     ASSERT_EQ(ip_func, IP_SQ8_FP16_GetDistFunc(dim, nullptr));
     ASSERT_EQ(cosine_func, Cosine_SQ8_FP16_GetDistFunc(dim, nullptr));
+    ASSERT_EQ(cosine_similarity_func, Cosine_SQ8_FP16_GetDistFunc(dim, nullptr));
 
     // dim < 16 takes the scalar early-return in every SQ8_FP16 dispatcher (no SIMD tier).
     size_t small_dim = 8;


### PR DESCRIPTION
**Describe the changes in the pull request**

Adds `COSINE_SIMILARITY` as a fourth vector metric (`VecSimMetric_CosineSimilarity`). It reuses the existing cosine-distance execution path end-to-end — no new spaces functions, preprocessors, ordering, heap, or comparator logic. A `VecSimMetric_IsCosineFamily()` helper is introduced so every place that special-cases `VecSimMetric_Cosine` (preprocessing/normalization, SVS factory, quant preprocessor, stored/query blob sizing, dist-func selection) treats the new metric identically. The public metric name and the exposed score/range semantics (`similarity = 1 - distance`) are translated at the API boundary in the RediSearch layer; this repo only adds the metric and routes it through the cosine internals.

Non-breaking: `L2`, `IP`, and `COSINE` behavior is unchanged, and the new enum value is appended last so existing serialized indexes keep their metric ordinals (L2=0, IP=1, Cosine=2).

**Which issues this PR fixes**
1. MOD-17012
2. redis/redis-vl-python#407 (related — underlying cause)

**Main objects this PR modified**
1. `VecSimMetric` enum + new `VecSimMetric_IsCosineFamily()` helper (`vec_sim_common.h`)
2. Cosine-path routing: `spaces.cpp` (dist-func selection, all types incl. SQ8_FP16), `preprocessors_factory.h`, `preprocessors.h` (QuantPreprocessor), `svs_factory.cpp`, `svs_utils.h`
3. Metric-aware sizing/stringify: `vec_utils.cpp` (`VecSimMetric_ToString`, `VecSimParams_GetStoredDataSize`), `vec_sim.cpp` (`VecSimParams_GetQueryBlobSize`)
4. Python binding value (`bindings.cpp`)
5. Unit tests: `test_spaces.cpp`, `test_components.cpp`

**Mark if applicable**

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core metric routing (preprocessing, distance kernels, SVS factory, blob sizing) across many types; behavior for existing L2/IP/Cosine should be unchanged but mis-routing would affect search correctness.
> 
> **Overview**
> Introduces **`VecSimMetric_CosineSimilarity`** as a new enum value (appended after existing metrics) and **`VecSimMetric_IsCosineFamily()`** so cosine-specific behavior applies to both cosine metrics without duplicating logic.
> 
> **Cosine-path routing** is extended to the new metric: distance function selection in `spaces.cpp`, preprocessor factory and **QuantPreprocessor** static checks, SVS index creation (`DistanceIP` + forced preprocessing), integral-vector norm sizing for stored/query blobs, and `VecSimMetric_ToString`. SVS drops a redundant `DistanceCosineSimilarity` distance conversion specialization in favor of the shared IP path.
> 
> **Bindings and tests**: Python exposes the new enum; unit tests cover invalid-metric checks, SQ8 dist-func parity with cosine, and quant preprocessor parametrization for `CosineSimilarity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7725ab1812c10cbc396fda0b0dd5094d415885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->