### PR TITLE
[MOD-14952] Support normalization in QuantPreprocessor

### DIFF
--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
- * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates
+ * <open-source-office@arm.com>
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
@@ -343,8 +344,10 @@ class QuantPreprocessor : public PreprocessorInterface {
         void *meta_dst = quantized + this->dim;
         MetadataType buf[5] = {min_val, delta, sum};
         size_t n = 3;
-        if constexpr (Metric == VecSimMetric_L2) buf[n++] = sum_squares;
-        if constexpr (WithNorm) buf[n++] = x_mean_ip;
+        if constexpr (Metric == VecSimMetric_L2)
+            buf[n++] = sum_squares;
+        if constexpr (WithNorm)
+            buf[n++] = x_mean_ip;
         memcpy(meta_dst, buf, n * sizeof(MetadataType));
     }
 
@@ -417,14 +420,17 @@ class QuantPreprocessor : public PreprocessorInterface {
         // when DataType is float16 and dim is odd.
         MetadataType buf[3] = {sum};
         size_t n = 1;
-        if constexpr (Metric == VecSimMetric_L2) buf[n++] = sum_squares;
-        if constexpr (WithNorm) buf[n++] = y_mean_ip;
+        if constexpr (Metric == VecSimMetric_L2)
+            buf[n++] = sum_squares;
+        if constexpr (WithNorm)
+            buf[n++] = y_mean_ip;
         memcpy(output_metadata, buf, n * sizeof(MetadataType));
     }
 
 public:
     // Standard constructor (WithNorm == false): no mean vector.
-    QuantPreprocessor(std::shared_ptr<VecSimAllocator> allocator, size_t dim) requires(!WithNorm)
+    QuantPreprocessor(std::shared_ptr<VecSimAllocator> allocator, size_t dim)
+        requires(!WithNorm)
         : PreprocessorInterface(allocator), dim(dim),
           storage_bytes_count(dim * sizeof(OUTPUT_TYPE) +
                               sq8::storage_metadata_count<Metric>() * sizeof(MetadataType)),
@@ -433,7 +439,8 @@ public:
 
     // WithNorm constructor: accepts a pre-computed mean vector (FP32, length == dim).
     QuantPreprocessor(std::shared_ptr<VecSimAllocator> allocator, size_t dim,
-                      const vecsim_stl::vector<float> &mean_vec) requires(WithNorm)
+                      const vecsim_stl::vector<float> &mean_vec)
+        requires(WithNorm)
         : PreprocessorInterface(allocator), mean(mean_vec), dim(dim),
           storage_bytes_count(dim * sizeof(OUTPUT_TYPE) +
                               sq8::storage_metadata_count<Metric, WithNorm>() *

--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -1,8 +1,6 @@
 /*
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
- * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the

--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
@@ -17,12 +18,14 @@
 #include <cstring>
 #include <memory>
 #include <type_traits>
+#include <variant>
 
 #include "VecSim/memory/vecsim_base.h"
 #include "VecSim/spaces/spaces.h"
 #include "VecSim/memory/memory_utils.h"
 #include "VecSim/types/float16.h"
 #include "VecSim/types/sq8.h"
+#include "VecSim/utils/vecsim_stl.h"
 
 class PreprocessorInterface : public VecsimBaseObject {
 public:
@@ -235,7 +238,7 @@ static inline float to_fp32(T x) {
     }
 }
 
-template <QuantInput DataType, VecSimMetric Metric>
+template <QuantInput DataType, VecSimMetric Metric, bool WithNorm = false>
 class QuantPreprocessor : public PreprocessorInterface {
     using OUTPUT_TYPE = uint8_t;
     using MetadataType = float; // SQ8 metadata is always FP32 (see class doc).
@@ -244,13 +247,35 @@ class QuantPreprocessor : public PreprocessorInterface {
     static_assert(Metric == VecSimMetric_L2 || Metric == VecSimMetric_IP ||
                       Metric == VecSimMetric_Cosine,
                   "QuantPreprocessor only supports L2, IP and Cosine metrics");
+    static_assert(!WithNorm || Metric != VecSimMetric_Cosine,
+                  "WithNorm does not support Cosine metric.");
 
     // Helper function to perform quantization. This function is used by the storage preprocessing
     // methods.
     void quantize(const DataType *input, OUTPUT_TYPE *quantized) const {
         assert(input && quantized);
-        // Find min and max values (computed in MetadataType regardless of DataType).
-        auto [min_val, max_val] = find_min_max(input);
+
+        if constexpr (std::is_same_v<DataType, float> && !WithNorm) {
+            quantize_impl(input, quantized);
+        } else {
+            float x_mean_ip = 0.0f; // only used for WithNorm
+
+            // Get transformed values (convert to float, mean-subtracted for WithNorm)
+            vecsim_stl::vector<float> values(this->dim, this->allocator);
+            for (size_t i = 0; i < this->dim; ++i) {
+                values[i] = to_fp32<DataType>(input[i]);
+                if constexpr (WithNorm) {
+                    x_mean_ip += values[i] * mean[i];
+                    values[i] -= mean[i];
+                }
+            }
+            quantize_impl(values.data(), quantized, x_mean_ip);
+        }
+    }
+
+    void quantize_impl(const float *values, OUTPUT_TYPE *quantized, float x_mean_ip = 0.0f) const {
+        // Find min and max values.
+        auto [min_val, max_val] = find_min_max(values);
 
         // Calculate scaling factor (typed as MetadataType because they end up as metadata).
         const MetadataType diff = (max_val - min_val);
@@ -272,10 +297,10 @@ class QuantPreprocessor : public PreprocessorInterface {
         // Quantize the values
         for (; i < dim_round_down; i += 4) {
             // Load once (widened to FP32 if DataType is FP16).
-            const float x0 = to_fp32<DataType>(input[i + 0]);
-            const float x1 = to_fp32<DataType>(input[i + 1]);
-            const float x2 = to_fp32<DataType>(input[i + 2]);
-            const float x3 = to_fp32<DataType>(input[i + 3]);
+            const float x0 = values[i + 0];
+            const float x1 = values[i + 1];
+            const float x2 = values[i + 2];
+            const float x3 = values[i + 3];
             // We know (input - min) => 0
             // If min == max, all values are the same and should be quantized to 0.
             // reconstruction will yield the same original value for all vectors.
@@ -305,7 +330,7 @@ class QuantPreprocessor : public PreprocessorInterface {
         MetadataType sum_squares = (q0 + q1) + (q2 + q3);
 
         for (; i < this->dim; ++i) {
-            const float x = to_fp32<DataType>(input[i]);
+            const float x = values[i];
             quantized[i] = static_cast<OUTPUT_TYPE>(std::round((x - min_val) * inv_delta));
             sum += x;
             if constexpr (Metric == VecSimMetric_L2) {
@@ -316,26 +341,29 @@ class QuantPreprocessor : public PreprocessorInterface {
         // Metadata uses MetadataType. Use memcpy because the metadata offset
         // (dim * sizeof(uint8_t)) is not guaranteed to be sizeof(MetadataType)-aligned.
         void *meta_dst = quantized + this->dim;
-        if constexpr (Metric == VecSimMetric_L2) {
-            const MetadataType buf[4] = {min_val, delta, sum, sum_squares};
-            memcpy(meta_dst, buf, sizeof(buf));
-        } else {
-            const MetadataType buf[3] = {min_val, delta, sum};
-            memcpy(meta_dst, buf, sizeof(buf));
-        }
+        MetadataType buf[5] = {min_val, delta, sum};
+        size_t n = 3;
+        if constexpr (Metric == VecSimMetric_L2) buf[n++] = sum_squares;
+        if constexpr (WithNorm) buf[n++] = x_mean_ip;
+        memcpy(meta_dst, buf, n * sizeof(MetadataType));
     }
 
     // Computes and writes query metadata (FP32) in a single pass over the input vector.
-    // For IP/Cosine: writes y_sum = Σy_i
-    // For L2: writes y_sum = Σy_i and y_sum_squares = Σy_i²
+    // Without norm:
+    //   For IP/Cosine: writes y_sum = Σy_i
+    //   For L2: writes y_sum = Σy_i and y_sum_squares = Σy_i²
+    // With norm: additionally appends y_mean_ip = Σ(mean_i * y_i).
     // The output pointer addresses the metadata region after the query body and may not be
     // 4-byte aligned (e.g. FP16 query body with odd dim), so writes go through memcpy.
     void assign_query_metadata(const DataType *input, void *output_metadata) const {
+
         // Accumulators are FP32 to preserve precision for FP16 inputs.
         // 4 independent accumulators for sum
         float s0{}, s1{}, s2{}, s3{};
         // 4 independent accumulators for sum of squares (only used for L2)
         float q0{}, q1{}, q2{}, q3{};
+        // 4 independent accumulators for y_mean_ip (only used for WithNorm)
+        float m0{}, m1{}, m2{}, m3{};
 
         size_t i = 0;
         // round dim down to the nearest multiple of 4
@@ -358,11 +386,19 @@ class QuantPreprocessor : public PreprocessorInterface {
                 q2 += y2 * y2;
                 q3 += y3 * y3;
             }
+
+            if constexpr (WithNorm) {
+                m0 += mean[i + 0] * y0;
+                m1 += mean[i + 1] * y1;
+                m2 += mean[i + 2] * y2;
+                m3 += mean[i + 3] * y3;
+            }
         }
 
-        // Sum/sum_squares become metadata, so they are MetadataType.
+        // Sum/sum_squares/y_mean_ip become metadata, so they are MetadataType.
         MetadataType sum = (s0 + s1) + (s2 + s3);
         MetadataType sum_squares = (q0 + q1) + (q2 + q3);
+        MetadataType y_mean_ip = (m0 + m1) + (m2 + m3);
 
         // Tail: handle remaining elements
         for (; i < this->dim; ++i) {
@@ -371,29 +407,41 @@ class QuantPreprocessor : public PreprocessorInterface {
             if constexpr (Metric == VecSimMetric_L2) {
                 sum_squares += y * y;
             }
+            if constexpr (WithNorm) {
+                y_mean_ip += mean[i] * y;
+            }
         }
 
         // Metadata uses MetadataType. Use memcpy because the metadata offset (after the query
         // body of dim * sizeof(DataType)) is not guaranteed to be sizeof(MetadataType)-aligned
         // when DataType is float16 and dim is odd.
-        if constexpr (Metric == VecSimMetric_L2) {
-            const MetadataType buf[2] = {sum, sum_squares};
-            memcpy(output_metadata, buf, sizeof(buf));
-        } else {
-            const MetadataType buf[1] = {sum};
-            memcpy(output_metadata, buf, sizeof(buf));
-        }
+        MetadataType buf[3] = {sum};
+        size_t n = 1;
+        if constexpr (Metric == VecSimMetric_L2) buf[n++] = sum_squares;
+        if constexpr (WithNorm) buf[n++] = y_mean_ip;
+        memcpy(output_metadata, buf, n * sizeof(MetadataType));
     }
 
 public:
-    QuantPreprocessor(std::shared_ptr<VecSimAllocator> allocator, size_t dim)
+    // Standard constructor (WithNorm == false): no mean vector.
+    QuantPreprocessor(std::shared_ptr<VecSimAllocator> allocator, size_t dim) requires(!WithNorm)
         : PreprocessorInterface(allocator), dim(dim),
           storage_bytes_count(dim * sizeof(OUTPUT_TYPE) +
-                              (vecsim_types::sq8::storage_metadata_count<Metric>()) *
+                              sq8::storage_metadata_count<Metric>() * sizeof(MetadataType)),
+          query_bytes_count(dim * sizeof(DataType) +
+                            sq8::query_metadata_count<Metric>() * sizeof(MetadataType)) {}
+
+    // WithNorm constructor: accepts a pre-computed mean vector (FP32, length == dim).
+    QuantPreprocessor(std::shared_ptr<VecSimAllocator> allocator, size_t dim,
+                      const vecsim_stl::vector<float> &mean_vec) requires(WithNorm)
+        : PreprocessorInterface(allocator), mean(mean_vec), dim(dim),
+          storage_bytes_count(dim * sizeof(OUTPUT_TYPE) +
+                              sq8::storage_metadata_count<Metric, WithNorm>() *
                                   sizeof(MetadataType)),
           query_bytes_count(dim * sizeof(DataType) +
-                            (vecsim_types::sq8::query_metadata_count<Metric>()) *
-                                sizeof(MetadataType)) {}
+                            sq8::query_metadata_count<Metric, WithNorm>() * sizeof(MetadataType)) {
+        assert(this->mean.size() == dim && "mean vector size must equal dim");
+    }
 
     /**
      * Preprocesses the original blob into separate storage and query blobs.
@@ -495,14 +543,14 @@ public:
     }
 
 private:
-    // Returns (min, max) of the input vector evaluated in MetadataType. Both float and float16
-    // expose a usable operator< (float16's overload delegates to FP32 semantics), so a single
-    // std::minmax_element call covers both DataTypes. The returned values are written verbatim
-    // into the metadata region.
-    std::pair<MetadataType, MetadataType> find_min_max(const DataType *input) const {
+    std::pair<float, float> find_min_max(const float *input) const {
         auto [min_it, max_it] = std::minmax_element(input, input + dim);
-        return {to_fp32<DataType>(*min_it), to_fp32<DataType>(*max_it)};
+        return {*min_it, *max_it};
     }
+
+    // Mean vector for WithNorm=true; zero-size placeholder otherwise (no runtime overhead).
+    [[no_unique_address]] std::conditional_t<WithNorm, vecsim_stl::vector<float>, std::monostate>
+        mean;
 
     const size_t dim;
     const size_t storage_bytes_count;

--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -254,27 +254,8 @@ class QuantPreprocessor : public PreprocessorInterface {
     void quantize(const DataType *input, OUTPUT_TYPE *quantized) const {
         assert(input && quantized);
 
-        if constexpr (std::is_same_v<DataType, float> && !WithNorm) {
-            quantize_impl(input, quantized);
-        } else {
-            float x_mean_ip = 0.0f; // only used for WithNorm
-
-            // Get transformed values (convert to float, mean-subtracted for WithNorm)
-            vecsim_stl::vector<float> values(this->dim, this->allocator);
-            for (size_t i = 0; i < this->dim; ++i) {
-                values[i] = to_fp32<DataType>(input[i]);
-                if constexpr (WithNorm) {
-                    x_mean_ip += values[i] * mean[i];
-                    values[i] -= mean[i];
-                }
-            }
-            quantize_impl(values.data(), quantized, x_mean_ip);
-        }
-    }
-
-    void quantize_impl(const float *values, OUTPUT_TYPE *quantized, float x_mean_ip = 0.0f) const {
-        // Find min and max values.
-        auto [min_val, max_val] = find_min_max(values);
+        float x_mean_ip = 0.0f; // only used for WithNorm
+        auto [min_val, max_val] = find_min_max(input, x_mean_ip);
 
         // Calculate scaling factor (typed as MetadataType because they end up as metadata).
         const MetadataType diff = (max_val - min_val);
@@ -296,10 +277,10 @@ class QuantPreprocessor : public PreprocessorInterface {
         // Quantize the values
         for (; i < dim_round_down; i += 4) {
             // Load once (widened to FP32 if DataType is FP16).
-            const float x0 = values[i + 0];
-            const float x1 = values[i + 1];
-            const float x2 = values[i + 2];
-            const float x3 = values[i + 3];
+            const float x0 = transformed_value(input, i + 0);
+            const float x1 = transformed_value(input, i + 1);
+            const float x2 = transformed_value(input, i + 2);
+            const float x3 = transformed_value(input, i + 3);
             // We know (input - min) => 0
             // If min == max, all values are the same and should be quantized to 0.
             // reconstruction will yield the same original value for all vectors.
@@ -329,7 +310,7 @@ class QuantPreprocessor : public PreprocessorInterface {
         MetadataType sum_squares = (q0 + q1) + (q2 + q3);
 
         for (; i < this->dim; ++i) {
-            const float x = values[i];
+            const float x = transformed_value(input, i);
             quantized[i] = static_cast<OUTPUT_TYPE>(std::round((x - min_val) * inv_delta));
             sum += x;
             if constexpr (Metric == VecSimMetric_L2) {
@@ -548,9 +529,34 @@ public:
     }
 
 private:
-    std::pair<float, float> find_min_max(const float *input) const {
-        auto [min_it, max_it] = std::minmax_element(input, input + dim);
-        return {*min_it, *max_it};
+    inline float transformed_value(const DataType *input, size_t i) const {
+        float value = to_fp32<DataType>(input[i]);
+        if constexpr (WithNorm) {
+            value -= mean[i];
+        }
+        return value;
+    }
+
+    std::pair<float, float> find_min_max(const DataType *input, float &x_mean_ip) const {
+        if constexpr (!WithNorm) {
+            auto [min_it, max_it] = std::minmax_element(input, input + dim);
+            return {to_fp32<DataType>(*min_it), to_fp32<DataType>(*max_it)};
+        } else {
+            const float first_input_value = to_fp32<DataType>(input[0]);
+            float value = first_input_value - mean[0];
+            float min_val = value;
+            float max_val = value;
+            x_mean_ip = first_input_value * mean[0];
+
+            for (size_t i = 1; i < dim; ++i) {
+                const float input_value = to_fp32<DataType>(input[i]);
+                value = input_value - mean[i];
+                min_val = std::min(min_val, value);
+                max_val = std::max(max_val, value);
+                x_mean_ip += input_value * mean[i];
+            }
+            return {min_val, max_val};
+        }
     }
 
     // Mean vector for WithNorm=true; zero-size placeholder otherwise (no runtime overhead).

--- a/src/VecSim/types/sq8.h
+++ b/src/VecSim/types/sq8.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
@@ -31,15 +32,27 @@ struct sq8 {
         SUM_SQUARES_QUERY = 1 // Only for L2
     };
 
-    // Template on metric — compile-time constant when metric is known
-    template <VecSimMetric Metric>
+    // Template on Metric and WithNorm — compile-time constants
+    // WithNorm: one extra metadata slot for x_mean_ip / y_mean_ip
+    template <VecSimMetric Metric, bool WithNorm = false>
     static constexpr size_t storage_metadata_count() {
-        return (Metric == VecSimMetric_L2) ? 4 : 3;
+        return ((Metric == VecSimMetric_L2) ? 4 : 3) + (WithNorm ? 1 : 0);
+    }
+
+    template <VecSimMetric Metric, bool WithNorm = false>
+    static constexpr size_t query_metadata_count() {
+        return ((Metric == VecSimMetric_L2) ? 2 : 1) + (WithNorm ? 1 : 0);
+    }
+
+    // Index of x_mean_ip / y_mean_ip in the last slot in metadata array
+    template <VecSimMetric Metric>
+    static constexpr size_t mean_ip_index() {
+        return storage_metadata_count<Metric, true>() - 1;
     }
 
     template <VecSimMetric Metric>
-    static constexpr size_t query_metadata_count() {
-        return (Metric == VecSimMetric_L2) ? 2 : 1;
+    static constexpr size_t query_mean_ip_index() {
+        return query_metadata_count<Metric, true>() - 1;
     }
 };
 

--- a/src/VecSim/types/sq8.h
+++ b/src/VecSim/types/sq8.h
@@ -1,8 +1,6 @@
 /*
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
- * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the

--- a/src/VecSim/types/sq8.h
+++ b/src/VecSim/types/sq8.h
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
- * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates
+ * <open-source-office@arm.com>
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the

--- a/tests/unit/test_components.cpp
+++ b/tests/unit/test_components.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
@@ -1612,3 +1613,193 @@ TEST(QuantPreprocessorFP16Test, QuantizeReconstructRoundTripL2) {
     allocator->free_allocation(storage_blob);
     delete preprocessor;
 }
+
+// Shared parameterized fixture for QuantPreprocessor<DataType, *, WithNorm=true>.
+template <typename DataType>
+class QuantPreprocessorWithNormMetricTestBase : public testing::TestWithParam<VecSimMetric> {
+protected:
+    static constexpr size_t dim = 5;
+    static constexpr unsigned char alignment = 0;
+    static constexpr size_t original_blob_size = dim * sizeof(DataType);
+
+    std::shared_ptr<VecSimAllocator> allocator;
+    DataType original_blob[dim];
+    float widened_blob[dim];
+    float mean_vec[dim] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f};
+
+    void SetUp() override {
+        allocator = VecSimAllocator::newVecsimAllocator();
+        const float source[dim] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+        for (size_t i = 0; i < dim; ++i) {
+            if constexpr (std::is_same_v<DataType, vecsim_types::float16>) {
+                original_blob[i] = vecsim_types::FP32_to_FP16(source[i]);
+                widened_blob[i] = vecsim_types::FP16_to_FP32(original_blob[i]);
+            } else {
+                original_blob[i] = source[i];
+                widened_blob[i] = source[i];
+            }
+        }
+    }
+
+    static float load_meta(const void *base, size_t byte_offset) {
+        float value;
+        std::memcpy(&value, static_cast<const uint8_t *>(base) + byte_offset, sizeof(value));
+        return value;
+    }
+
+    template <VecSimMetric Metric>
+    size_t getExpectedStorageSize() const {
+        return dim * sizeof(uint8_t) + sq8::storage_metadata_count<Metric, true>() * sizeof(float);
+    }
+
+    template <VecSimMetric Metric>
+    size_t getExpectedQuerySize() const {
+        return dim * sizeof(DataType) + sq8::query_metadata_count<Metric, true>() * sizeof(float);
+    }
+
+    template <VecSimMetric Metric>
+    void runQuantizationTest() {
+        const size_t expected_storage_size = getExpectedStorageSize<Metric>();
+        const size_t expected_query_size = getExpectedQuerySize<Metric>();
+        const size_t storage_meta_offset = dim * sizeof(uint8_t);
+        const size_t query_meta_offset = dim * sizeof(DataType);
+        float centered[dim];
+        float expected_x_mean_ip = 0.0f;
+        float expected_y_sum = 0.0f;
+        float expected_y_sum_squares = 0.0f;
+        float expected_y_mean_ip = 0.0f;
+        for (size_t i = 0; i < dim; ++i) {
+            centered[i] = widened_blob[i] - mean_vec[i];
+            expected_x_mean_ip += widened_blob[i] * mean_vec[i];
+            expected_y_sum += widened_blob[i];
+            expected_y_sum_squares += widened_blob[i] * widened_blob[i];
+            expected_y_mean_ip += widened_blob[i] * mean_vec[i];
+        }
+
+        constexpr size_t max_storage_baseline = dim * sizeof(uint8_t) + 4 * sizeof(float);
+        uint8_t baseline_storage[max_storage_baseline];
+        ComputeSQ8Quantization(centered, dim, baseline_storage);
+
+        vecsim_stl::vector<float> mean_vector(allocator);
+        for (size_t i = 0; i < dim; ++i) {
+            mean_vector.push_back(mean_vec[i]);
+        }
+        auto quant_preprocessor =
+            new (allocator) QuantPreprocessor<DataType, Metric, true>(allocator, dim, mean_vector);
+
+        {
+            void *storage_blob = nullptr;
+            void *query_blob = nullptr;
+            size_t storage_blob_size = original_blob_size;
+            size_t query_blob_size = original_blob_size;
+            quant_preprocessor->preprocess(original_blob, storage_blob, query_blob,
+                                           storage_blob_size, query_blob_size, alignment,
+                                           alignment);
+
+            ASSERT_NE(storage_blob, nullptr);
+            ASSERT_EQ(storage_blob_size, expected_storage_size);
+            ASSERT_NE(query_blob, nullptr);
+            ASSERT_EQ(query_blob_size, expected_query_size);
+
+            const size_t compare_size = (Metric == VecSimMetric_L2)
+                                            ? dim * sizeof(uint8_t) + 4 * sizeof(float)
+                                            : dim * sizeof(uint8_t) + 3 * sizeof(float);
+            EXPECT_NO_FATAL_FAILURE(CompareVectors<uint8_t>(
+                static_cast<const uint8_t *>(storage_blob), baseline_storage, compare_size));
+            ASSERT_FLOAT_EQ(
+                load_meta(storage_blob,
+                          storage_meta_offset + sq8::mean_ip_index<Metric>() * sizeof(float)),
+                expected_x_mean_ip);
+            EXPECT_NO_FATAL_FAILURE(CompareVectors<DataType>(
+                static_cast<const DataType *>(query_blob), original_blob, dim));
+            ASSERT_FLOAT_EQ(
+                load_meta(query_blob, query_meta_offset + sq8::SUM_QUERY * sizeof(float)),
+                expected_y_sum);
+            if constexpr (Metric == VecSimMetric_L2) {
+                ASSERT_FLOAT_EQ(load_meta(query_blob, query_meta_offset +
+                                                          sq8::SUM_SQUARES_QUERY * sizeof(float)),
+                                expected_y_sum_squares);
+            }
+            ASSERT_FLOAT_EQ(
+                load_meta(query_blob,
+                          query_meta_offset + sq8::query_mean_ip_index<Metric>() * sizeof(float)),
+                expected_y_mean_ip);
+            allocator->free_allocation(storage_blob);
+            allocator->free_allocation(query_blob);
+        }
+
+        {
+            void *blob = nullptr;
+            size_t blob_size = original_blob_size;
+            quant_preprocessor->preprocessForStorage(original_blob, blob, blob_size, alignment);
+            ASSERT_NE(blob, nullptr);
+            ASSERT_EQ(blob_size, expected_storage_size);
+            allocator->free_allocation(blob);
+        }
+
+        {
+            void *blob = nullptr;
+            size_t blob_size = original_blob_size;
+            quant_preprocessor->preprocessQuery(original_blob, blob, blob_size, alignment);
+            ASSERT_NE(blob, nullptr);
+            ASSERT_EQ(blob_size, expected_query_size);
+            EXPECT_NO_FATAL_FAILURE(
+                CompareVectors<DataType>(static_cast<const DataType *>(blob), original_blob, dim));
+            ASSERT_FLOAT_EQ(load_meta(blob, query_meta_offset + sq8::SUM_QUERY * sizeof(float)),
+                            expected_y_sum);
+            if constexpr (Metric == VecSimMetric_L2) {
+                ASSERT_FLOAT_EQ(
+                    load_meta(blob, query_meta_offset + sq8::SUM_SQUARES_QUERY * sizeof(float)),
+                    expected_y_sum_squares);
+            }
+            ASSERT_FLOAT_EQ(load_meta(blob, query_meta_offset +
+                                                sq8::query_mean_ip_index<Metric>() * sizeof(float)),
+                            expected_y_mean_ip);
+            allocator->free_allocation(blob);
+        }
+
+        delete quant_preprocessor;
+    }
+};
+
+using QuantPreprocessorWithNormMetricTest = QuantPreprocessorWithNormMetricTestBase<float>;
+
+TEST_P(QuantPreprocessorWithNormMetricTest, QuantizationBlobSizeAndMetadata) {
+    VecSimMetric metric = GetParam();
+    switch (metric) {
+    case VecSimMetric_L2:
+        runQuantizationTest<VecSimMetric_L2>();
+        break;
+    case VecSimMetric_IP:
+        runQuantizationTest<VecSimMetric_IP>();
+        break;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(QuantPreprocessorWithNormTests, QuantPreprocessorWithNormMetricTest,
+                         testing::Values(VecSimMetric_L2, VecSimMetric_IP),
+                         [](const testing::TestParamInfo<VecSimMetric> &info) {
+                             return VecSimMetric_ToString(info.param);
+                         });
+
+using QuantPreprocessorFP16WithNormMetricTest =
+    QuantPreprocessorWithNormMetricTestBase<vecsim_types::float16>;
+
+TEST_P(QuantPreprocessorFP16WithNormMetricTest, QuantizationBlobSizeAndMetadata) {
+    VecSimMetric metric = GetParam();
+    switch (metric) {
+    case VecSimMetric_L2:
+        runQuantizationTest<VecSimMetric_L2>();
+        break;
+    case VecSimMetric_IP:
+        runQuantizationTest<VecSimMetric_IP>();
+        break;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(QuantPreprocessorFP16WithNormTests,
+                         QuantPreprocessorFP16WithNormMetricTest,
+                         testing::Values(VecSimMetric_L2, VecSimMetric_IP),
+                         [](const testing::TestParamInfo<VecSimMetric> &info) {
+                             return VecSimMetric_ToString(info.param);
+                         });

--- a/tests/unit/test_components.cpp
+++ b/tests/unit/test_components.cpp
@@ -1,8 +1,6 @@
 /*
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
- * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the

--- a/tests/unit/test_components.cpp
+++ b/tests/unit/test_components.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2006-Present, Redis Ltd.
  * All rights reserved.
- * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates
+ * <open-source-office@arm.com>
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the

--- a/tests/unit/test_hnsw.cpp
+++ b/tests/unit/test_hnsw.cpp
@@ -11,6 +11,8 @@
 #include "VecSim/vec_sim.h"
 #include "VecSim/vec_sim_debug.h"
 #include "VecSim/algorithms/hnsw/hnsw_single.h"
+#include "VecSim/index_factories/components/components_factory.h"
+#include "VecSim/index_factories/factory_utils.h"
 #include "VecSim/index_factories/hnsw_factory.h"
 #include "unit_test_utils.h"
 #include "VecSim/utils/serializer.h"
@@ -42,6 +44,50 @@ protected:
 // DataTypeSet, TEST_DATA_T and TEST_DIST_T are defined in unit_test_utils.h
 
 TYPED_TEST_SUITE(HNSWTest, DataTypeSet);
+
+namespace {
+
+float storedDispatchTestFunc(const void *, const void *, size_t) { return 11.0f; }
+
+float queryDispatchTestFunc(const void *, const void *, size_t) { return 22.0f; }
+
+} // namespace
+
+TEST(HNSWDistanceDispatchTest, UsesStoredToQueryDispatch) {
+    constexpr size_t dim = 4;
+    HNSWParams params = {
+        .type = VecSimType_FLOAT32,
+        .dim = dim,
+        .metric = VecSimMetric_L2,
+        .multi = false,
+    };
+    auto abstract_params = VecSimFactory::NewAbstractInitParams(&params, nullptr, false);
+    auto components = CreateIndexComponents<float, float>(abstract_params.allocator, params.metric,
+                                                          params.dim, false);
+    delete components.indexCalculator;
+    components.indexCalculator = new (abstract_params.allocator) DistanceCalculatorCommon<float>(
+        abstract_params.allocator, storedDispatchTestFunc, queryDispatchTestFunc);
+
+    auto *index = new (abstract_params.allocator)
+        HNSWIndex_Single<float, float>(&params, abstract_params, components);
+    float vector[dim] = {1.0f, 2.0f, 3.0f, 4.0f};
+    float query[dim] = {4.0f, 3.0f, 2.0f, 1.0f};
+    VecSimIndex_AddVector(index, vector, 7);
+
+    ASSERT_FLOAT_EQ(index->calcDistance(vector, query), 11.0f);
+    auto verify_query_score = [](size_t id, double score, size_t) {
+        ASSERT_EQ(id, 7);
+        ASSERT_FLOAT_EQ(score, 22.0f);
+    };
+
+    runTopKSearchTest(index, query, 1, verify_query_score);
+    runRangeQueryTest(index, query, 23.0, verify_query_score, 1, BY_SCORE);
+    VecSimBatchIterator *batch_iterator = VecSimBatchIterator_New(index, query, nullptr);
+    runBatchIteratorSearchTest(batch_iterator, 1, verify_query_score);
+    VecSimBatchIterator_Free(batch_iterator);
+
+    VecSimIndex_Free(index);
+}
 
 TYPED_TEST(HNSWTest, hnsw_vector_add_test) {
     size_t dim = 4;


### PR DESCRIPTION
**Describe the changes in the pull request**

PR [#999](https://github.com/RedisAI/VectorSimilarity/pull/999) has merged. This PR targets `main` and builds on its stored-to-query distance dispatch.

Cherry-picks ARM's [`027d5510b2bf7add6a45be9b0c07cda38c15b5ca`](https://github.com/ARM-software/VectorSimilarity-for-Arm/commit/027d5510b2bf7add6a45be9b0c07cda38c15b5ca) from [ARM-software/VectorSimilarity-for-Arm#2](https://github.com/ARM-software/VectorSimilarity-for-Arm/pull/2).

This PR adds an optional normalization-aware mode to `QuantPreprocessor`. It stores the mean-vector inner product as additional SQ8 metadata for normalized storage and queries, extends SQ8 metadata sizing, and shares a float-based quantization implementation to avoid duplicated logic.

Existing `QuantPreprocessor` configurations retain their current behavior. FP32 and FP16 tests cover normalization for L2 and inner-product metrics.

It also follows up on review feedback from #999 with an HNSW integration test that installs distinct stored-to-stored and stored-to-query kernels. Top-K, range, and batch-iterator searches must all return the query-kernel score, proving HNSW selects the cached `StoredToQuery` dispatch.

**Which issues this PR fixes**

1. MOD-14952

**Main objects this PR modified**

1. `QuantPreprocessor`
2. `vecsim_types::sq8`
3. Quantization component unit tests
4. HNSW stored-to-query dispatch integration coverage

**Mark if applicable**

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

**Validation**

- `make format`
- `make check-format`
- Release build of `test_components` and `test_hnsw`
- `test_components`: 32/32 passed
- `test_hnsw` excluding the two external serialization fixtures: 169/169 passed
- GitHub Actions, sanitizer, CodeQL, and Codecov checks passed
- `git diff --check main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new preprocessor constructor and larger SQ8 metadata when normalization is on; default `WithNorm=false` limits blast radius, but wrong mean or layout mismatches would break distance reconstruction.
> 
> **Overview**
> Adds an optional **normalization-aware** mode to `QuantPreprocessor` via a `WithNorm` template flag (default **off**, so existing indexes keep the same blob layout and behavior).
> 
> When `WithNorm` is enabled, storage quantization uses **mean-centered** values (`x - mean[i]`) for min/max, scaling, and sums, while query vectors stay in the original `DataType`. An extra FP32 metadata field records **Σ(x·mean)** on storage (`x_mean_ip`) and **Σ(y·mean)** on queries (`y_mean_ip`). A new constructor takes a precomputed FP32 mean vector; **Cosine + WithNorm** is rejected at compile time. `vecsim_types::sq8` grows metadata sizing helpers and index accessors for the extra slot.
> 
> Unit coverage exercises L2 and inner product for **float32** and **float16** with norm. An HNSW test wires distinct stored-to-stored vs stored-to-query distance kernels and checks top-K, range, and batch search use the **query** path score.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e8f1c99242c26f7125b1a6cb5776aa1db24481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->