### PR TITLE
[8.4] SVS shared thread pool with rental model (MOD-9881, MOD-17090)

### DIFF
--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -37,13 +37,14 @@ struct SVSIndexBase
 {
     SVSIndexBase() : num_marked_deleted{0} {};
     virtual ~SVSIndexBase() = default;
+
     virtual int addVectors(const void *vectors_data, const labelType *labels, size_t n) = 0;
     virtual int deleteVectors(const labelType *labels, size_t n) = 0;
     virtual bool isLabelExists(labelType label) const = 0;
     virtual size_t indexStorageSize() const = 0;
-    virtual size_t getNumThreads() const = 0;
-    virtual void setNumThreads(size_t numThreads) = 0;
-    virtual size_t getThreadPoolCapacity() const = 0;
+    virtual size_t getParallelism() const = 0;
+    virtual void setParallelism(size_t parallelism) = 0;
+    virtual size_t getPoolSize() const = 0;
     virtual bool isCompressed() const = 0;
     size_t getNumMarkedDeleted() const { return num_marked_deleted; }
 
@@ -66,9 +67,9 @@ protected:
 };
 
 /** Thread Management Strategy:
- * - addVector(): Requires numThreads == 1
- * - addVectors(): Allows any numThreads value, but prohibits n=1 with numThreads>1
- * - Callers are responsible for setting appropriate thread counts
+ * - addVector(): Requires parallelism == 1
+ * - addVectors(): Allows any parallelism value, but prohibits n=1 with parallelism>1
+ * - Callers are responsible for setting appropriate parallelism
  **/
 template <typename MetricType, typename DataType, bool isMulti, size_t QuantBits,
           size_t ResidualBits, bool IsLeanVec>
@@ -251,12 +252,12 @@ protected:
         this->impl_ = std::move(svs_handler->impl);
     }
 
-    // Assuming numThreads was updated to reflect the number of available threads before this
+    // Assuming parallelism was updated to reflect the number of available threads before this
     // function was called.
-    // This function assumes that the caller has already set numThreads to the appropriate value
+    // This function assumes that the caller has already set parallelism to the appropriate value
     // for the operation.
-    // Important NOTE: For single vector operations (n=1), numThreads should be 1.
-    // For bulk operations (n>1), numThreads should reflect the number of available threads.
+    // Important NOTE: For single vector operations (n=1), parallelism should be 1.
+    // For bulk operations (n>1), parallelism should reflect the number of available threads.
     int addVectorsImpl(const void *vectors_data, const labelType *labels, size_t n) {
         if (n == 0) {
             return 0;
@@ -360,10 +361,14 @@ public:
           leanvec_dim{
               svs_details::getOrDefault(params.leanvec_dim, SVS_VAMANA_DEFAULT_LEANVEC_DIM)},
           epsilon{svs_details::getOrDefault(params.epsilon, SVS_VAMANA_DEFAULT_EPSILON)},
-          is_two_level_lvq{isTwoLevelLVQ(params.quantBits)},
-          threadpool_{std::max(size_t{SVS_VAMANA_DEFAULT_NUM_THREADS}, params.num_threads)},
+          is_two_level_lvq{isTwoLevelLVQ(params.quantBits)}, threadpool_{this->logCallbackCtx},
           impl_{nullptr} {
         logger_ = makeLogger();
+        if (params.num_threads != 0) {
+            this->log(VecSimCommonStrings::LOG_WARNING_STRING,
+                      "SVSParams.num_threads is deprecated and ignored. "
+                      "Thread pool size is controlled globally via VecSim_UpdateThreadPoolSize().");
+        }
     }
 
     ~SVSIndex() = default;
@@ -412,8 +417,8 @@ public:
                           .maxCandidatePoolSize = this->buildParams.max_candidate_pool_size,
                           .pruneTo = this->buildParams.prune_to,
                           .useSearchHistory = this->buildParams.use_full_search_history,
-                          .numThreads = this->getThreadPoolCapacity(),
-                          .lastReservedThreads = this->getNumThreads(),
+                          .numThreads = this->getPoolSize(),
+                          .lastReservedThreads = this->getParallelism(),
                           .numberOfMarkedDeletedNodes = this->num_marked_deleted,
                           .searchWindowSize = this->search_window_size,
                           .searchBufferCapacity = this->search_buffer_capacity,
@@ -517,16 +522,16 @@ public:
 
     int addVector(const void *vector_data, labelType label) override {
         // Enforce single-threaded execution for single vector operations to ensure optimal
-        // performance and consistent behavior. Callers must set numThreads=1 before calling this
+        // performance and consistent behavior. Callers must set parallelism=1 before calling this
         // method.
-        assert(getNumThreads() == 1 && "Can't use more than one thread to insert a single vector");
+        assert(getParallelism() == 1 && "Can't use more than one thread to insert a single vector");
         return addVectorsImpl(vector_data, &label, 1);
     }
 
     int addVectors(const void *vectors_data, const labelType *labels, size_t n) override {
         // Prevent misuse: single vector operations should use addVector(), not addVectors() with
         // n=1 This ensures proper thread management and API contract enforcement.
-        assert(!(n == 1 && getNumThreads() > 1) &&
+        assert(!(n == 1 && getParallelism() > 1) &&
                "Can't use more than one thread to insert a single vector");
         return addVectorsImpl(vectors_data, labels, n);
     }
@@ -541,10 +546,10 @@ public:
         return impl_ ? impl_->has_id(label) : false;
     }
 
-    size_t getNumThreads() const override { return threadpool_.size(); }
-    void setNumThreads(size_t numThreads) override { threadpool_.resize(numThreads); }
+    size_t getParallelism() const override { return threadpool_.getParallelism(); }
+    void setParallelism(size_t parallelism) override { threadpool_.setParallelism(parallelism); }
 
-    size_t getThreadPoolCapacity() const override { return threadpool_.capacity(); }
+    size_t getPoolSize() const override { return threadpool_.poolSize(); }
 
     bool isCompressed() const override { return storage_traits_t::is_compressed(); }
 

--- a/src/VecSim/algorithms/svs/svs.h
+++ b/src/VecSim/algorithms/svs/svs.h
@@ -361,8 +361,8 @@ public:
           leanvec_dim{
               svs_details::getOrDefault(params.leanvec_dim, SVS_VAMANA_DEFAULT_LEANVEC_DIM)},
           epsilon{svs_details::getOrDefault(params.epsilon, SVS_VAMANA_DEFAULT_EPSILON)},
-          is_two_level_lvq{isTwoLevelLVQ(params.quantBits)}, threadpool_{this->logCallbackCtx},
-          impl_{nullptr} {
+          is_two_level_lvq{isTwoLevelLVQ(params.quantBits)},
+          threadpool_{this->allocator, this->logCallbackCtx}, impl_{nullptr} {
         logger_ = makeLogger();
         if (params.num_threads != 0) {
             this->log(VecSimCommonStrings::LOG_WARNING_STRING,
@@ -429,8 +429,14 @@ public:
 
     VecSimDebugInfoIterator *debugInfoIterator() const override {
         VecSimIndexDebugInfo info = this->debugInfo();
-        // For readability. Update this number when needed.
-        size_t numberOfInfoFields = 23;
+        // Capacity hint: 26 = 25 fields added below (1 ALGORITHM + 9 from
+        // addCommonInfoToIterator + 15 SVS-specific) + 1 for the SHARED_MEMORY field
+        // that the C API wrapper VecSimIndex_DebugInfoIterator appends after this
+        // method returns. Reserving the extra slot avoids a reallocation on the
+        // top-level path; when nested in a tiered BACKEND_INDEX the C API does not
+        // append it, so the hint over-reserves by one (harmless).
+        // Update this number when fields are added or removed.
+        size_t numberOfInfoFields = 26;
         VecSimDebugInfoIterator *infoIterator =
             new VecSimDebugInfoIterator(numberOfInfoFields, this->allocator);
 

--- a/src/VecSim/algorithms/svs/svs_tiered.h
+++ b/src/VecSim/algorithms/svs/svs_tiered.h
@@ -144,6 +144,7 @@ private:
     task_type task;
     std::shared_ptr<ControlBlock> controlBlock;
     JobsRegistry *jobsRegistry;
+    bool isScheduled; // true if this job holds a pending-job reservation on the thread pool
 
     static void ExecuteMultiThreadJobImpl(AsyncJob *job) {
         auto *jobPtr = static_cast<SVSMultiThreadJob *>(job);
@@ -162,26 +163,44 @@ private:
 
     SVSMultiThreadJob(std::shared_ptr<VecSimAllocator> allocator, JobType jobType,
                       task_type callback, VecSimIndex *index,
-                      std::shared_ptr<ControlBlock> controlBlock, JobsRegistry *registry)
+                      std::shared_ptr<ControlBlock> controlBlock, JobsRegistry *registry,
+                      bool scheduled = false)
         : AsyncJob(std::move(allocator), jobType, ExecuteMultiThreadJobImpl, index),
-          task(std::move(callback)), controlBlock(std::move(controlBlock)), jobsRegistry(registry) {
+          task(std::move(callback)), controlBlock(std::move(controlBlock)), jobsRegistry(registry),
+          isScheduled(scheduled) {}
+
+    ~SVSMultiThreadJob() {
+        if (isScheduled) {
+            VecSimSVSThreadPoolImpl::instance()->endScheduledJob();
+        }
     }
 
 public:
     template <typename Rep, typename Period>
     static vecsim_stl::vector<AsyncJob *>
+    createScheduledJobs(const std::shared_ptr<VecSimAllocator> &allocator, JobType jobType,
+                        std::function<void(VecSimIndex *, size_t)> callback, VecSimIndex *index,
+                        std::chrono::duration<Rep, Period> threads_wait_timeout,
+                        JobsRegistry *registry) {
+        size_t num_threads = VecSimSVSThreadPoolImpl::instance()->beginScheduledJob();
+        return createJobs(allocator, jobType, callback, index, num_threads, threads_wait_timeout,
+                          registry, /*scheduled=*/true);
+    }
+
+    template <typename Rep, typename Period>
+    static vecsim_stl::vector<AsyncJob *>
     createJobs(const std::shared_ptr<VecSimAllocator> &allocator, JobType jobType,
                std::function<void(VecSimIndex *, size_t)> callback, VecSimIndex *index,
                size_t num_threads, std::chrono::duration<Rep, Period> threads_wait_timeout,
-               JobsRegistry *registry) {
+               JobsRegistry *registry, bool scheduled = false) {
         assert(num_threads > 0);
         std::shared_ptr<ControlBlock> controlBlock =
             num_threads == 1 ? nullptr
                              : std::make_shared<ControlBlock>(num_threads, threads_wait_timeout);
 
         vecsim_stl::vector<AsyncJob *> jobs(num_threads, allocator);
-        jobs[0] = new (allocator)
-            SVSMultiThreadJob(allocator, jobType, callback, index, controlBlock, registry);
+        jobs[0] = new (allocator) SVSMultiThreadJob(allocator, jobType, callback, index,
+                                                    controlBlock, registry, scheduled);
         for (size_t i = 1; i < num_threads; ++i) {
             jobs[i] =
                 new (allocator) ReserveThreadJob(allocator, jobType, index, controlBlock, registry);
@@ -587,7 +606,8 @@ private:
             // No need to run GC on an empty index.
             return;
         }
-        svs_index->setNumThreads(std::min(availableThreads, index->backendIndex->indexSize()));
+        index->executeTracingCallback("GCJob::before_run_gc");
+        svs_index->setParallelism(std::min(availableThreads, index->backendIndex->indexSize()));
         // VecSimIndexAbstract::runGC() is protected
         static_cast<VecSimIndexInterface *>(index->backendIndex)->runGC();
     }
@@ -601,9 +621,8 @@ public:
             return;
         }
 
-        auto total_threads = this->GetSVSIndex()->getThreadPoolCapacity();
-        auto jobs = SVSMultiThreadJob::createJobs(
-            this->allocator, SVS_BATCH_UPDATE_JOB, updateSVSIndexWrapper, this, total_threads,
+        auto jobs = SVSMultiThreadJob::createScheduledJobs(
+            this->allocator, SVS_BATCH_UPDATE_JOB, updateSVSIndexWrapper, this,
             std::chrono::microseconds(updateJobWaitTime), &uncompletedJobs);
         this->submitJobs(jobs);
     }
@@ -614,9 +633,8 @@ public:
             return;
         }
 
-        auto total_threads = this->GetSVSIndex()->getThreadPoolCapacity();
-        auto jobs = SVSMultiThreadJob::createJobs(
-            this->allocator, SVS_GC_JOB, SVSIndexGCWrapper, this, total_threads,
+        auto jobs = SVSMultiThreadJob::createScheduledJobs(
+            this->allocator, SVS_GC_JOB, SVSIndexGCWrapper, this,
             std::chrono::microseconds(updateJobWaitTime), &uncompletedJobs);
         this->submitJobs(jobs);
     }
@@ -677,13 +695,14 @@ private:
         } // release frontend index
 
         executeTracingCallback("UpdateJob::before_add_to_svs");
-        { // lock backend index for writing and add vectors there
+        if (!labels_to_move.empty()) {
+            // lock backend index for writing and add vectors there
             std::shared_lock main_shared_lock(this->mainIndexGuard);
             auto svs_index = GetSVSIndex();
             assert(labels_to_move.size() == vectors_to_move.size() / this->frontendIndex->getDim());
             if (this->backendIndex->indexSize() == 0) {
                 // If backend index is empty, we need to initialize it first.
-                svs_index->setNumThreads(std::min(availableThreads, labels_to_move.size()));
+                svs_index->setParallelism(std::min(availableThreads, labels_to_move.size()));
                 auto impl = svs_index->createImpl(vectors_to_move.data(), labels_to_move.data(),
                                                   labels_to_move.size());
 
@@ -696,7 +715,7 @@ private:
                 main_shared_lock.unlock();
                 std::lock_guard lock(this->mainIndexGuard);
                 // Upgrade to unique lock to add vectors
-                svs_index->setNumThreads(std::min(availableThreads, labels_to_move.size()));
+                svs_index->setParallelism(std::min(availableThreads, labels_to_move.size()));
                 svs_index->addVectors(vectors_to_move.data(), labels_to_move.data(),
                                       labels_to_move.size());
             }
@@ -819,11 +838,9 @@ public:
                 // prevent update job from running in parallel and lock any access to the backend
                 // index
                 std::scoped_lock lock(this->updateJobMutex, this->mainIndexGuard);
-                // Set available thread count to 1 for single vector write-in-place operation.
-                // This maintains the contract that single vector operations use exactly one thread.
-                // TODO: Replace this setNumThreads(1) call with an assertion once we establish
-                // a contract that write-in-place mode guarantees numThreads == 1.
-                svs_index->setNumThreads(1);
+                // Defensive: ensure single-threaded operation for write-in-place mode.
+                // parallelism_ defaults to 1, so this is a no-op in the normal case.
+                svs_index->setParallelism(1);
                 return this->backendIndex->addVector(storage_blob.get(), label);
             }
         }
@@ -1087,7 +1104,7 @@ public:
                 return;
             }
             // Force single thread for write-in-place mode.
-            this->GetSVSIndex()->setNumThreads(1);
+            this->GetSVSIndex()->setParallelism(1);
             // VecSimIndexAbstract::runGC() is protected
             static_cast<VecSimIndexInterface *>(this->backendIndex)->runGC();
             return;

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -9,6 +9,7 @@
 
 #pragma once
 #include "VecSim/query_results.h"
+#include "VecSim/vec_sim_interface.h"
 #include "VecSim/types/float16.h"
 
 #include "svs/core/distance.h"
@@ -19,8 +20,11 @@
 #include "svs/cpuid.h"
 #endif
 
+#include <atomic>
 #include <cstdint>
 #include <cstdlib>
+#include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -341,110 +345,342 @@ struct SVSGraphBuilder {
     }
 };
 
-// Custom thread pool for SVS index
+// A slot in the shared SVS thread pool. Wraps an SVS Thread with an occupancy flag
+// used by the rental mechanism. Stored as shared_ptr in the pool so that deferred
+// resize can safely shrink. Renters hold raw pointers (safe because the deferred-resize
+// protocol prevents slot destruction while jobs are in flight).
+struct ThreadSlot {
+    svs::threads::Thread thread;
+    std::atomic<bool> occupied{false};
+
+    ThreadSlot() = default;
+
+    // Non-copyable, non-movable (atomic is not movable)
+    ThreadSlot(const ThreadSlot &) = delete;
+    ThreadSlot &operator=(const ThreadSlot &) = delete;
+    ThreadSlot(ThreadSlot &&) = delete;
+    ThreadSlot &operator=(ThreadSlot &&) = delete;
+};
+
+// Shared thread pool for SVS indexes with rental model.
 // Based on svs::threads::NativeThreadPoolBase with changes:
-// * Number of threads is fixed on construction time
-// * Pool is resizable in bounds of pre-allocated threads
+// * Pool is physically resizable (creates/destroys OS threads)
+// * Threads are rented for the duration of a parallel_for call
+// * Multiple callers can rent disjoint subsets of threads concurrently
+// * Shrinking while threads are rented is safe (shared_ptr lifecycle)
 class VecSimSVSThreadPoolImpl {
-public:
-    // Allocate `num_threads - 1` threads since the main thread participates in the work
-    // as well.
-    explicit VecSimSVSThreadPoolImpl(size_t num_threads = 1)
-        : size_{num_threads}, threads_(num_threads - 1) {}
+    // RAII guard for threads rented from the shared pool. On destruction, marks all
+    // rented slots as unoccupied (lock-free atomic stores). Uses raw pointers to
+    // avoid shared_ptr ref-counting overhead on the hot path.
+    // Safety: raw pointers are safe because the deferred-resize protocol ensures the
+    // pool cannot shrink (destroy slots) while scheduled jobs are in flight, and all
+    // multi-threaded SVS operations run within scheduled jobs.
+    class RentedThreads {
+    public:
+        RentedThreads() = default;
 
-    size_t capacity() const { return threads_.size() + 1; }
-    size_t size() const { return size_; }
+        // Move-only
+        RentedThreads(RentedThreads &&other) noexcept : slots_(std::move(other.slots_)) {}
+        RentedThreads(const RentedThreads &) = delete;
+        RentedThreads &operator=(const RentedThreads &) = delete;
+        RentedThreads &operator=(RentedThreads &&) = delete;
 
-    // Support resize - do not modify threads container just limit the size
-    void resize(size_t new_size) {
-        std::lock_guard lock{use_mutex_};
-        size_ = std::clamp(new_size, size_t{1}, threads_.size() + 1);
+        ~RentedThreads() { release(); }
+
+        void add(ThreadSlot *slot) { slots_.push_back(slot); }
+
+        size_t count() const { return slots_.size(); }
+
+        svs::threads::Thread &operator[](size_t i) {
+            assert(i < slots_.size());
+            return slots_[i]->thread;
+        }
+
+    private:
+        void release() {
+            for (auto *slot : slots_) {
+                slot->occupied.store(false, std::memory_order_release);
+            }
+            slots_.clear();
+        }
+
+        std::vector<ThreadSlot *> slots_;
+    };
+
+    // Create a pool with `num_threads` total parallelism (including the calling thread).
+    // Spawns `num_threads - 1` worker OS threads. num_threads must be >= 1.
+    // In write-in-place mode, the pool is created with num_threads == 1 (0 worker threads,
+    // only the calling thread participates).
+    // Private — use instance() to access the shared singleton.
+    explicit VecSimSVSThreadPoolImpl(size_t num_threads = 1) {
+        assert(num_threads && "VecSimSVSThreadPoolImpl should not be created with 0 threads");
+        slots_.reserve(num_threads - 1);
+        for (size_t i = 0; i < num_threads - 1; ++i) {
+            slots_.push_back(std::make_shared<ThreadSlot>());
+        }
     }
 
-    void parallel_for(std::function<void(size_t)> f, size_t n) {
-        if (n > size_) {
-            throw svs::threads::ThreadingException("Number of tasks exceeds the thread pool size");
+public:
+    // Singleton accessor for the shared SVS thread pool.
+    // Always valid — initialized with size 1 (write-in-place mode: 0 worker threads,
+    // only the calling thread participates). Resized on VecSim_UpdateThreadPoolSize() calls.
+    static std::shared_ptr<VecSimSVSThreadPoolImpl> instance() {
+        static auto shared_pool = std::shared_ptr<VecSimSVSThreadPoolImpl>(
+            new VecSimSVSThreadPoolImpl(1), [](VecSimSVSThreadPoolImpl *) { /* leak at exit */ });
+        return shared_pool;
+    }
+
+    // Total parallelism: worker slots + 1 (the calling thread always participates).
+    size_t size() const {
+        std::lock_guard lock{pool_mutex_};
+        return slots_.size() + 1;
+    }
+
+    // Physically resize the pool. Creates new OS threads on grow, shuts down idle threads
+    // on shrink. new_size is total parallelism including the calling thread (minimum 1).
+    // Occupied threads (held by renters) survive shrink via the deferred-resize protocol —
+    // the pool defers shrink while jobs are in flight, so slots cannot be destroyed while rented.
+    //
+    // If jobs are in flight (pending_jobs_ > 0), shrink is deferred — the target size is
+    // stored and applied when the last job completes (see endScheduledJob()). Grow is
+    // always applied immediately so new jobs can use the extra threads right away.
+    void resize(size_t new_size) {
+        new_size = std::max(new_size, size_t{1});
+        std::lock_guard lock{pool_mutex_};
+        resize_locked(new_size);
+    }
+
+    // Deferred-resize protocol
+    // ========================
+    // When a job is created via createScheduledJobs(), the pool size is snapshotted
+    // to determine how many reserve jobs to submit to the RediSearch worker pool.
+    // If resize() shrinks the SVS pool between that snapshot and when the job
+    // actually executes, the RediSearch workers would have checked in (reserved
+    // threads exist) but the SVS pool slots they need to rent from would have been
+    // destroyed — causing a failure.
+    //
+    // To prevent this, beginScheduledJob() increments pending_jobs_, and any shrink
+    // while pending_jobs_ > 0 is deferred (stored in deferred_size_) until the last
+    // in-flight job completes and its destructor calls endScheduledJob(). Grows are
+    // always applied immediately since extra threads don't break anything.
+
+    // Atomically mark a logical job as pending and snapshot the current shared pool size.
+    size_t beginScheduledJob() {
+        std::lock_guard lock{pool_mutex_};
+        ++pending_jobs_;
+        return slots_.size() + 1;
+    }
+
+    // Decrement the pending-jobs counter. When it reaches zero, apply any deferred resize.
+    void endScheduledJob() {
+        std::lock_guard lock{pool_mutex_};
+        assert(pending_jobs_ > 0 && "endScheduledJob called without matching beginScheduledJob");
+        if (--pending_jobs_ == 0 && deferred_size_.has_value()) {
+            resize_locked(deferred_size_.value());
+            deferred_size_.reset();
         }
+    }
+
+    // Execute `f` in parallel with `n` partitions. The calling thread runs partition 0,
+    // and up to `n-1` worker threads are rented for partitions 1..n-1.
+    // Same signature as the SVS ThreadPool concept.
+    void parallel_for(std::function<void(size_t)> f, size_t n, void *log_ctx = nullptr) {
         if (n == 0) {
             return;
-        } else if (n == 1) {
-            // Run on the main function.
+        }
+        if (n == 1) {
+            // Single partition: run on the calling thread, no rental needed.
             try {
                 f(0);
             } catch (const std::exception &error) {
-                manage_exception_during_run(error.what());
+                // No workers to check — just rethrow with formatted message.
+                auto msg = fmt::format("Thread 0: {}\n", error.what());
+                throw svs::threads::ThreadingException{std::move(msg)};
             }
             return;
-        } else {
-            std::lock_guard lock{use_mutex_};
-            for (size_t i = 0; i < n - 1; ++i) {
-                threads_[i].assign({&f, i + 1});
-            }
-            // Run on the main function.
-            try {
-                f(0);
-            } catch (const std::exception &error) {
-                manage_exception_during_run(error.what());
-            }
+        }
 
-            // Wait until all threads are done.
-            // If any thread fails, then we're throwing.
-            for (size_t i = 0; i < size_ - 1; ++i) {
-                auto &thread = threads_[i];
-                thread.wait();
-                if (!thread.is_okay()) {
-                    manage_exception_during_run();
+        // Rent n-1 worker threads
+        auto rented = rent(n - 1, log_ctx);
+
+        // Assign work to rented workers (partitions 1..n-1)
+        for (size_t i = 0; i < rented.count(); ++i) {
+            rented[i].assign({&f, i + 1});
+        }
+
+        // Run partition 0 on the calling thread
+        std::string main_thread_error;
+        try {
+            f(0);
+        } catch (const std::exception &error) {
+            main_thread_error = error.what();
+        }
+
+        // Wait for all rented workers and collect errors.
+        // RentedThreads destructor will release the slots after this block.
+        manage_workers_after_run(main_thread_error, rented);
+    }
+
+private:
+    // Rent up to `count` worker threads from the pool. Returns an RAII guard that
+    // automatically releases the threads when destroyed.
+    // The SVS pool is sized to match the RediSearch thread pool, and RediSearch controls
+    // scheduling via reserve jobs, so all requested slots should always be available.
+    // Getting fewer threads than requested indicates a bug in the scheduling logic.
+    RentedThreads rent(size_t count, void *log_ctx = nullptr) {
+        RentedThreads rented;
+        if (count == 0) {
+            return rented;
+        }
+
+        std::lock_guard lock{pool_mutex_};
+        size_t rented_count = 0;
+        for (auto &slot : slots_) {
+            bool expected = false;
+            if (slot->occupied.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+                rented.add(slot.get());
+                if (++rented_count >= count) {
+                    break;
                 }
             }
         }
+
+        if (rented.count() < count) {
+            auto msg = fmt::format("SVS thread pool: rented {} threads out of {} requested "
+                                   "(pool has {} slots). This should not happen.",
+                                   rented.count(), count, slots_.size());
+            if (VecSimIndexInterface::logCallback) {
+                assert(log_ctx && "Log context must be provided when logging is available");
+                VecSimIndexInterface::logCallback(log_ctx, "warning", msg.c_str());
+            }
+            assert(false && "Failed to rent the expected number of SVS threads");
+        }
+        return rented;
     }
 
-    void manage_exception_during_run(const std::string &thread_0_message = {}) {
+    // Wait for all rented workers to finish. If any worker (or the main thread) threw,
+    // restart crashed workers and throw a combined exception.
+    void manage_workers_after_run(const std::string &main_thread_error, RentedThreads &rented) {
         auto message = std::string{};
         auto inserter = std::back_inserter(message);
-        if (!thread_0_message.empty()) {
-            fmt::format_to(inserter, "Thread 0: {}\n", thread_0_message);
+        bool has_error = !main_thread_error.empty();
+
+        if (has_error) {
+            fmt::format_to(inserter, "Thread 0: {}\n", main_thread_error);
         }
 
-        // Manage all other exceptions thrown, restarting crashed threads.
-        for (size_t i = 0; i < size_ - 1; ++i) {
-            auto &thread = threads_[i];
+        for (size_t i = 0; i < rented.count(); ++i) {
+            auto &thread = rented[i];
             thread.wait();
             if (!thread.is_okay()) {
+                has_error = true;
                 try {
                     thread.unsafe_get_exception();
                 } catch (const std::exception &error) {
                     fmt::format_to(inserter, "Thread {}: {}\n", i + 1, error.what());
                 }
-                // Restart the thread.
-                threads_[i].shutdown();
-                threads_[i] = svs::threads::Thread{};
+                // Restart the crashed thread so the slot is usable again.
+                thread.shutdown();
+                thread = svs::threads::Thread{};
             }
         }
-        throw svs::threads::ThreadingException{std::move(message)};
+
+        if (has_error) {
+            throw svs::threads::ThreadingException{std::move(message)};
+        }
     }
 
-private:
-    std::mutex use_mutex_;
-    size_t size_;
-    std::vector<svs::threads::Thread> threads_;
+    // Actual resize logic. Caller must hold pool_mutex_.
+    // Grow is always applied immediately. Shrink is deferred if pending_jobs_ > 0.
+    void resize_locked(size_t new_size) {
+        size_t target_workers = new_size - 1;
+
+        if (target_workers >= slots_.size()) {
+            // Grow (or same size): apply immediately, cancel any pending deferred shrink.
+            deferred_size_.reset();
+            for (size_t i = slots_.size(); i < target_workers; ++i) {
+                slots_.push_back(std::make_shared<ThreadSlot>());
+            }
+        } else {
+            // Shrink.
+            if (pending_jobs_ > 0) {
+                // Defer shrink — jobs in flight may still need these threads.
+                deferred_size_ = new_size;
+            } else {
+                // Safe to shrink now — no jobs in flight.
+                // Occupied threads (held by renters) survive via shared_ptr.
+                // Idle threads are destroyed immediately.
+                slots_.resize(target_workers);
+            }
+        }
+    }
+
+    mutable std::mutex pool_mutex_;
+    std::vector<std::shared_ptr<ThreadSlot>> slots_;
+    size_t pending_jobs_ = 0;             // jobs currently scheduled / in-flight
+    std::optional<size_t> deferred_size_; // resize target deferred until pending_jobs_ == 0
 };
 
-// Copy-movable wrapper for VecSimSVSThreadPoolImpl
+// Per-index wrapper around the shared VecSimSVSThreadPoolImpl singleton.
+// Lightweight, copyable (SVS stores a copy via ThreadPoolHandle). Both the original
+// and SVS's copy share the same pool_ and parallelism_ via shared_ptr, so state
+// changes propagate automatically.
+// Satisfies the svs::threads::ThreadPool concept (size() + parallel_for).
+// The pool is always valid — in write-in-place mode it has size 1 (0 worker threads).
 class VecSimSVSThreadPool {
 private:
-    std::shared_ptr<VecSimSVSThreadPoolImpl> pool_;
+    std::shared_ptr<VecSimSVSThreadPoolImpl> pool_; // shared across all indexes
+    // Per-index parallelism, shared across copies (SVS stores a copy of VecSimSVSThreadPool).
+    // SVS reads this value via size() during parallel_for to decide how many threads to use
+    // for task partitioning. Because SVS reads size() internally — not under our control —
+    // the caller must ensure that parallelism_ is stable for the entire duration of any SVS
+    // operation (search, build, consolidate, add, etc.). In practice this means:
+    //   setParallelism(n) and the subsequent SVS call must be protected by the same lock,
+    //   and no other code path may call setParallelism() on the same index concurrently.
+    // Currently, mainIndexGuard (exclusive) or updateJobMutex fulfills this role.
+    std::shared_ptr<std::atomic<size_t>> parallelism_;
+    void *log_ctx_ = nullptr; // per-index log context
 
 public:
-    explicit VecSimSVSThreadPool(size_t num_threads = 1)
-        : pool_{std::make_shared<VecSimSVSThreadPoolImpl>(num_threads)} {}
+    // Construct using the shared pool singleton.
+    // parallelism_ starts at 1 (the calling thread always participates), matching the
+    // pool's minimum size. Safe for immediate use in write-in-place mode without an
+    // explicit setParallelism() call.
+    explicit VecSimSVSThreadPool(void *log_ctx = nullptr)
+        : pool_(VecSimSVSThreadPoolImpl::instance()),
+          parallelism_(std::make_shared<std::atomic<size_t>>(1)), log_ctx_(log_ctx) {}
 
-    size_t capacity() const { return pool_->capacity(); }
-    size_t size() const { return pool_->size(); }
+    // Resize the shared pool singleton. Delegates to VecSimSVSThreadPoolImpl::instance().
+    static void resize(size_t new_size) { VecSimSVSThreadPoolImpl::instance()->resize(new_size); }
 
-    void parallel_for(std::function<void(size_t)> f, size_t n) {
-        pool_->parallel_for(std::move(f), n);
+    // Set the degree of parallelism for this index's next operation.
+    // n must be the number of threads actually reserved by the caller (i.e., the
+    // RediSearch workers that checked in via ReserveThreadJob). This is what allows
+    // us to assert n <= pool size: reserved workers are occupied RediSearch threads,
+    // so the pool cannot shrink while they are held, and n cannot exceed the pool size.
+    //
+    // IMPORTANT: The caller must hold a lock that prevents any concurrent SVS operation
+    // on this index from reading size() between setParallelism() and the operation that
+    // depends on it. SVS internally calls pool.size() (which returns parallelism_) during
+    // parallel_for — if another thread calls setParallelism() concurrently, the operation
+    // may see an inconsistent value.
+    void setParallelism(size_t n) {
+        assert(n >= 1 && "Parallelism must be at least 1 (the calling thread)");
+        assert(n <= pool_->size() && "Parallelism exceeds shared pool size");
+        parallelism_->store(n);
     }
+    size_t getParallelism() const { return parallelism_->load(); }
 
-    void resize(size_t new_size) { pool_->resize(new_size); }
+    // Returns per-index parallelism. SVS uses this for task partitioning (ThreadPool concept).
+    size_t size() const { return parallelism_->load(); }
+
+    // Shared pool size — used by scheduling to decide how many reserve jobs to submit.
+    static size_t poolSize() { return VecSimSVSThreadPoolImpl::instance()->size(); }
+
+    // Delegates to the shared pool's parallel_for, passing the per-index log context.
+    // n may be less than parallelism_ when the problem size is smaller than the
+    // thread count (SVS computes n = min(arg.size(), pool.size())).
+    void parallel_for(std::function<void(size_t)> f, size_t n) {
+        pool_->parallel_for(std::move(f), n, log_ctx_);
+    }
 };

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -10,6 +10,7 @@
 #pragma once
 #include "VecSim/query_results.h"
 #include "VecSim/vec_sim_interface.h"
+#include "VecSim/utils/vecsim_stl.h"
 #include "VecSim/types/float16.h"
 
 #include "svs/core/distance.h"
@@ -407,17 +408,29 @@ class VecSimSVSThreadPoolImpl {
         std::vector<ThreadSlot *> slots_;
     };
 
+    using SlotPtr = std::shared_ptr<ThreadSlot>;
+
     // Create a pool with `num_threads` total parallelism (including the calling thread).
     // Spawns `num_threads - 1` worker OS threads. num_threads must be >= 1.
     // In write-in-place mode, the pool is created with num_threads == 1 (0 worker threads,
     // only the calling thread participates).
     // Private — use instance() to access the shared singleton.
-    explicit VecSimSVSThreadPoolImpl(size_t num_threads = 1) {
+    explicit VecSimSVSThreadPoolImpl(size_t num_threads = 1)
+        : allocator_(VecSimAllocator::newVecsimAllocator()), slots_(allocator_) {
         assert(num_threads && "VecSimSVSThreadPoolImpl should not be created with 0 threads");
         slots_.reserve(num_threads - 1);
         for (size_t i = 0; i < num_threads - 1; ++i) {
-            slots_.push_back(std::make_shared<ThreadSlot>());
+            slots_.push_back(
+                std::allocate_shared<ThreadSlot>(VecsimSTLAllocator<ThreadSlot>(allocator_)));
         }
+    }
+
+    // Set to true the first time instance() constructs the singleton. Allows other
+    // code paths (e.g., global stats reporting) to query whether the pool has been
+    // touched without forcing its lazy construction.
+    static std::atomic<bool> &initialized_flag() {
+        static std::atomic<bool> flag{false};
+        return flag;
     }
 
 public:
@@ -425,15 +438,39 @@ public:
     // Always valid — initialized with size 1 (write-in-place mode: 0 worker threads,
     // only the calling thread participates). Resized on VecSim_UpdateThreadPoolSize() calls.
     static std::shared_ptr<VecSimSVSThreadPoolImpl> instance() {
-        static auto shared_pool = std::shared_ptr<VecSimSVSThreadPoolImpl>(
-            new VecSimSVSThreadPoolImpl(1), [](VecSimSVSThreadPoolImpl *) { /* leak at exit */ });
+        static auto shared_pool = [] {
+            auto p = std::shared_ptr<VecSimSVSThreadPoolImpl>(
+                new VecSimSVSThreadPoolImpl(1),
+                [](VecSimSVSThreadPoolImpl *) { /* leak at exit */ });
+            initialized_flag().store(true, std::memory_order_release);
+            return p;
+        }();
         return shared_pool;
     }
+
+    // Returns true iff instance() has ever been called (singleton constructed).
+    static bool isInitialized() { return initialized_flag().load(std::memory_order_acquire); }
 
     // Total parallelism: worker slots + 1 (the calling thread always participates).
     size_t size() const {
         std::lock_guard lock{pool_mutex_};
         return slots_.size() + 1;
+    }
+
+    // Bytes currently allocated through the pool's internal allocator (the slots vector
+    // and the ThreadSlot objects). Does not include allocations performed by SVS itself
+    // outside of the pool, nor per-index wrapper state.
+    size_t getAllocationSize() const { return allocator_->getAllocationSize(); }
+
+    // Bytes allocated by the shared pool singleton. Returns 0 if the singleton has
+    // never been constructed (e.g., no SVS index was ever created and
+    // VecSim_UpdateThreadPoolSize was never called). Safe to call from any context;
+    // does not force singleton construction.
+    static size_t getSharedAllocationSize() {
+        if (!isInitialized()) {
+            return 0;
+        }
+        return instance()->getAllocationSize();
     }
 
     // Physically resize the pool. Creates new OS threads on grow, shuts down idle threads
@@ -599,7 +636,8 @@ private:
             // Grow (or same size): apply immediately, cancel any pending deferred shrink.
             deferred_size_.reset();
             for (size_t i = slots_.size(); i < target_workers; ++i) {
-                slots_.push_back(std::make_shared<ThreadSlot>());
+                slots_.push_back(
+                    std::allocate_shared<ThreadSlot>(VecsimSTLAllocator<ThreadSlot>(allocator_)));
             }
         } else {
             // Shrink.
@@ -615,8 +653,9 @@ private:
         }
     }
 
+    std::shared_ptr<VecSimAllocator> allocator_; // pool's own allocator for memory tracking
     mutable std::mutex pool_mutex_;
-    std::vector<std::shared_ptr<ThreadSlot>> slots_;
+    vecsim_stl::vector<SlotPtr> slots_;
     size_t pending_jobs_ = 0;             // jobs currently scheduled / in-flight
     std::optional<size_t> deferred_size_; // resize target deferred until pending_jobs_ == 0
 };
@@ -646,9 +685,14 @@ public:
     // parallelism_ starts at 1 (the calling thread always participates), matching the
     // pool's minimum size. Safe for immediate use in write-in-place mode without an
     // explicit setParallelism() call.
-    explicit VecSimSVSThreadPool(void *log_ctx = nullptr)
+    // parallelism_ is allocated through the provided VecsimAllocator so that the
+    // allocation is tracked by the index's memory accounting.
+    explicit VecSimSVSThreadPool(const std::shared_ptr<VecSimAllocator> &allocator,
+                                 void *log_ctx = nullptr)
         : pool_(VecSimSVSThreadPoolImpl::instance()),
-          parallelism_(std::make_shared<std::atomic<size_t>>(1)), log_ctx_(log_ctx) {}
+          parallelism_(std::allocate_shared<std::atomic<size_t>>(
+              VecsimSTLAllocator<std::atomic<size_t>>(allocator), size_t{1})),
+          log_ctx_(log_ctx) {}
 
     // Resize the shared pool singleton. Delegates to VecSimSVSThreadPoolImpl::instance().
     static void resize(size_t new_size) { VecSimSVSThreadPoolImpl::instance()->resize(new_size); }
@@ -676,6 +720,11 @@ public:
 
     // Shared pool size — used by scheduling to decide how many reserve jobs to submit.
     static size_t poolSize() { return VecSimSVSThreadPoolImpl::instance()->size(); }
+
+    // See VecSimSVSThreadPoolImpl::getSharedAllocationSize().
+    static size_t getSharedAllocationSize() {
+        return VecSimSVSThreadPoolImpl::getSharedAllocationSize();
+    }
 
     // Delegates to the shared pool's parallel_for, passing the per-index log context.
     // n may be less than parallelism_ when the problem size is smaller than the

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -462,15 +462,25 @@ public:
     // outside of the pool, nor per-index wrapper state.
     size_t getAllocationSize() const { return allocator_->getAllocationSize(); }
 
-    // Bytes allocated by the shared pool singleton. Returns 0 if the singleton has
-    // never been constructed (e.g., no SVS index was ever created and
-    // VecSim_UpdateThreadPoolSize was never called). Safe to call from any context;
-    // does not force singleton construction.
+    // Bytes allocated by the shared pool singleton. Returns 0 until the first SVS index
+    // attaches, for either reason:
+    //   * the singleton was never constructed (no SVS index created and
+    //     VecSim_UpdateThreadPoolSize never called), or
+    //   * it was constructed to record a requested size (VecSim_UpdateThreadPoolSize at
+    //     module init) but no SVS index has attached yet.
+    // This keeps process-wide vector memory reported as 0 on deployments that only use
+    // non-SVS indexes (or none at all). Safe to call from any context; does not force
+    // singleton construction.
     static size_t getSharedAllocationSize() {
         if (!isInitialized()) {
             return 0;
         }
-        return instance()->getAllocationSize();
+        auto pool = instance();
+        std::lock_guard lock{pool->pool_mutex_};
+        if (!pool->has_attached_index_) {
+            return 0;
+        }
+        return pool->getAllocationSize();
     }
 
     // Resize the shared pool. in all cases the requested size is stored in

--- a/src/VecSim/algorithms/svs/svs_utils.h
+++ b/src/VecSim/algorithms/svs/svs_utils.h
@@ -473,33 +473,56 @@ public:
         return instance()->getAllocationSize();
     }
 
-    // Physically resize the pool. Creates new OS threads on grow, shuts down idle threads
-    // on shrink. new_size is total parallelism including the calling thread (minimum 1).
-    // Occupied threads (held by renters) survive shrink via the deferred-resize protocol —
-    // the pool defers shrink while jobs are in flight, so slots cannot be destroyed while rented.
-    //
-    // If jobs are in flight (pending_jobs_ > 0), shrink is deferred — the target size is
-    // stored and applied when the last job completes (see endScheduledJob()). Grow is
-    // always applied immediately so new jobs can use the extra threads right away.
+    // Resize the shared pool. in all cases the requested size is stored in
+    // deferred_size_ and applied later if not applied immediately:
+    //   * no SVS index attached yet → recorded; applied on first
+    //     onIndexAttached() (so no OS threads are spawned in deployments that
+    //     never create an SVS index).
+    //   * shrink while jobs are in flight (pending_jobs_ > 0) → recorded;
+    //     applied when endScheduledJob() drops pending_jobs_ back to 0 (avoids
+    //     destroying slots that already-reserved RediSearch workers will rent).
+    //   * otherwise (grows; shrinks with no jobs in flight) → applied
+    //     immediately via resize_locked().
+    // The two deferral cases never overlap — no jobs can be in flight before
+    // the first index attaches. Clamps to a minimum of 1.
     void resize(size_t new_size) {
         new_size = std::max(new_size, size_t{1});
         std::lock_guard lock{pool_mutex_};
-        resize_locked(new_size);
+        if (has_attached_index_) {
+            resize_locked(new_size);
+        } else {
+            deferred_size_ = new_size;
+        }
     }
 
-    // Deferred-resize protocol
-    // ========================
-    // When a job is created via createScheduledJobs(), the pool size is snapshotted
-    // to determine how many reserve jobs to submit to the RediSearch worker pool.
-    // If resize() shrinks the SVS pool between that snapshot and when the job
-    // actually executes, the RediSearch workers would have checked in (reserved
-    // threads exist) but the SVS pool slots they need to rent from would have been
-    // destroyed — causing a failure.
-    //
-    // To prevent this, beginScheduledJob() increments pending_jobs_, and any shrink
-    // while pending_jobs_ > 0 is deferred (stored in deferred_size_) until the last
-    // in-flight job completes and its destructor calls endScheduledJob(). Grows are
-    // always applied immediately since extra threads don't break anything.
+    // Called from the per-index VecSimSVSThreadPool ctor. The first call flips
+    // has_attached_index_ and applies any size requested earlier via resize()
+    // — this is where OS threads are actually spawned in the lazy path.
+    void onIndexAttached() {
+        std::lock_guard lock{pool_mutex_};
+        if (has_attached_index_)
+            return;
+        has_attached_index_ = true;
+        if (deferred_size_)
+            resize_locked(deferred_size_.value());
+    }
+
+#ifdef BUILD_TESTS
+    // Restore the singleton to its as-constructed state: drop all worker slots
+    // (releasing vector capacity so getAllocationSize() returns 0), clear
+    // has_attached_index_, deferred_size_, and pending_jobs_. Intended for unit
+    // tests that need a clean baseline (the singleton itself is process-wide
+    // and cannot be torn down). Caller must ensure no jobs are in flight.
+    void resetForTest() {
+        std::lock_guard lock{pool_mutex_};
+        assert(pending_jobs_ == 0 && "resetForTest called with jobs in flight");
+        // Swap with a fresh empty vector to release the capacity allocation
+        // (clear() destroys elements but retains capacity).
+        vecsim_stl::vector<SlotPtr>(allocator_).swap(slots_);
+        deferred_size_.reset();
+        has_attached_index_ = false;
+    }
+#endif
 
     // Atomically mark a logical job as pending and snapshot the current shared pool size.
     size_t beginScheduledJob() {
@@ -656,8 +679,14 @@ private:
     std::shared_ptr<VecSimAllocator> allocator_; // pool's own allocator for memory tracking
     mutable std::mutex pool_mutex_;
     vecsim_stl::vector<SlotPtr> slots_;
-    size_t pending_jobs_ = 0;             // jobs currently scheduled / in-flight
-    std::optional<size_t> deferred_size_; // resize target deferred until pending_jobs_ == 0
+    size_t pending_jobs_ = 0; // jobs currently scheduled / in-flight
+    // Pending pool size to apply at the next safe point: either the first SVS index
+    // attaches (onIndexAttached()) or pending_jobs_ drops to 0 (endScheduledJob()).
+    // The two cases are sequential and never overlap.
+    std::optional<size_t> deferred_size_;
+    // Flips true on the first onIndexAttached() call; gates resize() between
+    // "record only" and "apply immediately".
+    bool has_attached_index_ = false;
 };
 
 // Per-index wrapper around the shared VecSimSVSThreadPoolImpl singleton.
@@ -687,12 +716,16 @@ public:
     // explicit setParallelism() call.
     // parallelism_ is allocated through the provided VecsimAllocator so that the
     // allocation is tracked by the index's memory accounting.
+    // Notifies the shared pool that an index has attached — on the very first call this
+    // applies any size requested earlier via resize() (lazy thread spawn).
     explicit VecSimSVSThreadPool(const std::shared_ptr<VecSimAllocator> &allocator,
                                  void *log_ctx = nullptr)
         : pool_(VecSimSVSThreadPoolImpl::instance()),
           parallelism_(std::allocate_shared<std::atomic<size_t>>(
               VecsimSTLAllocator<std::atomic<size_t>>(allocator), size_t{1})),
-          log_ctx_(log_ctx) {}
+          log_ctx_(log_ctx) {
+        pool_->onIndexAttached();
+    }
 
     // Resize the shared pool singleton. Delegates to VecSimSVSThreadPoolImpl::instance().
     static void resize(size_t new_size) { VecSimSVSThreadPoolImpl::instance()->resize(new_size); }

--- a/src/VecSim/index_factories/svs_factory.cpp
+++ b/src/VecSim/index_factories/svs_factory.cpp
@@ -13,12 +13,29 @@
 #include "VecSim/memory/vecsim_malloc.h"
 #include "VecSim/vec_sim_index.h"
 #include "VecSim/algorithms/svs/svs.h"
+#include "VecSim/algorithms/svs/svs_utils.h"
 #include "VecSim/index_factories/components/components_factory.h"
 #include "VecSim/index_factories/factory_utils.h"
+#include <atomic>
 
 namespace SVSFactory {
 
 namespace {
+
+// Bytes consumed by the per-index VecSimSVSThreadPool::parallelism_ allocation
+// (a std::allocate_shared<std::atomic<size_t>> through the index's allocator).
+// The exact size of the inplace shared_ptr control block is implementation-defined,
+// so measure the allocation delta once at startup against a throwaway VecSimAllocator.
+size_t getThreadPoolParallelismAllocationSize() {
+    static const size_t size = []() {
+        auto allocator = VecSimAllocator::newVecsimAllocator();
+        size_t before = allocator->getAllocationSize();
+        [[maybe_unused]] auto p = std::allocate_shared<std::atomic<size_t>>(
+            VecsimSTLAllocator<std::atomic<size_t>>(allocator), size_t{1});
+        return allocator->getAllocationSize() - before;
+    }();
+    return size;
+}
 
 // NewVectorsImpl() is the chain of a template helper functions to create a new SVS index.
 template <typename MetricType, typename DataType, size_t QuantBits, size_t ResidualBits,
@@ -230,6 +247,9 @@ size_t EstimateInitialSize(const SVSParams *params, bool is_normalized) {
     est += EstimateSVSIndexSize(params);
     est += EstimateComponentsMemorySVS(params->type, params->metric, is_normalized);
     est += sizeof(DataBlocksContainer) + allocations_overhead;
+    // Per-index VecSimSVSThreadPool::parallelism_ allocation tracked through
+    // the index's VecSimAllocator (see VecSimSVSThreadPool ctor).
+    est += getThreadPoolParallelismAllocationSize();
     return est;
 }
 

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -87,6 +87,8 @@ const char *VecSimCommonStrings::TIERED_SVS_UPDATE_THRESHOLD_STRING = "TIERED_SV
 const char *VecSimCommonStrings::TIERED_SVS_THREADS_RESERVE_TIMEOUT_STRING =
     "TIERED_SVS_THREADS_RESERVE_TIMEOUT";
 
+const char *VecSimCommonStrings::SHARED_MEMORY_STRING = "SHARED_MEMORY";
+
 // Log levels
 const char *VecSimCommonStrings::LOG_DEBUG_STRING = "debug";
 const char *VecSimCommonStrings::LOG_VERBOSE_STRING = "verbose";

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -85,6 +85,11 @@ public:
     static const char *TIERED_SVS_UPDATE_THRESHOLD_STRING;
     static const char *TIERED_SVS_THREADS_RESERVE_TIMEOUT_STRING;
 
+    // Process-wide VecSim allocations not tied to any single index (e.g. the
+    // shared SVS thread-pool allocation). Appended by VecSimIndex_DebugInfoIterator
+    // (C API) to every algorithm's response. Does NOT include per-index memory.
+    static const char *SHARED_MEMORY_STRING;
+
     // Log levels
     static const char *LOG_DEBUG_STRING;
     static const char *LOG_VERBOSE_STRING;

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -339,7 +339,20 @@ extern "C" VecSimIndexDebugInfo VecSimIndex_DebugInfo(VecSimIndex *index) {
 }
 
 extern "C" VecSimDebugInfoIterator *VecSimIndex_DebugInfoIterator(VecSimIndex *index) {
-    return index->debugInfoIterator();
+    VecSimDebugInfoIterator *infoIterator = index->debugInfoIterator();
+    // Append the process-wide shared memory total. This field is not emitted by
+    // any algorithm's own debugInfoIterator(); it is injected here at the C API
+    // boundary so that every caller (regardless of algorithm) can account for
+    // memory not tied to any single index without special-casing SVS internals.
+    infoIterator->addInfoField(
+        VecSim_InfoField{.fieldName = VecSimCommonStrings::SHARED_MEMORY_STRING,
+                         .fieldType = INFOFIELD_UINT64,
+                         .fieldValue = {FieldValue{.uintegerValue = VecSim_GetSharedMemory()}}});
+    return infoIterator;
+}
+
+extern "C" size_t VecSim_GetSharedMemory(void) {
+    return VecSimSVSThreadPool::getSharedAllocationSize();
 }
 
 extern "C" VecSimIndexBasicInfo VecSimIndex_BasicInfo(VecSimIndex *index) {

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -34,9 +34,9 @@ extern "C" void VecSim_UpdateThreadPoolSize(size_t new_size) {
     } else {
         VecSimIndex::setWriteMode(VecSim_WriteAsync);
     }
-    // Resize the shared SVS thread pool. resize() clamps to minimum size 1.
-    // new_size == 0 → pool size 1 (only calling thread, write-in-place).
-    // new_size >  0 → pool size new_size (new_size - 1 worker threads).
+    // Resize the shared SVS pool. Clamped to a minimum of 1. OS threads are spawned
+    // lazily on first SVS index creation; once an index exists this resizes the
+    // shared pool immediately (cooperating with the deferred-shrink protocol).
     VecSimSVSThreadPool::resize(new_size);
 }
 

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -14,6 +14,7 @@
 #include "VecSim/index_factories/index_factory.h"
 #include "VecSim/vec_sim_index.h"
 #include "VecSim/types/bfloat16.h"
+#include "VecSim/algorithms/svs/svs_utils.h"
 #include <cassert>
 #include "memory.h"
 
@@ -26,6 +27,18 @@ extern "C" void VecSim_SetLogCallbackFunction(logCallbackFunction callback) {
 }
 
 extern "C" void VecSim_SetWriteMode(VecSimWriteMode mode) { VecSimIndex::setWriteMode(mode); }
+
+extern "C" void VecSim_UpdateThreadPoolSize(size_t new_size) {
+    if (new_size == 0) {
+        VecSimIndex::setWriteMode(VecSim_WriteInPlace);
+    } else {
+        VecSimIndex::setWriteMode(VecSim_WriteAsync);
+    }
+    // Resize the shared SVS thread pool. resize() clamps to minimum size 1.
+    // new_size == 0 → pool size 1 (only calling thread, write-in-place).
+    // new_size >  0 → pool size new_size (new_size - 1 worker threads).
+    VecSimSVSThreadPool::resize(new_size);
+}
 
 static VecSimResolveCode _ResolveParams_EFRuntime(VecSimAlgo index_type, VecSimRawParam rparam,
                                                   VecSimQueryParams *qparams,

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -282,6 +282,14 @@ void VecSim_SetWriteMode(VecSimWriteMode mode);
  */
 void VecSim_UpdateThreadPoolSize(size_t new_size);
 
+/**
+ * @brief Return the total bytes of process-wide VecSim allocations that are NOT tied to any
+ *        single index (e.g. the shared SVS thread-pool allocation).
+ *        This does NOT include per-index memory; use VecSimIndex_Info() for per-index accounting.
+ * @return Process-wide shared VecSim allocation size in bytes.
+ */
+size_t VecSim_GetSharedMemory(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -272,6 +272,16 @@ void VecSim_SetTestLogContext(const char *test_name, const char *test_type);
  */
 void VecSim_SetWriteMode(VecSimWriteMode mode);
 
+/**
+ * @brief Update the shared SVS thread pool size and set the write mode accordingly.
+ * If new_size == 0, sets write mode to in-place (no background threads).
+ * If new_size > 0, sets write mode to async and resizes the shared thread pool.
+ * @note Should be called from the main thread only.
+ *
+ * @param new_size the new thread pool size (0 = in-place mode, >0 = async mode).
+ */
+void VecSim_UpdateThreadPoolSize(size_t new_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -189,7 +189,9 @@ typedef struct {
     size_t prune_to;                 // Amount that candidates will be pruned.
     VecSimOptionMode use_search_history; // Either the contents of the search buffer can be used or
                                          // the entire search history.
-    size_t num_threads;                  // Maximum number of threads in threadpool.
+    size_t num_threads;                  // DEPRECATED: ignored. Thread pool size is controlled
+                                         // globally via VecSim_UpdateThreadPoolSize(). Setting
+                                         // this field has no effect and will emit a warning log.
     size_t search_window_size;           // Search window size to use during search.
     size_t search_buffer_capacity;       // Search buffer capacity to use during search.
     size_t leanvec_dim;                  // Leanvec dimension to use when LeanVec is enabled.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -322,7 +322,10 @@ typedef struct {
  * production without worrying about performance
  */
 typedef struct {
-    size_t memory;
+    size_t memory;                // Memory tracked by the index's own allocator. Does NOT include
+                                  // process-wide allocations such as the shared SVS thread pool;
+                                  // those are reported via VecSim_GetSharedMemory() so callers
+                                  // that aggregate across indexes don't double-count them.
     size_t numberOfMarkedDeleted; // The number of vectors that are marked as deleted (HNSW/tiered
                                   // only).
 } VecSimIndexStatsInfo;

--- a/tests/benchmark/bm_utils.h
+++ b/tests/benchmark/bm_utils.h
@@ -30,9 +30,9 @@ CreateTieredSVSParams(VecSimParams &svs_params, tieredIndexMock &mock_thread_poo
 template <typename data_t>
 static void verifyNumThreads(TieredSVSIndex<data_t> *tiered_index, size_t expected_num_threads,
                              size_t expected_capcity, std::string msg = "") {
-    ASSERT_EQ(tiered_index->GetSVSIndex()->getThreadPoolCapacity(), expected_capcity)
+    ASSERT_EQ(tiered_index->GetSVSIndex()->getPoolSize(), expected_capcity)
         << msg << ": thread pool capacity mismatch";
-    size_t num_reserved_threads = tiered_index->GetSVSIndex()->getNumThreads();
+    size_t num_reserved_threads = tiered_index->GetSVSIndex()->getParallelism();
     if (num_reserved_threads < expected_num_threads) {
         std::cout << msg << ": WARNING: last reserved threads (" << num_reserved_threads
                   << ") is less than expected (" << expected_num_threads << ")." << std::endl;

--- a/tests/benchmark/bm_vecsim_svs.h
+++ b/tests/benchmark/bm_vecsim_svs.h
@@ -93,7 +93,6 @@ private:
             .quantBits = this->quantBits,
             .graph_max_degree = BM_VecSimGeneral::M,
             .construction_window_size = BM_VecSimGeneral::EF_C,
-            .num_threads = mock_thread_pool.thread_pool_size,
         };
         VecSimParams params{.algo = VecSimAlgo_SVS, .algoParams = {.svsParams = svs_params}};
 
@@ -107,30 +106,21 @@ private:
         // Set the created tiered index in the index external context (it will take ownership over
         // the index, and we'll need to release the ctx at the end of the test.
         mock_thread_pool.ctx->index_strong_ref.reset(tiered_index);
-        // Set numThreads to 1 by default to allow direct calls to SVS addVector() API,
-        // which requires exactly 1 thread. When using tiered index addVector API,
-        // the thread count is managed internally according to the operation and threadpool
-        // capacity, so testing parallelism remains intact.
-        size_t params_threadpool_size =
-            tiered_params.primaryIndexParams->algoParams.svsParams.num_threads;
-        size_t num_threads =
-            params_threadpool_size ? params_threadpool_size : mock_thread_pool.thread_pool_size;
-        tiered_index->GetSVSIndex()->setNumThreads(num_threads);
-        test_utils::verifyNumThreads(tiered_index, num_threads, num_threads,
+        VecSim_UpdateThreadPoolSize(mock_thread_pool.thread_pool_size);
+        test_utils::verifyNumThreads(tiered_index, 1,
+                                     std::max(mock_thread_pool.thread_pool_size, size_t{1}),
                                      std::string("CreateTieredSVSIndex"));
 
         return tiered_index;
     }
 
-    VecSimIndexAbstract<data_t, float> *CreateSVSIndexFromFile(size_t update_threshold,
-                                                               size_t num_threads = 1) {
+    VecSimIndexAbstract<data_t, float> *CreateSVSIndexFromFile(size_t update_threshold) {
         SVSParams svs_params = {.type = this->data_type,
                                 .dim = BM_VecSimGeneral::dim,
                                 .metric = VecSimMetric_Cosine,
                                 .quantBits = this->quantBits,
                                 .graph_max_degree = BM_VecSimGeneral::M,
-                                .construction_window_size = BM_VecSimGeneral::EF_C,
-                                .num_threads = num_threads};
+                                .construction_window_size = BM_VecSimGeneral::EF_C};
         VecSimParams params{.algo = VecSimAlgo_SVS, .algoParams = {.svsParams = svs_params}};
 
         // Load svs index - construct path based on quantBits
@@ -153,13 +143,11 @@ private:
                                 .metric = VecSimMetric_Cosine,
                                 .quantBits = this->quantBits,
                                 .graph_max_degree = BM_VecSimGeneral::M,
-                                .construction_window_size = BM_VecSimGeneral::EF_C,
-                                .num_threads = mock_thread_pool.thread_pool_size};
+                                .construction_window_size = BM_VecSimGeneral::EF_C};
         VecSimParams params{.algo = VecSimAlgo_SVS, .algoParams = {.svsParams = svs_params}};
 
         // Load svs index
-        auto *svs_index =
-            CreateSVSIndexFromFile(update_threshold, mock_thread_pool.thread_pool_size);
+        auto *svs_index = CreateSVSIndexFromFile(update_threshold);
         TieredIndexParams tiered_params = test_utils::CreateTieredSVSParams(
             params, mock_thread_pool, update_threshold, update_threshold);
 
@@ -171,7 +159,8 @@ private:
         // the index, and we'll need to release the ctx at the end of the test.
         mock_thread_pool.ctx->index_strong_ref.reset(tiered_index);
         size_t num_threads = mock_thread_pool.thread_pool_size;
-        test_utils::verifyNumThreads(tiered_index, num_threads, num_threads,
+        VecSim_UpdateThreadPoolSize(num_threads);
+        test_utils::verifyNumThreads(tiered_index, 1, std::max(num_threads, size_t{1}),
                                      std::string("CreateTieredSVSIndexFromFile"));
 
         return tiered_index;
@@ -237,6 +226,13 @@ void BM_VecSimSVS<index_type_t>::runTrainBMIteration(benchmark::State &st,
     this->quantBits = static_cast<VecSimSvsQuantBits>(st.range(0));
     auto *tiered_index = CreateTieredSVSIndex(mock_thread_pool, training_threshold);
 
+    // Verify write mode
+    if (mock_thread_pool.thread_pool_size) {
+        ASSERT_EQ(VecSimIndexInterface::asyncWriteMode, VecSim_WriteAsync);
+    } else {
+        ASSERT_EQ(VecSimIndexInterface::asyncWriteMode, VecSim_WriteInPlace);
+    }
+
     auto verify_index_size = [&](size_t expected_tiered_index_size, size_t expected_frontend_size,
                                  size_t expected_backend_size, std::string msg = "") {
         VecSimIndexDebugInfo info = VecSimIndex_DebugInfo(tiered_index);
@@ -292,30 +288,22 @@ void BM_VecSimSVS<index_type_t>::runTrainBMIteration(benchmark::State &st,
 
 template <typename index_type_t>
 void BM_VecSimSVS<index_type_t>::Train(benchmark::State &st) {
-    // set write mode to inplace
-    auto original_mode = VecSimIndexInterface::asyncWriteMode;
-    VecSim_SetWriteMode(VecSim_WriteInPlace);
-
     auto training_threshold = st.range(1);
 
     // Ensure we have enough vectors to train.
     ASSERT_GE(N_QUERIES, training_threshold);
     for (auto _ : st) {
         st.PauseTiming();
-        // In each iteration create a new index
-        auto mock_thread_pool = tieredIndexMock(1);
+        // In each iteration create a new index with 0 threads (in-place mode).
+        // VecSim_UpdateThreadPoolSize(0) sets write mode to VecSim_WriteInPlace.
+        auto mock_thread_pool = tieredIndexMock(0);
         runTrainBMIteration<false>(st, mock_thread_pool, training_threshold);
     }
-    // Restore original write mode
     ASSERT_EQ(VecSimIndexInterface::asyncWriteMode, VecSim_WriteInPlace);
-    VecSim_SetWriteMode(original_mode);
 }
 
 template <typename index_type_t>
 void BM_VecSimSVS<index_type_t>::TrainAsync(benchmark::State &st) {
-    // ensure mode is async
-    ASSERT_EQ(VecSimIndexInterface::asyncWriteMode, VecSim_WriteAsync);
-
     auto training_threshold = st.range(1);
     int unsigned num_threads = st.range(2);
 
@@ -339,7 +327,7 @@ template <typename index_type_t>
 void BM_VecSimSVS<index_type_t>::AddLabel(benchmark::State &st) {
 
     size_t label = 0;
-    auto index = CreateSVSIndexFromFile(1, 1);
+    auto index = CreateSVSIndexFromFile(1);
     size_t memory_delta = index->getAllocationSize();
     for (auto _ : st) {
         VecSimIndex_AddVector(index, test_vectors[label].data(), label + N_VECTORS);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -47,7 +47,7 @@ add_executable(test_fp16 ../utils/test_main_with_timeout.cpp ../utils/mock_threa
 add_executable(test_int8 ../utils/test_main_with_timeout.cpp ../utils/mock_thread_pool.cpp test_int8.cpp unit_test_utils.cpp)
 add_executable(test_uint8 ../utils/test_main_with_timeout.cpp ../utils/mock_thread_pool.cpp test_uint8.cpp unit_test_utils.cpp)
 add_executable(test_index_test_utils ../utils/test_main_with_timeout.cpp ../utils/mock_thread_pool.cpp test_index_test_utils.cpp unit_test_utils.cpp)
-add_executable(test_svs ../utils/test_main_with_timeout.cpp ../utils/mock_thread_pool.cpp test_svs.cpp test_svs_tiered.cpp test_svs_multi.cpp test_svs_fp16.cpp unit_test_utils.cpp)
+add_executable(test_svs ../utils/test_main_with_timeout.cpp ../utils/mock_thread_pool.cpp test_svs.cpp test_svs_tiered.cpp test_svs_multi.cpp test_svs_fp16.cpp test_svs_threadpool.cpp unit_test_utils.cpp)
 
 target_link_libraries(test_hnsw PUBLIC gtest VectorSimilarity)
 target_link_libraries(test_hnsw_parallel PUBLIC gtest VectorSimilarity)

--- a/tests/unit/test_hnsw_tiered.cpp
+++ b/tests/unit/test_hnsw_tiered.cpp
@@ -2859,7 +2859,9 @@ TYPED_TEST(HNSWTieredIndexTest, testInfoIterator) {
     VecSimIndexDebugInfo frontendIndexInfo = tiered_index->frontendIndex->debugInfo();
     VecSimIndexDebugInfo backendIndexInfo = tiered_index->backendIndex->debugInfo();
 
-    VecSimDebugInfoIterator *infoIterator = tiered_index->debugInfoIterator();
+    // Use the C API wrapper (as RediSearch does) so the process-wide SHARED_MEMORY
+    // field is appended at the top level — compareTieredIndexInfoToIterator expects it.
+    VecSimDebugInfoIterator *infoIterator = VecSimIndex_DebugInfoIterator(tiered_index);
     compareTieredIndexInfoToIterator(info, frontendIndexInfo, backendIndexInfo, infoIterator);
 
     VecSimDebugInfoIterator_Free(infoIterator);

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -1676,8 +1676,8 @@ TYPED_TEST(SVSTest, test_svs_parameter_combinations_and_defaults) {
           .constructionWindowSize = 100,
           .maxCandidatePoolSize = 500,
           .pruneTo = 55,
-          .useSearchHistory = false, // VecSimOption_DISABLE
-          .numThreads = 4,
+          .useSearchHistory = false,                    // VecSimOption_DISABLE
+          .numThreads = SVS_VAMANA_DEFAULT_NUM_THREADS, // Deprecated, expect default to be used
           .numberOfMarkedDeletedNodes = 0,
           .searchWindowSize = 20,
           .searchBufferCapacity = 40,
@@ -3298,6 +3298,69 @@ TEST(SVSTest, compute_distance) {
     munmap(raw_b, 2 * page_size);
 }
 #endif // defined(__linux__) && defined(__x86_64__)
+
+// ---------------------------------------------------------------------------
+// SVSParams::num_threads is deprecated and ignored — pool size comes from
+// the shared singleton. Setting it should log a warning but not affect the pool.
+// ---------------------------------------------------------------------------
+TEST(SVSTest, NumThreadsParamIgnored) {
+    // Resize the shared singleton pool to a known size.
+    VecSimSVSThreadPool::resize(2);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 2);
+
+    // Capture warning logs emitted by VecSim.
+    std::string captured_log;
+    VecSimIndexInterface::logCallback = [](void *ctx, const char *level, const char *msg) {
+        auto *out = static_cast<std::string *>(ctx);
+        *out += std::string(level) + ": " + msg + "\n";
+    };
+
+    // Create an SVS index with an explicit (deprecated) num_threads value.
+    SVSParams svs_params = {
+        .type = VecSimType_FLOAT32,
+        .dim = 4,
+        .metric = VecSimMetric_L2,
+        .num_threads = 16, // should be ignored
+    };
+    VecSimParams params{.algo = VecSimAlgo_SVS,
+                        .algoParams = {.svsParams = svs_params},
+                        .logCtx = static_cast<void *>(&captured_log)};
+    VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_NE(index, nullptr);
+
+    // The shared pool size must remain at 2 — num_threads was ignored.
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 2);
+
+    // The index reports the shared pool size, not the deprecated param value.
+    VecSimIndexDebugInfo info = VecSimIndex_DebugInfo(index);
+    ASSERT_EQ(info.svsInfo.numThreads, 2);
+
+    // A deprecation warning should have been logged.
+    EXPECT_NE(captured_log.find("deprecated"), std::string::npos)
+        << "Expected deprecation warning in log, got: " << captured_log;
+
+    VecSimIndex_Free(index);
+
+    // Verify: creating an index without setting num_threads produces no warning.
+    captured_log.clear();
+    SVSParams svs_params_default = {
+        .type = VecSimType_FLOAT32, .dim = 4, .metric = VecSimMetric_L2,
+        // num_threads left as 0 (default / unset)
+    };
+    VecSimParams params_default{.algo = VecSimAlgo_SVS,
+                                .algoParams = {.svsParams = svs_params_default},
+                                .logCtx = static_cast<void *>(&captured_log)};
+    VecSimIndex *index2 = VecSimIndex_New(&params_default);
+    ASSERT_NE(index2, nullptr);
+    EXPECT_EQ(captured_log.find("deprecated"), std::string::npos)
+        << "No deprecation warning expected when num_threads is not set, got: " << captured_log;
+
+    VecSimIndex_Free(index2);
+
+    // Restore pool to default size and clear log callback.
+    VecSimSVSThreadPool::resize(1);
+    VecSimIndexInterface::logCallback = nullptr;
+}
 
 #else // HAVE_SVS
 

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -3445,12 +3445,13 @@ TYPED_TEST(SVSTest, sharedMemoryTracksThreadPoolResize) {
 // ---------------------------------------------------------------------------
 TEST(SVSTest, ThreadPoolLazyInit) {
     // Reset the shared singleton to a clean state — earlier tests may have
-    // attached indexes and resized the pool. After reset, getAllocationSize()
-    // still reports sizeof(VecSimAllocator) (the allocator's self-accounting,
-    // see VecSimAllocator() ctor); assertions below compare against this
-    // baseline rather than absolute zero.
+    // attached indexes and resized the pool. resetForTest() clears
+    // has_attached_index_, so VecSim_GetSharedMemory() reports 0 even though the
+    // singleton object (and its self-accounting allocator) still exist: shared
+    // memory is only attributed once an SVS index attaches.
     VecSimSVSThreadPoolImpl::instance()->resetForTest();
     const size_t baseline_mem = VecSim_GetSharedMemory();
+    EXPECT_EQ(baseline_mem, 0u) << "shared memory must be 0 before any SVS index attaches";
 
     // Recording a non-trivial requested size before any SVS index exists must
     // not allocate any worker slots.

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -3304,6 +3304,10 @@ TEST(SVSTest, compute_distance) {
 // the shared singleton. Setting it should log a warning but not affect the pool.
 // ---------------------------------------------------------------------------
 TEST(SVSTest, NumThreadsParamIgnored) {
+    // Mark the pool as attached so resize() applies eagerly (this test resizes
+    // before constructing the SVS index, so the lazy code path would otherwise
+    // just record the size without spawning threads).
+    VecSimSVSThreadPoolImpl::instance()->onIndexAttached();
     // Resize the shared singleton pool to a known size.
     VecSimSVSThreadPool::resize(2);
     ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 2);
@@ -3357,8 +3361,9 @@ TEST(SVSTest, NumThreadsParamIgnored) {
 
     VecSimIndex_Free(index2);
 
-    // Restore pool to default size and clear log callback.
-    VecSimSVSThreadPool::resize(1);
+    // Restore singleton to baseline (clears has_attached_index_ and slots) and
+    // clear log callback so subsequent tests see a clean state.
+    VecSimSVSThreadPoolImpl::instance()->resetForTest();
     VecSimIndexInterface::logCallback = nullptr;
 }
 
@@ -3367,15 +3372,15 @@ TEST(SVSTest, NumThreadsParamIgnored) {
 // present on every algorithm. Verify it appears exactly once in an SVS
 // response and reports the same bytes as the public API.
 TYPED_TEST(SVSTest, debugInfoSharedMemoryMatchesApi) {
-    // Ensure the shared SVS thread pool singleton has allocated memory so the
-    // field reports a non-zero value. resize() always lazy-initializes the singleton.
+    // Request a non-trivial pool size; with lazy init the actual allocation only
+    // happens on first SVS index creation below.
     VecSim_UpdateThreadPoolSize(2);
-    ASSERT_GT(VecSim_GetSharedMemory(), 0u);
 
     size_t dim = 4;
     SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
     VecSimIndex *index = this->CreateNewIndex(params);
     ASSERT_INDEX(index);
+    ASSERT_GT(VecSim_GetSharedMemory(), 0u);
 
     VecSimDebugInfoIterator *infoIterator = VecSimIndex_DebugInfoIterator(index);
 
@@ -3407,6 +3412,12 @@ TYPED_TEST(SVSTest, debugInfoSharedMemoryMatchesApi) {
 // SHARED_MEMORY could be a constant and debugInfoSharedMemoryMatchesApi would
 // still pass (both readouts share the same getSharedAllocationSize() source).
 TYPED_TEST(SVSTest, sharedMemoryTracksThreadPoolResize) {
+    // With lazy init, resize() only records the requested size until an SVS index
+    // has attached. Mark the pool attached up front so the resizes below apply
+    // eagerly and their allocation effect is observable (idempotent, matches the
+    // pattern used by NumThreadsParamIgnored and the SVSThreadPoolTest fixture).
+    VecSimSVSThreadPoolImpl::instance()->onIndexAttached();
+
     // Use the C API to ensure it is covered. VecSim_UpdateThreadPoolSize(0)
     // sets WriteInPlace and pool size 1.
     VecSim_UpdateThreadPoolSize(0);
@@ -3426,6 +3437,42 @@ TYPED_TEST(SVSTest, sharedMemoryTracksThreadPoolResize) {
 
     // Restore to default baseline.
     VecSim_UpdateThreadPoolSize(0);
+}
+
+// ---------------------------------------------------------------------------
+// Lazy thread-pool init: VecSim_UpdateThreadPoolSize must not allocate worker
+// threads until the first SVS index attaches.
+// ---------------------------------------------------------------------------
+TEST(SVSTest, ThreadPoolLazyInit) {
+    // Reset the shared singleton to a clean state — earlier tests may have
+    // attached indexes and resized the pool. After reset, getAllocationSize()
+    // still reports sizeof(VecSimAllocator) (the allocator's self-accounting,
+    // see VecSimAllocator() ctor); assertions below compare against this
+    // baseline rather than absolute zero.
+    VecSimSVSThreadPoolImpl::instance()->resetForTest();
+    const size_t baseline_mem = VecSim_GetSharedMemory();
+
+    // Recording a non-trivial requested size before any SVS index exists must
+    // not allocate any worker slots.
+    VecSim_UpdateThreadPoolSize(8);
+    EXPECT_EQ(VecSim_GetSharedMemory(), baseline_mem)
+        << "VecSim_UpdateThreadPoolSize must not allocate threads before any SVS index exists";
+    EXPECT_EQ(VecSimSVSThreadPool::poolSize(), 1u)
+        << "Pool size must stay at 1 (no worker slots) until first index attaches";
+
+    // First SVS index creation triggers onIndexAttached(), which applies the
+    // recorded size and spawns 7 worker threads.
+    SVSParams params = {.type = VecSimType_FLOAT32, .dim = 4, .metric = VecSimMetric_L2};
+    VecSimParams vp{.algo = VecSimAlgo_SVS, .algoParams = {.svsParams = params}};
+    VecSimIndex *index = VecSimIndex_New(&vp);
+    ASSERT_NE(index, nullptr);
+    ASSERT_GT(VecSim_GetSharedMemory(), baseline_mem)
+        << "First SVS index creation must trigger lazy thread spawn";
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 8u)
+        << "Pool size must reflect the most recent requested size after first attach";
+
+    VecSimIndex_Free(index);
+    VecSimSVSThreadPoolImpl::instance()->resetForTest();
 }
 
 #else // HAVE_SVS

--- a/tests/unit/test_svs.cpp
+++ b/tests/unit/test_svs.cpp
@@ -3362,6 +3362,72 @@ TEST(SVSTest, NumThreadsParamIgnored) {
     VecSimIndexInterface::logCallback = nullptr;
 }
 
+// The SHARED_MEMORY field is a top-level field appended by
+// VecSimIndex_DebugInfoIterator (mirrors VecSim_GetSharedMemory()); it is
+// present on every algorithm. Verify it appears exactly once in an SVS
+// response and reports the same bytes as the public API.
+TYPED_TEST(SVSTest, debugInfoSharedMemoryMatchesApi) {
+    // Ensure the shared SVS thread pool singleton has allocated memory so the
+    // field reports a non-zero value. resize() always lazy-initializes the singleton.
+    VecSim_UpdateThreadPoolSize(2);
+    ASSERT_GT(VecSim_GetSharedMemory(), 0u);
+
+    size_t dim = 4;
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimIndex *index = this->CreateNewIndex(params);
+    ASSERT_INDEX(index);
+
+    VecSimDebugInfoIterator *infoIterator = VecSimIndex_DebugInfoIterator(index);
+
+    bool seen_shared_memory = false;
+    uint64_t shared_memory_value = 0;
+    while (VecSimDebugInfoIterator_HasNextField(infoIterator)) {
+        VecSim_InfoField *f = VecSimDebugInfoIterator_NextField(infoIterator);
+        if (!strcmp(f->fieldName, VecSimCommonStrings::SHARED_MEMORY_STRING)) {
+            ASSERT_FALSE(seen_shared_memory) << "SHARED_MEMORY appears more than once";
+            ASSERT_EQ(f->fieldType, INFOFIELD_UINT64);
+            shared_memory_value = f->fieldValue.uintegerValue;
+            seen_shared_memory = true;
+        }
+    }
+    EXPECT_TRUE(seen_shared_memory) << "SHARED_MEMORY field missing from SVS debug info";
+    EXPECT_EQ(shared_memory_value, VecSim_GetSharedMemory());
+
+    VecSimDebugInfoIterator_Free(infoIterator);
+    VecSimIndex_Free(index);
+
+    // Reset the shared singleton pool to size 1 so the next test is not affected.
+    // Use VecSimSVSThreadPool::resize(1) directly (matching other thread-pool tests)
+    // to avoid the write-mode side effect that VecSim_UpdateThreadPoolSize(0) carries.
+    VecSimSVSThreadPool::resize(1);
+}
+
+// VecSim shared memory must actually track the SVS thread-pool allocation:
+// it grows when the pool grows and shrinks when the pool shrinks. Without this,
+// SHARED_MEMORY could be a constant and debugInfoSharedMemoryMatchesApi would
+// still pass (both readouts share the same getSharedAllocationSize() source).
+TYPED_TEST(SVSTest, sharedMemoryTracksThreadPoolResize) {
+    // Use the C API to ensure it is covered. VecSim_UpdateThreadPoolSize(0)
+    // sets WriteInPlace and pool size 1.
+    VecSim_UpdateThreadPoolSize(0);
+    size_t mem_baseline = VecSim_GetSharedMemory();
+
+    // Grow the pool (sets WriteAsync).
+    VecSim_UpdateThreadPoolSize(8);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 8u);
+    size_t mem_8 = VecSim_GetSharedMemory();
+    EXPECT_GT(mem_8, mem_baseline) << "shared memory must grow when the pool grows";
+
+    // Shrink back to size 1 (still WriteAsync).
+    VecSim_UpdateThreadPoolSize(1);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1u);
+    size_t mem_after = VecSim_GetSharedMemory();
+    EXPECT_LT(mem_after, mem_8) << "shared memory must shrink when the pool shrinks";
+
+    // Restore to default baseline.
+    VecSim_UpdateThreadPoolSize(0);
+}
+
 #else // HAVE_SVS
 
 TEST(SVSTest, svs_not_supported) {

--- a/tests/unit/test_svs_fp16.cpp
+++ b/tests/unit/test_svs_fp16.cpp
@@ -2228,9 +2228,6 @@ protected:
                           size_t update_threshold = SVS_VAMANA_DEFAULT_UPDATE_THRESHOLD) {
         // trainingThreshold = training_threshold;
         // updateThreshold = update_threshold;
-        if (svs_params.algoParams.svsParams.num_threads == 0) {
-            svs_params.algoParams.svsParams.num_threads = mock_thread_pool.thread_pool_size;
-        }
         return TieredIndexParams{
             .jobQueue = &mock_thread_pool.jobQ,
             .jobQueueCtx = mock_thread_pool.ctx,
@@ -2240,15 +2237,17 @@ protected:
                                    TieredSVSParams{.trainingTriggerThreshold = training_threshold,
                                                    .updateTriggerThreshold = update_threshold}}};
     }
-    void verifyNumThreads(TieredSVSIndex<data_t> *tiered_index, size_t expected_num_threads,
-                          size_t expected_capcity) {
-        ASSERT_EQ(tiered_index->GetSVSIndex()->getNumThreads(), expected_num_threads);
-        ASSERT_EQ(tiered_index->GetSVSIndex()->getThreadPoolCapacity(), expected_capcity);
+    void verifyNumThreads(TieredSVSIndex<data_t> *tiered_index, size_t expected_capcity) {
+        ASSERT_EQ(tiered_index->GetSVSIndex()->getParallelism(), 1);
+        ASSERT_EQ(tiered_index->GetSVSIndex()->getPoolSize(), expected_capcity);
     }
 
     TieredSVSIndex<data_t> *CreateTieredSVSIndex(const TieredIndexParams &tiered_params,
-                                                 tieredIndexMock &mock_thread_pool,
-                                                 size_t num_available_threads = 1) {
+                                                 tieredIndexMock &mock_thread_pool) {
+        // Resize the shared SVS thread pool singleton to match the mock thread pool size,
+        // simulating what RediSearch does via VecSim_UpdateThreadPoolSize during module init.
+        VecSim_UpdateThreadPoolSize(mock_thread_pool.thread_pool_size);
+
         auto *tiered_index =
             reinterpret_cast<TieredSVSIndex<data_t> *>(TieredFactory::NewIndex(&tiered_params));
 
@@ -2256,26 +2255,18 @@ protected:
         // the index, and we'll need to release the ctx at the end of the test.
         mock_thread_pool.ctx->index_strong_ref.reset(tiered_index);
 
-        // Set number of available threads to 1 unless specified otherwise,
-        // so we can insert one vector at a time directly to svs.
-        tiered_index->GetSVSIndex()->setNumThreads(num_available_threads);
-        size_t params_threadpool_size =
-            tiered_params.primaryIndexParams->algoParams.svsParams.num_threads;
-        size_t expected_capacity =
-            params_threadpool_size ? params_threadpool_size : mock_thread_pool.thread_pool_size;
-        verifyNumThreads(tiered_index, num_available_threads, expected_capacity);
+        verifyNumThreads(tiered_index, mock_thread_pool.thread_pool_size);
         return tiered_index;
     }
 
     TieredSVSIndex<data_t> *
     CreateTieredSVSIndex(VecSimParams &svs_params, tieredIndexMock &mock_thread_pool,
                          size_t training_threshold = SVS_VAMANA_DEFAULT_TRAINING_THRESHOLD,
-                         size_t update_threshold = SVS_VAMANA_DEFAULT_UPDATE_THRESHOLD,
-                         size_t num_available_threads = 1) {
+                         size_t update_threshold = SVS_VAMANA_DEFAULT_UPDATE_THRESHOLD) {
         svs_params.algoParams.svsParams.quantBits = index_type_t::get_quant_bits();
         TieredIndexParams tiered_params = CreateTieredSVSParams(
             svs_params, mock_thread_pool, training_threshold, update_threshold);
-        return CreateTieredSVSIndex(tiered_params, mock_thread_pool, num_available_threads);
+        return CreateTieredSVSIndex(tiered_params, mock_thread_pool);
     }
 
     void SetUp() override {
@@ -2812,10 +2803,10 @@ TYPED_TEST(FP16SVSTieredIndexTest, KNNSearch) {
 TYPED_TEST(FP16SVSTieredIndexTest, deleteVector) {
     // Create TieredSVS index instance with a mock queue.
     size_t dim = 4;
-    SVSParams params = {.dim = dim, .metric = VecSimMetric_L2, .num_threads = 1};
+    SVSParams params = {.dim = dim, .metric = VecSimMetric_L2};
     this->SetTypeParams(params);
     VecSimParams svs_params = CreateParams(params);
-    auto mock_thread_pool = tieredIndexMock();
+    auto mock_thread_pool = tieredIndexMock(1);
     auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1, 1);
     ASSERT_NO_FATAL_FAILURE(this->verify_index(tiered_index));
 
@@ -2876,10 +2867,10 @@ TYPED_TEST(FP16SVSTieredIndexTest, deleteVector) {
 TYPED_TEST(FP16SVSTieredIndexTest, deleteVectorMulti) {
     // Create TieredSVS index instance with a mock queue.
     size_t dim = 4;
-    SVSParams params = {.dim = dim, .metric = VecSimMetric_L2, .multi = true, .num_threads = 1};
+    SVSParams params = {.dim = dim, .metric = VecSimMetric_L2, .multi = true};
     this->SetTypeParams(params);
     VecSimParams svs_params = CreateParams(params);
-    auto mock_thread_pool = tieredIndexMock();
+    auto mock_thread_pool = tieredIndexMock(1);
     auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1, 1);
     ASSERT_NO_FATAL_FAILURE(this->verify_index(tiered_index));
 

--- a/tests/unit/test_svs_threadpool.cpp
+++ b/tests/unit/test_svs_threadpool.cpp
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#include "gtest/gtest.h"
+
+#if HAVE_SVS
+#include <atomic>
+#include <latch>
+#include <set>
+#include <thread>
+
+#include <chrono>
+
+#include "VecSim/algorithms/svs/svs.h"
+#include "VecSim/algorithms/svs/svs_utils.h"
+#include "VecSim/vec_sim.h"
+#include "VecSim/vec_sim_interface.h"
+
+// std::latch::wait() blocks indefinitely. Use this to fail with a diagnostic
+// message instead of hanging if a bug causes a deadlock.
+static bool wait_with_timeout(std::latch &l, std::chrono::seconds timeout) {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!l.try_wait()) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return true;
+}
+
+static constexpr auto kTestTimeout = std::chrono::seconds(5);
+
+class SVSThreadPoolTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Save and clear global log callback so that pool operations
+        // don't assert on nullptr log_ctx (we don't have an index context).
+        saved_callback_ = VecSimIndexInterface::logCallback;
+        VecSimIndexInterface::logCallback = nullptr;
+    }
+    void TearDown() override {
+        // Reset the shared singleton pool to size 1 so tests don't leak state.
+        VecSimSVSThreadPool::resize(1);
+        VecSimIndexInterface::logCallback = saved_callback_;
+    }
+
+private:
+    logCallbackFunction saved_callback_ = nullptr;
+};
+
+// ---------------------------------------------------------------------------
+// Test 1: VecSimSVSThreadPool::resize — grow and shrink
+// ---------------------------------------------------------------------------
+TEST_F(SVSThreadPoolTest, ResizeGrowAndShrink) {
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1);
+
+    // Grow 1 → 4
+    VecSimSVSThreadPool::resize(4);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 4);
+
+    // Shrink 4 → 2
+    VecSimSVSThreadPool::resize(2);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 2);
+
+    // No-op 2 → 2
+    VecSimSVSThreadPool::resize(2);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 2);
+
+    // Shrink to minimum 2 → 1
+    VecSimSVSThreadPool::resize(1);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1);
+
+    // resize(0) clamps to 1
+    VecSimSVSThreadPool::resize(0);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1);
+
+    // Grow from 1 → 8 and verify parallel_for works at new size
+    VecSimSVSThreadPool::resize(8);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 8);
+    std::atomic_int counter{0};
+    VecSimSVSThreadPoolImpl::instance()->parallel_for([&counter](size_t) { counter++; }, 8);
+    ASSERT_EQ(counter, 8);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Scheduled jobs defer shrink until they end
+// ---------------------------------------------------------------------------
+TEST_F(SVSThreadPoolTest, ScheduledJobDefersShrinkUntilEnd) {
+    VecSimSVSThreadPool::resize(4);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 4);
+
+    auto pool = VecSimSVSThreadPoolImpl::instance();
+    size_t snapshot = pool->beginScheduledJob();
+    ASSERT_EQ(snapshot, 4);
+
+    VecSimSVSThreadPool::resize(1);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 4);
+
+    pool->endScheduledJob();
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Shrink while threads are rented
+// ---------------------------------------------------------------------------
+TEST_F(SVSThreadPoolTest, ShrinkWhileRented) {
+    // Pool size 5: 4 worker slots [s0, s1, s2, s3].
+    VecSimSVSThreadPool::resize(5);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 5);
+
+    // Wrapper A uses parallelism 3 → rents 2 workers (s0, s1).
+    VecSimSVSThreadPool wrapperA;
+    wrapperA.setParallelism(3);
+
+    std::latch hold(1);          // blocks rented workers
+    std::latch workers_ready(2); // signaled when both workers start
+    std::atomic_int resultA{0};
+
+    // Spawned thread: run parallel_for that blocks until we release the latch.
+    // parallel_for runs tid=0 on the calling thread (no slot rented) and
+    // tid=1,2 on rented worker threads (s0, s1). Only the worker threads
+    // (tid > 0) count down workers_ready, so main can wait until both workers
+    // are actually running and holding their slots before proceeding to shrink.
+    std::thread t([&] {
+        wrapperA.parallel_for(
+            [&](size_t tid) {
+                if (tid > 0) {
+                    workers_ready.count_down();
+                }
+                hold.wait();
+                resultA++;
+            },
+            3);
+    });
+
+    // Wait until both workers are running (blocked on latch).
+    ASSERT_TRUE(wait_with_timeout(workers_ready, kTestTimeout))
+        << "Timed out waiting for wrapper A's 2 workers to start. "
+           "resultA="
+        << resultA << ", pool_size=" << VecSimSVSThreadPool::poolSize();
+
+    // Shrink pool from 5 → 4 (slots become [s0, s1, s2]). s3 is free and
+    // gets destroyed. s0, s1 are occupied by wrapperA but remain in the vector.
+    // s2 is free and available for rental.
+    VecSimSVSThreadPool::resize(4);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 4);
+
+    // While wrapperA's threads are still alive (blocked on latch), run
+    // parallel_for on the shrunk pool with a second wrapper using a free slot.
+    VecSimSVSThreadPool wrapperB;
+    // Parallelism 2 = 1 rented worker + calling thread. The pool has 3 slots
+    // [s0, s1, s2] after shrink; s0 and s1 are occupied by wrapperA, so the
+    // single rented worker will get s2 (the only free slot).
+    wrapperB.setParallelism(2);
+    std::atomic_int resultB{0};
+    wrapperB.parallel_for([&](size_t) { resultB++; }, 2);
+    ASSERT_EQ(resultB, 2);
+
+    // Release the latch — wrapperA's parallel_for completes.
+    hold.count_down();
+    t.join();
+    ASSERT_EQ(resultA, 3);
+
+    // After the renter's RentedThreads guard is destroyed, the old slots'
+    // shared_ptrs drop to refcount 0 and the threads are destroyed.
+    // Pool size remains at the shrunk value.
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Grow while threads are rented
+// ---------------------------------------------------------------------------
+TEST_F(SVSThreadPoolTest, GrowWhileRented) {
+    // Pool size 3: 2 worker slots [s0, s1].
+    VecSimSVSThreadPool::resize(3);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 3);
+
+    // Wrapper A uses parallelism 3 → rents 2 workers (s0, s1).
+    VecSimSVSThreadPool wrapperA;
+    wrapperA.setParallelism(3);
+
+    std::latch hold(1);          // blocks rented workers
+    std::latch workers_ready(2); // signaled when both workers start
+    std::atomic_int resultA{0};
+
+    // Spawned thread: parallel_for blocks all 3 partitions (tid=0 on calling
+    // thread, tid=1,2 on rented workers). Only workers (tid > 0) count down
+    // workers_ready so main knows the slots are occupied before growing.
+    std::thread t([&] {
+        wrapperA.parallel_for(
+            [&](size_t tid) {
+                if (tid > 0) {
+                    workers_ready.count_down();
+                }
+                hold.wait();
+                resultA++;
+            },
+            3);
+    });
+
+    ASSERT_TRUE(wait_with_timeout(workers_ready, kTestTimeout))
+        << "Timed out waiting for wrapper A's 2 workers to start. "
+           "resultA="
+        << resultA << ", pool_size=" << VecSimSVSThreadPool::poolSize();
+
+    // Grow pool from 3 → 5 while s0, s1 are occupied. New slots [s2, s3] are
+    // appended. The in-flight parallel_for is unaffected — it holds independent
+    // shared_ptr refs to s0, s1.
+    VecSimSVSThreadPool::resize(5);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 5);
+
+    // Wrapper B uses parallelism 3 → rents 2 workers. s0, s1 are occupied by
+    // wrapperA, so it gets the 2 newly created slots s2, s3... but we only
+    // need 2 of the 3 free slots (s2, s3 are free, only need 2).
+    VecSimSVSThreadPool wrapperB;
+    wrapperB.setParallelism(3);
+    std::atomic_int resultB{0};
+    wrapperB.parallel_for([&](size_t) { resultB++; }, 3);
+    ASSERT_EQ(resultB, 3);
+
+    // Release wrapperA's blocked threads.
+    hold.count_down();
+    t.join();
+    ASSERT_EQ(resultA, 3);
+
+    // Pool size remains at the grown value after renter releases.
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 5);
+
+    // After all threads are free, verify the full pool is usable at new size.
+    wrapperA.setParallelism(5);
+    std::atomic_int resultFull{0};
+    wrapperA.parallel_for([&](size_t) { resultFull++; }, 5);
+    ASSERT_EQ(resultFull, 5);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Parallelism propagation across copies
+// The VecSimSVSThreadPool wrapper is copied internally by SVS (via
+// ThreadPoolHandle). Both the original and the copy must share the same
+// parallelism_ (shared_ptr<atomic<size_t>>), so that setParallelism() on
+// the original is visible to SVS's copy when it calls size().
+// ---------------------------------------------------------------------------
+TEST_F(SVSThreadPoolTest, ParallelismPropagationAcrossCopies) {
+    VecSimSVSThreadPool::resize(8);
+
+    VecSimSVSThreadPool original;
+    original.setParallelism(2);
+    ASSERT_EQ(original.size(), 2);
+
+    // Copy the wrapper — simulates what SVS does internally.
+    VecSimSVSThreadPool copy = original;
+    ASSERT_EQ(copy.size(), 2);
+
+    // Change parallelism on the original. The copy must see it.
+    original.setParallelism(6);
+    ASSERT_EQ(original.size(), 6);
+    ASSERT_EQ(copy.size(), 6);
+
+    // Change via the copy. The original must see it too.
+    copy.setParallelism(3);
+    ASSERT_EQ(copy.size(), 3);
+    ASSERT_EQ(original.size(), 3);
+
+    // Both share the same pool.
+    ASSERT_EQ(original.poolSize(), 8);
+    ASSERT_EQ(copy.poolSize(), 8);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Two indexes sharing one pool with independent parallelism
+// Two wrappers from the same shared pool have independent parallelism values.
+// Changing one does not affect the other. Both can run parallel_for
+// sequentially using disjoint thread budgets.
+// ---------------------------------------------------------------------------
+TEST_F(SVSThreadPoolTest, TwoIndexesIndependentParallelism) {
+    VecSimSVSThreadPool::resize(8);
+
+    VecSimSVSThreadPool wrapperA;
+    VecSimSVSThreadPool wrapperB;
+
+    wrapperA.setParallelism(2);
+    wrapperB.setParallelism(5);
+
+    // Each wrapper reports its own parallelism via size().
+    ASSERT_EQ(wrapperA.size(), 2);
+    ASSERT_EQ(wrapperB.size(), 5);
+
+    // Both report the same shared pool size.
+    ASSERT_EQ(wrapperA.poolSize(), 8);
+    ASSERT_EQ(wrapperB.poolSize(), 8);
+
+    // Changing A's parallelism does not affect B.
+    wrapperA.setParallelism(4);
+    ASSERT_EQ(wrapperA.size(), 4);
+    ASSERT_EQ(wrapperB.size(), 5);
+
+    // Both can run parallel_for sequentially — all threads are free between calls.
+    std::atomic_int resultA{0};
+    wrapperA.parallel_for([&](size_t) { resultA++; }, 4);
+    ASSERT_EQ(resultA, 4);
+
+    std::atomic_int resultB{0};
+    wrapperB.parallel_for([&](size_t) { resultB++; }, 5);
+    ASSERT_EQ(resultB, 5);
+
+    // Verify both wrappers can use the full pool capacity sequentially.
+    wrapperA.setParallelism(8);
+    std::atomic_int resultFullA{0};
+    wrapperA.parallel_for([&](size_t) { resultFullA++; }, 8);
+    ASSERT_EQ(resultFullA, 8);
+
+    wrapperB.setParallelism(8);
+    std::atomic_int resultFullB{0};
+    wrapperB.parallel_for([&](size_t) { resultFullB++; }, 8);
+    ASSERT_EQ(resultFullB, 8);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: VecSim_UpdateThreadPoolSize mode transitions
+// The C API sets write mode and resizes the shared singleton pool.
+// ---------------------------------------------------------------------------
+TEST_F(SVSThreadPoolTest, UpdateThreadPoolSizeModeTransitions) {
+    // 0 → 4: switch to async mode, pool resizes to 4.
+    VecSim_UpdateThreadPoolSize(4);
+    ASSERT_EQ(VecSimIndex::asyncWriteMode, VecSim_WriteAsync);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 4);
+
+    // 4 → 8: stay in async mode (N→M, both > 0), pool resizes to 8.
+    VecSim_UpdateThreadPoolSize(8);
+    ASSERT_EQ(VecSimIndex::asyncWriteMode, VecSim_WriteAsync);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 8);
+
+    // 8 → 0: switch to in-place mode, pool resizes to 1.
+    VecSim_UpdateThreadPoolSize(0);
+    ASSERT_EQ(VecSimIndex::asyncWriteMode, VecSim_WriteInPlace);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1);
+
+    // 0 → 0: idempotent, stays in-place, no crash.
+    VecSim_UpdateThreadPoolSize(0);
+    ASSERT_EQ(VecSimIndex::asyncWriteMode, VecSim_WriteInPlace);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1);
+
+    // 0 → 2: back to async mode.
+    VecSim_UpdateThreadPoolSize(2);
+    ASSERT_EQ(VecSimIndex::asyncWriteMode, VecSim_WriteAsync);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 2);
+
+    // Restore to in-place mode so we don't leak state to other tests.
+    VecSim_UpdateThreadPoolSize(0);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Concurrent rental from two indexes
+// Two wrappers share a pool. Both call parallel_for concurrently from
+// different threads with parallelism values that sum to the pool size.
+// No thread should be double-rented — the mutex serializes rental scans.
+// ---------------------------------------------------------------------------
+TEST_F(SVSThreadPoolTest, ConcurrentRentalFromTwoIndexes) {
+    // Pool size 8: wrappers A (4) and B (4) sum to exactly 8.
+    VecSimSVSThreadPool::resize(8);
+
+    VecSimSVSThreadPool wrapperA;
+    wrapperA.setParallelism(4);
+    VecSimSVSThreadPool wrapperB;
+    wrapperB.setParallelism(4);
+
+    std::atomic_int resultA{0};
+    std::atomic_int resultB{0};
+
+    // Use a latch as a barrier: all 8 tasks (4 from A + 4 from B) must
+    // arrive before any can proceed. If a thread were double-rented, only
+    // 7 tasks could run simultaneously and the latch would never complete.
+    std::latch barrier(8);
+    std::mutex mtx;
+    std::set<std::thread::id> idsA, idsB;
+
+    std::thread tA([&] {
+        wrapperA.parallel_for(
+            [&](size_t) {
+                {
+                    std::lock_guard lock(mtx);
+                    idsA.insert(std::this_thread::get_id());
+                }
+                barrier.count_down();
+                barrier.wait();
+                resultA++;
+            },
+            4);
+    });
+    std::thread tB([&] {
+        wrapperB.parallel_for(
+            [&](size_t) {
+                {
+                    std::lock_guard lock(mtx);
+                    idsB.insert(std::this_thread::get_id());
+                }
+                barrier.count_down();
+                barrier.wait();
+                resultB++;
+            },
+            4);
+    });
+
+    // Wait for both threads to complete. If the barrier deadlocks (e.g., due
+    // to double-renting), these joins would hang — use a timed check.
+    auto deadline = std::chrono::steady_clock::now() + kTestTimeout;
+    tA.join();
+    tB.join();
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+        << "Timed out waiting for concurrent parallel_for calls. "
+           "resultA="
+        << resultA << ", resultB=" << resultB << ", idsA.size=" << idsA.size()
+        << ", idsB.size=" << idsB.size() << ", pool_size=" << wrapperA.poolSize();
+
+    ASSERT_EQ(resultA, 4);
+    ASSERT_EQ(resultB, 4);
+
+    // Each wrapper used 4 distinct OS threads, and no thread was shared.
+    ASSERT_EQ(idsA.size(), 4);
+    ASSERT_EQ(idsB.size(), 4);
+    for (auto &id : idsA) {
+        ASSERT_EQ(idsB.count(id), 0) << "Thread was double-rented across wrappers";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: All threads occupied — graceful degradation
+// When all pool threads are rented by wrapper A, wrapper B's parallel_for
+// cannot rent any workers. In debug builds, rent() asserts. In release
+// builds, parallel_for uses rented.count() (0 workers) and runs only
+// partition 0 on the calling thread.
+//
+// NOTE: This should never happen in production. RediSearch's reserve job
+// mechanism guarantees that the number of concurrent renters never exceeds
+// the pool size. This test exercises the defensive fallback path.
+// ---------------------------------------------------------------------------
+TEST_F(SVSThreadPoolTest, AllThreadsOccupied) {
+    // Pool size 4 (3 worker slots). Wrapper A rents all 3.
+    VecSimSVSThreadPool::resize(4);
+
+    VecSimSVSThreadPool wrapperA;
+    wrapperA.setParallelism(4);
+
+    std::latch hold(1);
+    std::latch workers_ready(3);
+    std::atomic_int resultA{0};
+
+    // Spawned thread: wrapper A grabs all 3 worker slots and blocks.
+    std::thread t([&] {
+        wrapperA.parallel_for(
+            [&](size_t tid) {
+                if (tid > 0) {
+                    workers_ready.count_down();
+                }
+                hold.wait();
+                resultA++;
+            },
+            4);
+    });
+
+    ASSERT_TRUE(wait_with_timeout(workers_ready, kTestTimeout))
+        << "Timed out waiting for wrapper A's 3 workers to start. "
+           "resultA="
+        << resultA << ", pool_size=" << wrapperA.poolSize();
+
+    // All 3 worker slots are occupied. Wrapper B tries to rent 1 worker.
+    VecSimSVSThreadPool wrapperB;
+    wrapperB.setParallelism(2);
+
+#ifdef NDEBUG
+    // Release: graceful degradation — rent() returns 0 workers, parallel_for
+    // runs only partition 0 on the calling thread. Work is silently dropped.
+    std::atomic_int resultB{0};
+    wrapperB.parallel_for([&](size_t) { resultB++; }, 2);
+    ASSERT_EQ(resultB, 1); // only partition 0 ran
+#else
+    // Debug: rent() asserts because it can't fulfill the request.
+    ASSERT_DEATH(wrapperB.parallel_for([&](size_t) {}, 2),
+                 "Failed to rent the expected number of SVS threads");
+#endif
+
+    // Clean up: release wrapper A's blocked threads.
+    hold.count_down();
+    t.join();
+    ASSERT_EQ(resultA, 4);
+}
+
+#endif // HAVE_SVS

--- a/tests/unit/test_svs_threadpool.cpp
+++ b/tests/unit/test_svs_threadpool.cpp
@@ -44,12 +44,18 @@ protected:
         // don't assert on nullptr log_ctx (we don't have an index context).
         saved_callback_ = VecSimIndexInterface::logCallback;
         VecSimIndexInterface::logCallback = nullptr;
+        // Reset the shared singleton pool to size 1 — earlier test suites may have
+        // resized it via VecSim_UpdateThreadPoolSize() and left it in that state.
+        VecSimSVSThreadPool::resize(1);
     }
     void TearDown() override {
         // Reset the shared singleton pool to size 1 so tests don't leak state.
         VecSimSVSThreadPool::resize(1);
         VecSimIndexInterface::logCallback = saved_callback_;
     }
+
+    // Allocator used by VecSimSVSThreadPool wrappers constructed in tests.
+    std::shared_ptr<VecSimAllocator> allocator_ = VecSimAllocator::newVecsimAllocator();
 
 private:
     logCallbackFunction saved_callback_ = nullptr;
@@ -116,7 +122,7 @@ TEST_F(SVSThreadPoolTest, ShrinkWhileRented) {
     ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 5);
 
     // Wrapper A uses parallelism 3 → rents 2 workers (s0, s1).
-    VecSimSVSThreadPool wrapperA;
+    VecSimSVSThreadPool wrapperA{allocator_};
     wrapperA.setParallelism(3);
 
     std::latch hold(1);          // blocks rented workers
@@ -154,7 +160,7 @@ TEST_F(SVSThreadPoolTest, ShrinkWhileRented) {
 
     // While wrapperA's threads are still alive (blocked on latch), run
     // parallel_for on the shrunk pool with a second wrapper using a free slot.
-    VecSimSVSThreadPool wrapperB;
+    VecSimSVSThreadPool wrapperB{allocator_};
     // Parallelism 2 = 1 rented worker + calling thread. The pool has 3 slots
     // [s0, s1, s2] after shrink; s0 and s1 are occupied by wrapperA, so the
     // single rented worker will get s2 (the only free slot).
@@ -183,7 +189,7 @@ TEST_F(SVSThreadPoolTest, GrowWhileRented) {
     ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 3);
 
     // Wrapper A uses parallelism 3 → rents 2 workers (s0, s1).
-    VecSimSVSThreadPool wrapperA;
+    VecSimSVSThreadPool wrapperA{allocator_};
     wrapperA.setParallelism(3);
 
     std::latch hold(1);          // blocks rented workers
@@ -219,7 +225,7 @@ TEST_F(SVSThreadPoolTest, GrowWhileRented) {
     // Wrapper B uses parallelism 3 → rents 2 workers. s0, s1 are occupied by
     // wrapperA, so it gets the 2 newly created slots s2, s3... but we only
     // need 2 of the 3 free slots (s2, s3 are free, only need 2).
-    VecSimSVSThreadPool wrapperB;
+    VecSimSVSThreadPool wrapperB{allocator_};
     wrapperB.setParallelism(3);
     std::atomic_int resultB{0};
     wrapperB.parallel_for([&](size_t) { resultB++; }, 3);
@@ -250,7 +256,7 @@ TEST_F(SVSThreadPoolTest, GrowWhileRented) {
 TEST_F(SVSThreadPoolTest, ParallelismPropagationAcrossCopies) {
     VecSimSVSThreadPool::resize(8);
 
-    VecSimSVSThreadPool original;
+    VecSimSVSThreadPool original{allocator_};
     original.setParallelism(2);
     ASSERT_EQ(original.size(), 2);
 
@@ -282,8 +288,8 @@ TEST_F(SVSThreadPoolTest, ParallelismPropagationAcrossCopies) {
 TEST_F(SVSThreadPoolTest, TwoIndexesIndependentParallelism) {
     VecSimSVSThreadPool::resize(8);
 
-    VecSimSVSThreadPool wrapperA;
-    VecSimSVSThreadPool wrapperB;
+    VecSimSVSThreadPool wrapperA{allocator_};
+    VecSimSVSThreadPool wrapperB{allocator_};
 
     wrapperA.setParallelism(2);
     wrapperB.setParallelism(5);
@@ -366,9 +372,9 @@ TEST_F(SVSThreadPoolTest, ConcurrentRentalFromTwoIndexes) {
     // Pool size 8: wrappers A (4) and B (4) sum to exactly 8.
     VecSimSVSThreadPool::resize(8);
 
-    VecSimSVSThreadPool wrapperA;
+    VecSimSVSThreadPool wrapperA{allocator_};
     wrapperA.setParallelism(4);
-    VecSimSVSThreadPool wrapperB;
+    VecSimSVSThreadPool wrapperB{allocator_};
     wrapperB.setParallelism(4);
 
     std::atomic_int resultA{0};
@@ -445,7 +451,7 @@ TEST_F(SVSThreadPoolTest, AllThreadsOccupied) {
     // Pool size 4 (3 worker slots). Wrapper A rents all 3.
     VecSimSVSThreadPool::resize(4);
 
-    VecSimSVSThreadPool wrapperA;
+    VecSimSVSThreadPool wrapperA{allocator_};
     wrapperA.setParallelism(4);
 
     std::latch hold(1);
@@ -471,7 +477,7 @@ TEST_F(SVSThreadPoolTest, AllThreadsOccupied) {
         << resultA << ", pool_size=" << wrapperA.poolSize();
 
     // All 3 worker slots are occupied. Wrapper B tries to rent 1 worker.
-    VecSimSVSThreadPool wrapperB;
+    VecSimSVSThreadPool wrapperB{allocator_};
     wrapperB.setParallelism(2);
 
 #ifdef NDEBUG

--- a/tests/unit/test_svs_threadpool.cpp
+++ b/tests/unit/test_svs_threadpool.cpp
@@ -44,6 +44,10 @@ protected:
         // don't assert on nullptr log_ctx (we don't have an index context).
         saved_callback_ = VecSimIndexInterface::logCallback;
         VecSimIndexInterface::logCallback = nullptr;
+        // Mark the shared pool as having an attached index so resize() behaves
+        // eagerly throughout the test (these unit tests exercise the pool in
+        // isolation, without constructing real SVS indexes). Idempotent.
+        VecSimSVSThreadPoolImpl::instance()->onIndexAttached();
         // Reset the shared singleton pool to size 1 — earlier test suites may have
         // resized it via VecSim_UpdateThreadPoolSize() and left it in that state.
         VecSimSVSThreadPool::resize(1);
@@ -330,15 +334,26 @@ TEST_F(SVSThreadPoolTest, TwoIndexesIndependentParallelism) {
 
 // ---------------------------------------------------------------------------
 // Test 6: VecSim_UpdateThreadPoolSize mode transitions
-// The C API sets write mode and resizes the shared singleton pool.
+// The C API always sets write mode immediately. The pool resize is lazy: it is
+// applied at first index attach if no index has attached yet, otherwise
+// immediately.
 // ---------------------------------------------------------------------------
 TEST_F(SVSThreadPoolTest, UpdateThreadPoolSizeModeTransitions) {
-    // 0 → 4: switch to async mode, pool resizes to 4.
+    // Reset to a fresh state — previous tests may have attached indexes via
+    // VecSimSVSThreadPool wrappers, leaving has_attached_index_ set.
+    VecSimSVSThreadPoolImpl::instance()->resetForTest();
+
+    // 0 → 4: switch to async mode immediately. Pool size stays at 1 because
+    // no SVS index has attached yet (resize is deferred).
     VecSim_UpdateThreadPoolSize(4);
     ASSERT_EQ(VecSimIndex::asyncWriteMode, VecSim_WriteAsync);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1);
+
+    // Attaching an index applies the deferred size.
+    VecSimSVSThreadPool wrapper{allocator_};
     ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 4);
 
-    // 4 → 8: stay in async mode (N→M, both > 0), pool resizes to 8.
+    // 4 → 8: now that an index is attached, resize is immediate.
     VecSim_UpdateThreadPoolSize(8);
     ASSERT_EQ(VecSimIndex::asyncWriteMode, VecSim_WriteAsync);
     ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 8);

--- a/tests/unit/test_svs_tiered.cpp
+++ b/tests/unit/test_svs_tiered.cpp
@@ -1,5 +1,6 @@
 #include "VecSim/index_factories/tiered_factory.h"
 #include "VecSim/vec_sim_debug.h"
+#include <atomic>
 #include <string>
 #include <array>
 
@@ -76,9 +77,6 @@ protected:
         trainingThreshold = training_threshold;
         updateThreshold = update_threshold;
         svs_params.algoParams.svsParams.quantBits = index_type_t::get_quant_bits();
-        if (svs_params.algoParams.svsParams.num_threads == 0) {
-            svs_params.algoParams.svsParams.num_threads = mock_thread_pool.thread_pool_size;
-        }
         return TieredIndexParams{
             .jobQueue = &mock_thread_pool.jobQ,
             .jobQueueCtx = mock_thread_pool.ctx,
@@ -90,30 +88,23 @@ protected:
                                                    .updateJobWaitTime = update_job_wait_time}}};
     }
 
-    void verifyNumThreads(TieredSVSIndex<data_t> *tiered_index, size_t expected_num_threads,
-                          size_t expected_capcity) {
-        ASSERT_EQ(tiered_index->GetSVSIndex()->getNumThreads(), expected_num_threads);
-        ASSERT_EQ(tiered_index->GetSVSIndex()->getThreadPoolCapacity(), expected_capcity);
+    void verifyNumThreads(TieredSVSIndex<data_t> *tiered_index, size_t expected_capcity) {
+        ASSERT_EQ(tiered_index->GetSVSIndex()->getParallelism(), 1);
+        ASSERT_EQ(tiered_index->GetSVSIndex()->getPoolSize(), expected_capcity);
     }
     TieredSVSIndex<data_t> *CreateTieredSVSIndex(const TieredIndexParams &tiered_params,
-                                                 tieredIndexMock &mock_thread_pool,
-                                                 size_t num_available_threads = 1) {
+                                                 tieredIndexMock &mock_thread_pool) {
+        // Resize the shared SVS thread pool singleton to match the mock thread pool size,
+        // simulating what RediSearch does via VecSim_UpdateThreadPoolSize during module init.
+        VecSim_UpdateThreadPoolSize(mock_thread_pool.thread_pool_size);
+
         auto *tiered_index =
             reinterpret_cast<TieredSVSIndex<data_t> *>(TieredFactory::NewIndex(&tiered_params));
 
         // Set the created tiered index in the index external context (it will take ownership over
         // the index, and we'll need to release the ctx at the end of the test.
         mock_thread_pool.ctx->index_strong_ref.reset(tiered_index);
-        // Set numThreads to 1 by default to allow direct calls to SVS addVector() API,
-        // which requires exactly 1 thread. When using tiered index addVector API,
-        // the thread count is managed internally according to the operation and threadpool
-        // capacity, so testing parallelism remains intact.
-        tiered_index->GetSVSIndex()->setNumThreads(num_available_threads);
-        size_t params_threadpool_size =
-            tiered_params.primaryIndexParams->algoParams.svsParams.num_threads;
-        size_t expected_capacity =
-            params_threadpool_size ? params_threadpool_size : mock_thread_pool.thread_pool_size;
-        verifyNumThreads(tiered_index, num_available_threads, expected_capacity);
+        verifyNumThreads(tiered_index, mock_thread_pool.thread_pool_size);
 
         return tiered_index;
     }
@@ -122,18 +113,17 @@ protected:
     CreateTieredSVSIndex(VecSimParams &svs_params, tieredIndexMock &mock_thread_pool,
                          size_t training_threshold = TestsDefaultTrainingThreshold,
                          size_t update_threshold = TestsDefaultUpdateThreshold,
-                         size_t update_job_wait_time = SVS_DEFAULT_UPDATE_JOB_WAIT_TIME,
-                         size_t num_available_threads = 1) {
+                         size_t update_job_wait_time = SVS_DEFAULT_UPDATE_JOB_WAIT_TIME) {
         svs_params.algoParams.svsParams.quantBits = index_type_t::get_quant_bits();
         TieredIndexParams tiered_params =
             CreateTieredSVSParams(svs_params, mock_thread_pool, training_threshold,
                                   update_threshold, update_job_wait_time);
-        return CreateTieredSVSIndex(tiered_params, mock_thread_pool, num_available_threads);
+        return CreateTieredSVSIndex(tiered_params, mock_thread_pool);
     }
 
     void SetUp() override {
         // Restore the write mode to default.
-        VecSim_SetWriteMode(VecSim_WriteAsync);
+        VecSim_UpdateThreadPoolSize(0);
         // Limit VecSim log level to avoid printing too much information
         VecSimIndexInterface::setLogCallbackFunction(svsTestLogCallBackNoDebug);
     }
@@ -199,11 +189,10 @@ TYPED_TEST(SVSTieredIndexTest, ThreadsReservation) {
     }
 
     std::chrono::milliseconds timeout{1000}; // long enough to reserve all threads
-    SVSParams params = {
-        .type = TypeParam::get_index_type(), .dim = 4, .metric = VecSimMetric_L2, .num_threads = 1};
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = 4, .metric = VecSimMetric_L2};
     VecSimParams svs_params = CreateParams(params);
-    auto mock_thread_pool = tieredIndexMock();
-    mock_thread_pool.thread_pool_size = num_threads;
+    auto mock_thread_pool = tieredIndexMock(num_threads);
+    ASSERT_EQ(mock_thread_pool.thread_pool_size, num_threads);
 
     // Create TieredSVS index instance with a mock queue.
     auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool);
@@ -281,24 +270,21 @@ TYPED_TEST(SVSTieredIndexTest, TestDebugInfoThreadCount) {
     constexpr size_t update_threshold = 10;
     constexpr size_t update_job_wait_time = 10000;
     constexpr size_t dim = 4;
-    SVSParams params = {.type = TypeParam::get_index_type(),
-                        .dim = dim,
-                        .metric = VecSimMetric_L2,
-                        .num_threads = num_threads};
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
     VecSimParams svs_params = CreateParams(params);
-    auto mock_thread_pool = tieredIndexMock();
-    mock_thread_pool.thread_pool_size = num_threads;
+    auto mock_thread_pool = tieredIndexMock(num_threads);
+    ASSERT_EQ(mock_thread_pool.thread_pool_size, num_threads);
 
     // Create TieredSVS index instance with a mock queue.
-    auto *tiered_index =
-        this->CreateTieredSVSIndex(svs_params, mock_thread_pool, training_threshold,
-                                   update_threshold, update_job_wait_time, num_threads);
+    auto *tiered_index = this->CreateTieredSVSIndex(
+        svs_params, mock_thread_pool, training_threshold, update_threshold, update_job_wait_time);
     ASSERT_INDEX(tiered_index);
 
-    // Verify initial state: both fields should equal configured thread count
+    // Verify initial state: numThreads reflects the shared pool size,
+    // lastReservedThreads starts at 1 (parallelism_ is initialized to 1).
     VecSimIndexDebugInfo backendIndexInfo = tiered_index->GetBackendIndex()->debugInfo();
     ASSERT_EQ(backendIndexInfo.svsInfo.numThreads, num_threads);
-    ASSERT_EQ(backendIndexInfo.svsInfo.lastReservedThreads, num_threads);
+    ASSERT_EQ(backendIndexInfo.svsInfo.lastReservedThreads, 1);
     // Get the allocator from the tiered index.
     auto allocator = tiered_index->getAllocator();
 
@@ -332,7 +318,9 @@ TYPED_TEST(SVSTieredIndexTest, TestDebugInfoThreadCount) {
     while (tiered_index->GetBackendIndex()->indexSize() != training_threshold) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    // Verify: numThreads unchanged, lastReservedThreads reflects actual availability
+    // Verify: numThreads (pool size) unchanged, lastReservedThreads (parallelism) reflects
+    // reduced availability — one thread was occupied, so at most num_threads - 1 could reserve.
+    // Use LE because OS timing may cause fewer threads to check in before the reservation timeout.
     backendIndexInfo = tiered_index->GetBackendIndex()->debugInfo();
     ASSERT_EQ(backendIndexInfo.svsInfo.numThreads, num_threads);
     ASSERT_LE(backendIndexInfo.svsInfo.lastReservedThreads, num_threads - 1);
@@ -346,7 +334,9 @@ TYPED_TEST(SVSTieredIndexTest, TestDebugInfoThreadCount) {
     }
     mock_thread_pool.thread_pool_join();
 
-    // Verify: numThreads unchanged, lastReservedThreads reflects we used all configured threads
+    // Verify: numThreads (pool size) unchanged, lastReservedThreads (parallelism) reflects
+    // that all configured threads were available for this operation.
+    // Use LE because OS timing may cause fewer threads to check in before the reservation timeout.
     backendIndexInfo = tiered_index->GetBackendIndex()->debugInfo();
     ASSERT_EQ(backendIndexInfo.svsInfo.numThreads, num_threads);
     ASSERT_LE(backendIndexInfo.svsInfo.lastReservedThreads, num_threads);
@@ -354,8 +344,8 @@ TYPED_TEST(SVSTieredIndexTest, TestDebugInfoThreadCount) {
 
 TYPED_TEST(SVSTieredIndexTest, TestDebugInfoThreadCountWriteInPlace) {
     // Test that write-in-place mode correctly reports thread usage in debug info.
-    // Even when the index is configured with multiple threads, write-in-place operations
-    // should use only 1 thread and lastReservedThreads should reflect this.
+    // Even when the shared pool has multiple threads, write-in-place operations
+    // should use only 1 thread and lastReservedThreads (parallelism) should reflect this.
 
     // Set thread_pool_size to 4 or actual number of available CPUs
     const auto num_threads = std::min(4U, getAvailableCPUs());
@@ -364,31 +354,28 @@ TYPED_TEST(SVSTieredIndexTest, TestDebugInfoThreadCountWriteInPlace) {
         GTEST_SKIP() << "No threads available";
     }
 
-    // Test svs when mode is write in place, but the index is configured with multiple threads.
+    // Test svs when mode is write in place, but the shared pool has multiple threads.
     constexpr size_t training_threshold = 10;
     constexpr size_t update_threshold = 10;
     constexpr size_t update_job_wait_time = 10000;
     constexpr size_t dim = 4;
-    SVSParams params = {.type = TypeParam::get_index_type(),
-                        .dim = dim,
-                        .metric = VecSimMetric_L2,
-                        .num_threads = num_threads};
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
     VecSimParams svs_params = CreateParams(params);
-    auto mock_thread_pool = tieredIndexMock();
-    mock_thread_pool.thread_pool_size = num_threads;
+    auto mock_thread_pool = tieredIndexMock(num_threads);
+    ASSERT_EQ(mock_thread_pool.thread_pool_size, num_threads);
 
     // Create TieredSVS index instance with a mock queue.
-    auto *tiered_index =
-        this->CreateTieredSVSIndex(svs_params, mock_thread_pool, training_threshold,
-                                   update_threshold, update_job_wait_time, num_threads);
+    auto *tiered_index = this->CreateTieredSVSIndex(
+        svs_params, mock_thread_pool, training_threshold, update_threshold, update_job_wait_time);
     ASSERT_INDEX(tiered_index);
 
-    // Set to mode to write in place even though the index is configured with multiple threads.
+    // Set mode to write in place even though the shared pool has multiple threads.
     VecSim_SetWriteMode(VecSim_WriteInPlace);
-    // Verify initial state: both fields should equal configured thread count
+    // Verify initial state: numThreads reflects the shared pool size,
+    // lastReservedThreads starts at 1 (parallelism_ is initialized to 1).
     VecSimIndexDebugInfo backendIndexInfo = tiered_index->GetBackendIndex()->debugInfo();
     ASSERT_EQ(backendIndexInfo.svsInfo.numThreads, num_threads);
-    ASSERT_EQ(backendIndexInfo.svsInfo.lastReservedThreads, num_threads);
+    ASSERT_EQ(backendIndexInfo.svsInfo.lastReservedThreads, 1);
     // Get the allocator from the tiered index.
     auto allocator = tiered_index->getAllocator();
 
@@ -403,8 +390,8 @@ TYPED_TEST(SVSTieredIndexTest, TestDebugInfoThreadCountWriteInPlace) {
     while (tiered_index->GetBackendIndex()->indexSize() != training_threshold) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    // Verify: numThreads unchanged, lastReservedThreads reflects we only used one thread (main
-    // thread)
+    // Verify: numThreads (pool size) unchanged, lastReservedThreads (parallelism) reflects
+    // we only used one thread (write-in-place calls updateSVSIndexWrapper with availableThreads=1).
     backendIndexInfo = tiered_index->GetBackendIndex()->debugInfo();
     ASSERT_EQ(backendIndexInfo.svsInfo.numThreads, num_threads);
     ASSERT_EQ(backendIndexInfo.svsInfo.lastReservedThreads, 1);
@@ -413,7 +400,7 @@ TYPED_TEST(SVSTieredIndexTest, TestDebugInfoThreadCountWriteInPlace) {
     size_t num_vectors = 10;
     for (size_t i = 0; i < num_vectors; ++i) {
         GenerateAndAddVector<TEST_DATA_T>(tiered_index, dim, training_threshold + i);
-        // Verify: numThreads unchanged, lastReservedThreads reflects we used only one thread
+        // Verify: numThreads (pool size) unchanged, lastReservedThreads (parallelism) = 1
         backendIndexInfo = tiered_index->GetBackendIndex()->debugInfo();
         ASSERT_EQ(backendIndexInfo.svsInfo.numThreads, num_threads);
         ASSERT_EQ(backendIndexInfo.svsInfo.lastReservedThreads, 1);
@@ -498,6 +485,134 @@ TYPED_TEST(SVSTieredIndexTest, CreateIndexInstance) {
     ASSERT_EQ(tiered_index->getDistanceFrom_Unsafe(1, vector), 0);
     ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 0);
     ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), 1);
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, ShrinkDuringScheduledUpdateIsDeferred) {
+    // Regression for the original crash: shrink after the update job reserved threads,
+    // but before the SVS update uses them. The update must still complete safely.
+    const auto num_threads = std::min(4U, getAvailableCPUs());
+    if (num_threads < 2) {
+        GTEST_SKIP() << "No threads available";
+    }
+
+    const size_t dim = 4;
+    const size_t n = num_threads;
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock(num_threads);
+
+    // Keep automatic training/update disabled so the test controls the scheduling point.
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, n + 10, n + 20);
+    ASSERT_INDEX(tiered_index);
+
+    for (size_t i = 0; i < n; i++) {
+        TEST_DATA_T vector[dim];
+        GenerateVector<TEST_DATA_T>(vector, dim, i);
+        tiered_index->addVector(vector, i);
+    }
+
+    std::atomic_bool shrink_callback_ran{false};
+    tiered_index->registerTracingCallback("UpdateJob::before_add_to_svs", [&]() {
+        // This is the real production entrypoint: the job has already reserved its threads,
+        // but updateSVSIndex() has not yet called setParallelism() / createImpl().
+        VecSimSVSThreadPool::resize(1);
+        shrink_callback_ran = true;
+    });
+
+    tiered_index->scheduleSVSIndexUpdate();
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), num_threads);
+
+    mock_thread_pool.init_threads();
+    mock_thread_pool.thread_pool_join();
+
+    ASSERT_TRUE(shrink_callback_ran);
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), n);
+    ASSERT_EQ(tiered_index->GetFlatIndex()->indexSize(), 0);
+    ASSERT_EQ(tiered_index->GetSVSIndex()->getPoolSize(), 1);
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, ScheduledJobsRegistryCleanupAppliesDeferredResize) {
+    // Covers the simplified cleanup path: scheduled jobs are created but never run.
+    // Destroying the registry must delete the jobs and release the deferred shrink.
+    const auto num_threads = std::min(4U, getAvailableCPUs());
+    if (num_threads < 2) {
+        GTEST_SKIP() << "No threads available";
+    }
+
+    constexpr size_t dim = 4;
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock(num_threads);
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, num_threads + 10,
+                                                    num_threads + 20);
+    ASSERT_INDEX(tiered_index);
+
+    auto allocator = tiered_index->getAllocator();
+    std::atomic_bool callback_ran{false};
+
+    {
+        SVSMultiThreadJob::JobsRegistry registry(allocator);
+        auto jobs = SVSMultiThreadJob::createScheduledJobs(
+            allocator, SVS_BATCH_UPDATE_JOB,
+            [&callback_ran](VecSimIndex * /*unused*/, size_t /*unused*/) { callback_ran = true; },
+            tiered_index, std::chrono::microseconds(SVS_DEFAULT_UPDATE_JOB_WAIT_TIME), &registry);
+
+        ASSERT_EQ(jobs.size(), num_threads);
+
+        VecSimSVSThreadPool::resize(1);
+        ASSERT_EQ(VecSimSVSThreadPool::poolSize(), num_threads);
+    }
+
+    ASSERT_FALSE(callback_ran);
+    ASSERT_EQ(VecSimSVSThreadPool::poolSize(), 1);
+}
+
+TYPED_TEST(SVSTieredIndexTestBasic, ShrinkDuringScheduledGCIsDeferred) {
+    // Mirror of the update regression for GC: shrink after reservation but before runGC().
+    // The GC job must still finish, and the deferred shrink should apply afterward.
+    const auto num_threads = std::min(4U, getAvailableCPUs());
+    if (num_threads < 2) {
+        GTEST_SKIP() << "No threads available";
+    }
+
+    constexpr size_t dim = 4;
+    const size_t n = num_threads * 2;
+    const size_t num_deleted = num_threads;
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
+    VecSimParams svs_params = CreateParams(params);
+    auto mock_thread_pool = tieredIndexMock(num_threads);
+    auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, n + 10, n + 20);
+    ASSERT_INDEX(tiered_index);
+
+    for (size_t i = 0; i < n; i++) {
+        TEST_DATA_T vector[dim];
+        GenerateVector<TEST_DATA_T>(vector, dim, i + 1);
+        VecSimIndex_AddVector(tiered_index->GetBackendIndex(), vector, i);
+    }
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), n);
+
+    for (size_t i = 0; i < num_deleted; i++) {
+        tiered_index->deleteVector(i);
+    }
+    ASSERT_EQ(tiered_index->GetSVSIndex()->getNumMarkedDeleted(), num_deleted);
+
+    std::atomic_bool shrink_callback_ran{false};
+    tiered_index->registerTracingCallback("GCJob::before_run_gc", [&]() {
+        VecSimSVSThreadPool::resize(1);
+        shrink_callback_ran = true;
+    });
+
+    VecSimTieredIndex_GC(tiered_index);
+    ASSERT_EQ(mock_thread_pool.jobQ.size(), num_threads);
+
+    mock_thread_pool.init_threads();
+    mock_thread_pool.thread_pool_join();
+
+    ASSERT_TRUE(shrink_callback_ran);
+    ASSERT_EQ(tiered_index->GetSVSIndex()->getNumMarkedDeleted(), 0);
+    ASSERT_EQ(tiered_index->GetBackendIndex()->indexSize(), n - num_deleted);
+    ASSERT_EQ(tiered_index->GetSVSIndex()->indexStorageSize(), n - num_deleted);
+    ASSERT_EQ(tiered_index->GetSVSIndex()->getPoolSize(), 1);
 }
 
 TYPED_TEST(SVSTieredIndexTest, addVector) {
@@ -1035,10 +1150,9 @@ TYPED_TEST(SVSTieredIndexTest, deleteVector) {
     SVSParams params = {.type = TypeParam::get_index_type(),
                         .dim = dim,
                         .metric = VecSimMetric_L2,
-                        .multi = TypeParam::isMulti(),
-                        .num_threads = 1};
+                        .multi = TypeParam::isMulti()};
     VecSimParams svs_params = CreateParams(params);
-    auto mock_thread_pool = tieredIndexMock();
+    auto mock_thread_pool = tieredIndexMock(1);
 
     auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1, 1);
     ASSERT_INDEX(tiered_index);
@@ -1101,12 +1215,9 @@ TYPED_TEST(SVSTieredIndexTestBasic, markedDeleted) {
     size_t dim = 4;
     constexpr size_t n = 10;
     constexpr size_t transfer_trigger = n;
-    SVSParams params = {.type = TypeParam::get_index_type(),
-                        .dim = dim,
-                        .metric = VecSimMetric_L2,
-                        .num_threads = 1};
+    SVSParams params = {.type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2};
     VecSimParams svs_params = CreateParams(params);
-    auto mock_thread_pool = tieredIndexMock();
+    auto mock_thread_pool = tieredIndexMock(1);
 
     auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, transfer_trigger,
                                                     transfer_trigger);
@@ -1180,13 +1291,10 @@ TYPED_TEST(SVSTieredIndexTestBasic, markedDeleted) {
 TYPED_TEST(SVSTieredIndexTestBasic, deleteVectorMulti) {
     // Create TieredSVS index instance with a mock queue.
     size_t dim = 4;
-    SVSParams params = {.type = TypeParam::get_index_type(),
-                        .dim = dim,
-                        .metric = VecSimMetric_L2,
-                        .multi = true,
-                        .num_threads = 1};
+    SVSParams params = {
+        .type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2, .multi = true};
     VecSimParams svs_params = CreateParams(params);
-    auto mock_thread_pool = tieredIndexMock();
+    auto mock_thread_pool = tieredIndexMock(1);
 
     auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1, 1);
     auto allocator = tiered_index->getAllocator();
@@ -2604,13 +2712,10 @@ TYPED_TEST(SVSTieredIndexTestBasic, overwriteVectorBasic) {
     // Create TieredSVS index instance with a mock queue.
     size_t dim = 4;
     size_t n = 1000;
-    SVSParams params = {.type = TypeParam::get_index_type(),
-                        .dim = dim,
-                        .metric = VecSimMetric_L2,
-                        .multi = false,
-                        .num_threads = 1};
+    SVSParams params = {
+        .type = TypeParam::get_index_type(), .dim = dim, .metric = VecSimMetric_L2, .multi = false};
     VecSimParams svs_params = CreateParams(params);
-    auto mock_thread_pool = tieredIndexMock();
+    auto mock_thread_pool = tieredIndexMock(1);
 
     auto *tiered_index = this->CreateTieredSVSIndex(svs_params, mock_thread_pool, 1, 1);
     ASSERT_INDEX(tiered_index);
@@ -3823,46 +3928,77 @@ TYPED_TEST(SVSTieredIndexTestBasic, testDeletedJournalMulti) {
 }
 
 TEST(SVSTieredIndexTest, testThreadPool) {
-    // Test VecSimSVSThreadPool
+    // Test VecSimSVSThreadPool with shared pool
     const size_t num_threads = 4;
-    auto pool = VecSimSVSThreadPool(num_threads);
-    ASSERT_EQ(pool.capacity(), num_threads);
-    ASSERT_EQ(pool.size(), num_threads);
+    VecSimSVSThreadPool::resize(num_threads);
+    VecSimSVSThreadPool pool;
+    ASSERT_EQ(pool.poolSize(), num_threads);
+    ASSERT_EQ(pool.size(), 1); // parallelism starts at 1 (calling thread)
+    ASSERT_EQ(pool.getParallelism(), 1);
 
     std::atomic_int counter(0);
     auto task = [&counter](size_t i) { counter += i + 1; };
 
-    // exeed the number of threads
-    ASSERT_THROW(pool.parallel_for(task, 10), svs::threads::ThreadingException);
-
-    counter = 0;
-    pool.parallel_for(task, 4);
-    ASSERT_EQ(counter, 10); // 1+2+3+4 = 10
-
-    pool.resize(1);
-    ASSERT_EQ(pool.capacity(), 4);
-    ASSERT_EQ(pool.size(), 1);
-    // exeed the new pool size
-    ASSERT_THROW(pool.parallel_for(task, 4), svs::threads::ThreadingException);
-
-    counter = 0;
+    // Can use parallel_for immediately with parallelism 1
     pool.parallel_for(task, 1);
     ASSERT_EQ(counter, 1); // 0+1 = 1
 
-    pool.resize(0);
-    ASSERT_EQ(pool.capacity(), 4);
-    ASSERT_EQ(pool.size(), 1);
+    // n > parallelism is allowed — the pool will use as many threads as available.
+    // (The old assert was removed to support deferred resize scenarios.)
 
-    pool.resize(5);
-    ASSERT_EQ(pool.capacity(), 4);
-    ASSERT_EQ(pool.size(), 4);
+    counter = 0;
+    pool.setParallelism(4);
+    pool.parallel_for(task, num_threads);
+    ASSERT_EQ(counter, 10); // 1+2+3+4 = 10
 
-    // Test VecSimSVSThreadPool for exception handling
+    // n < parallelism is valid (SVS may partition into fewer tasks for small problems)
+    counter = 0;
+    pool.parallel_for(task, 2);
+    ASSERT_EQ(counter, 3); // 1+2 = 3
+
+    // setParallelism changes per-index parallelism, not the shared pool
+    pool.setParallelism(2);
+    ASSERT_EQ(pool.poolSize(), num_threads); // shared pool unchanged
+    ASSERT_EQ(pool.size(), 2);               // per-index parallelism
+    ASSERT_EQ(pool.getParallelism(), 2);
+
+    counter = 0;
+    pool.parallel_for(task, 2);
+    ASSERT_EQ(counter, 3); // 1+2 = 3
+
+    // setParallelism boundary checks — asserts in debug mode
+#if !defined(RUNNING_ON_VALGRIND) && !defined(NDEBUG)
+    ASSERT_DEATH(pool.setParallelism(0), "Parallelism must be at least 1");
+    ASSERT_DEATH(pool.setParallelism(10), "Parallelism exceeds shared pool size");
+#endif
+
+    // Test write-in-place mode (pool with size 1)
+    VecSimSVSThreadPool::resize(1);
+    VecSimSVSThreadPool inplace_pool;
+    inplace_pool.setParallelism(1);
+    ASSERT_EQ(inplace_pool.size(), 1);
+    ASSERT_EQ(inplace_pool.poolSize(), 1);
+    counter = 0;
+    inplace_pool.parallel_for(task, 1);
+    ASSERT_EQ(counter, 1);
+
+    // parallel_for works immediately with default parallelism 1
+    VecSimSVSThreadPool::resize(num_threads);
+    VecSimSVSThreadPool default_pool;
+    counter = 0;
+    default_pool.parallel_for(task, 1);
+    ASSERT_EQ(counter, 1); // 0+1 = 1
+
+    // Test exception handling
     auto err_task = [](size_t) { throw std::runtime_error("Test exception"); };
-
-    ASSERT_NO_THROW(pool.parallel_for(err_task, 0)); // no task - no err
+    // n=0 is a no-op (no tasks to run, no error)
+    ASSERT_NO_THROW(pool.parallel_for(err_task, 0));
+    pool.setParallelism(num_threads);
     ASSERT_THROW(pool.parallel_for(err_task, 1), svs::threads::ThreadingException);
-    ASSERT_THROW(pool.parallel_for(err_task, 4), svs::threads::ThreadingException);
+    ASSERT_THROW(pool.parallel_for(err_task, num_threads), svs::threads::ThreadingException);
+
+    // Restore pool to default size so we don't leak state to other tests.
+    VecSimSVSThreadPool::resize(1);
 }
 
 #else // HAVE_SVS

--- a/tests/unit/test_svs_tiered.cpp
+++ b/tests/unit/test_svs_tiered.cpp
@@ -2970,7 +2970,9 @@ TYPED_TEST(SVSTieredIndexTest, testInfoIterator) {
     VecSimIndexDebugInfo frontendIndexInfo = tiered_index->GetFlatIndex()->debugInfo();
     VecSimIndexDebugInfo backendIndexInfo = tiered_index->GetBackendIndex()->debugInfo();
 
-    VecSimDebugInfoIterator *infoIterator = tiered_index->debugInfoIterator();
+    // Use the C API wrapper (as RediSearch does) so the process-wide SHARED_MEMORY
+    // field is appended at the top level — compareTieredIndexInfoToIterator expects it.
+    VecSimDebugInfoIterator *infoIterator = VecSimIndex_DebugInfoIterator(tiered_index);
     compareTieredIndexInfoToIterator(info, frontendIndexInfo, backendIndexInfo, infoIterator);
 
     VecSimDebugInfoIterator_Free(infoIterator);
@@ -3931,7 +3933,8 @@ TEST(SVSTieredIndexTest, testThreadPool) {
     // Test VecSimSVSThreadPool with shared pool
     const size_t num_threads = 4;
     VecSimSVSThreadPool::resize(num_threads);
-    VecSimSVSThreadPool pool;
+    auto allocator = VecSimAllocator::newVecsimAllocator();
+    VecSimSVSThreadPool pool{allocator};
     ASSERT_EQ(pool.poolSize(), num_threads);
     ASSERT_EQ(pool.size(), 1); // parallelism starts at 1 (calling thread)
     ASSERT_EQ(pool.getParallelism(), 1);
@@ -3974,7 +3977,7 @@ TEST(SVSTieredIndexTest, testThreadPool) {
 
     // Test write-in-place mode (pool with size 1)
     VecSimSVSThreadPool::resize(1);
-    VecSimSVSThreadPool inplace_pool;
+    VecSimSVSThreadPool inplace_pool{allocator};
     inplace_pool.setParallelism(1);
     ASSERT_EQ(inplace_pool.size(), 1);
     ASSERT_EQ(inplace_pool.poolSize(), 1);
@@ -3984,7 +3987,7 @@ TEST(SVSTieredIndexTest, testThreadPool) {
 
     // parallel_for works immediately with default parallelism 1
     VecSimSVSThreadPool::resize(num_threads);
-    VecSimSVSThreadPool default_pool;
+    VecSimSVSThreadPool default_pool{allocator};
     counter = 0;
     default_pool.parallel_for(task, 1);
     ASSERT_EQ(counter, 1); // 0+1 = 1

--- a/tests/unit/unit_test_utils.cpp
+++ b/tests/unit/unit_test_utils.cpp
@@ -19,7 +19,9 @@
 using bfloat16 = vecsim_types::bfloat16;
 using float16 = vecsim_types::float16;
 
-// Map index types to their expected number of debug iterator fields
+// Expected number of fields per debug iterator, as emitted by index->debugInfoIterator()
+// (the C++ method). The C API VecSimIndex_DebugInfoIterator appends one extra
+// SHARED_MEMORY field on top — top-level compare functions add +1 to these counts.
 namespace DebugInfoIteratorFieldCount {
 constexpr size_t FLAT = 10;
 constexpr size_t HNSW = 17;
@@ -274,8 +276,11 @@ template void runRangeTieredIndexSearchTest<true, float, float>(
     const std::function<void(size_t, double, size_t)> &, size_t, VecSimQueryReply_Order,
     VecSimQueryParams *);
 
-void compareFlatIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter) {
-    ASSERT_EQ(DebugInfoIteratorFieldCount::FLAT, VecSimDebugInfoIterator_NumberOfFields(infoIter));
+void compareFlatIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter,
+                                    bool expect_shared_memory) {
+    size_t extra = expect_shared_memory ? 1 : 0;
+    ASSERT_EQ(DebugInfoIteratorFieldCount::FLAT + extra,
+              VecSimDebugInfoIterator_NumberOfFields(infoIter));
     while (VecSimDebugInfoIterator_HasNextField(infoIter)) {
         VecSim_InfoField *infoField = VecSimDebugInfoIterator_NextField(infoIter);
         if (!strcmp(infoField->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
@@ -322,14 +327,21 @@ void compareFlatIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIt
             // Memory.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
             ASSERT_EQ(infoField->fieldValue.uintegerValue, info.commonInfo.memory);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::SHARED_MEMORY_STRING)) {
+            // Process-wide shared allocation appended by VecSimIndex_DebugInfoIterator.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, VecSim_GetSharedMemory());
         } else {
             FAIL();
         }
     }
 }
 
-void compareHNSWIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter) {
-    ASSERT_EQ(DebugInfoIteratorFieldCount::HNSW, VecSimDebugInfoIterator_NumberOfFields(infoIter));
+void compareHNSWIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter,
+                                    bool expect_shared_memory) {
+    size_t extra = expect_shared_memory ? 1 : 0;
+    ASSERT_EQ(DebugInfoIteratorFieldCount::HNSW + extra,
+              VecSimDebugInfoIterator_NumberOfFields(infoIter));
     while (VecSimDebugInfoIterator_HasNextField(infoIter)) {
         VecSim_InfoField *infoField = VecSimDebugInfoIterator_NextField(infoIter);
         if (!strcmp(infoField->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
@@ -406,6 +418,10 @@ void compareHNSWIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIt
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
             ASSERT_EQ(infoField->fieldValue.uintegerValue,
                       info.hnswInfo.numberOfMarkedDeletedNodes);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::SHARED_MEMORY_STRING)) {
+            // Process-wide shared allocation appended by VecSimIndex_DebugInfoIterator.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, VecSim_GetSharedMemory());
         } else {
             FAIL();
         }
@@ -416,12 +432,13 @@ void compareTieredIndexInfoToIterator(VecSimIndexDebugInfo info,
                                       VecSimIndexDebugInfo frontendIndexInfo,
                                       VecSimIndexDebugInfo backendIndexInfo,
                                       VecSimDebugInfoIterator *infoIterator) {
+    // +1 for the SHARED_MEMORY field appended by VecSimIndex_DebugInfoIterator (C API).
     VecSimAlgo backendAlgo = backendIndexInfo.commonInfo.basicInfo.algo;
     if (backendAlgo == VecSimAlgo_HNSWLIB) {
-        ASSERT_EQ(DebugInfoIteratorFieldCount::TIERED_HNSW,
+        ASSERT_EQ(DebugInfoIteratorFieldCount::TIERED_HNSW + 1,
                   VecSimDebugInfoIterator_NumberOfFields(infoIterator));
     } else if (backendAlgo == VecSimAlgo_SVS) {
-        ASSERT_EQ(DebugInfoIteratorFieldCount::TIERED_SVS,
+        ASSERT_EQ(DebugInfoIteratorFieldCount::TIERED_SVS + 1,
                   VecSimDebugInfoIterator_NumberOfFields(infoIterator));
     } else {
         FAIL() << "Unsupported backend algorithm";
@@ -478,7 +495,8 @@ void compareTieredIndexInfoToIterator(VecSimIndexDebugInfo info,
             ASSERT_EQ(infoField->fieldValue.integerValue, info.tieredInfo.backgroundIndexing);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::FRONTEND_INDEX_STRING)) {
             ASSERT_EQ(infoField->fieldType, INFOFIELD_ITERATOR);
-            compareFlatIndexInfoToIterator(frontendIndexInfo, infoField->fieldValue.iteratorValue);
+            compareFlatIndexInfoToIterator(frontendIndexInfo, infoField->fieldValue.iteratorValue,
+                                           /*expect_shared_memory=*/false);
         } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::BACKEND_INDEX_STRING)) {
             ASSERT_EQ(infoField->fieldType, INFOFIELD_ITERATOR);
             chooseCompareIndexInfoToIterator(backendIndexInfo, infoField->fieldValue.iteratorValue);
@@ -514,6 +532,10 @@ void compareTieredIndexInfoToIterator(VecSimIndexDebugInfo info,
             ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
             ASSERT_EQ(infoField->fieldValue.uintegerValue,
                       info.tieredInfo.specificTieredBackendInfo.svsTieredInfo.updateJobWaitTime);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::SHARED_MEMORY_STRING)) {
+            // Process-wide shared allocation appended by VecSimIndex_DebugInfoIterator.
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, VecSim_GetSharedMemory());
         } else {
             FAIL();
         }
@@ -522,20 +544,28 @@ void compareTieredIndexInfoToIterator(VecSimIndexDebugInfo info,
 
 static void chooseCompareIndexInfoToIterator(VecSimIndexDebugInfo info,
                                              VecSimDebugInfoIterator *infoIter) {
+    // These are nested C++ iterators (not from the C API), so SHARED_MEMORY is
+    // not appended — pass expect_shared_memory=false.
     switch (info.commonInfo.basicInfo.algo) {
     case VecSimAlgo_HNSWLIB:
-        compareHNSWIndexInfoToIterator(info, infoIter);
+        compareHNSWIndexInfoToIterator(info, infoIter, /*expect_shared_memory=*/false);
         break;
+#if HAVE_SVS
     case VecSimAlgo_SVS:
-        compareSVSIndexInfoToIterator(info, infoIter);
+        compareSVSIndexInfoToIterator(info, infoIter, /*expect_shared_memory=*/false);
         break;
+#endif
     default:
         FAIL();
     }
 }
 
-void compareSVSIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter) {
-    ASSERT_EQ(DebugInfoIteratorFieldCount::SVS, VecSimDebugInfoIterator_NumberOfFields(infoIter));
+#if HAVE_SVS
+void compareSVSIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter,
+                                   bool expect_shared_memory) {
+    size_t extra = expect_shared_memory ? 1 : 0;
+    ASSERT_EQ(DebugInfoIteratorFieldCount::SVS + extra,
+              VecSimDebugInfoIterator_NumberOfFields(infoIter));
     while (VecSimDebugInfoIterator_HasNextField(infoIter)) {
         VecSim_InfoField *infoField = VecSimDebugInfoIterator_NextField(infoIter);
         if (!strcmp(infoField->fieldName, VecSimCommonStrings::ALGORITHM_STRING)) {
@@ -643,11 +673,17 @@ void compareSVSIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIte
             // SVS epsilon parameter.
             ASSERT_EQ(infoField->fieldType, INFOFIELD_FLOAT64);
             ASSERT_EQ(infoField->fieldValue.floatingPointValue, info.svsInfo.epsilon);
+        } else if (!strcmp(infoField->fieldName, VecSimCommonStrings::SHARED_MEMORY_STRING)) {
+            // Process-wide shared allocation appended by VecSimIndex_DebugInfoIterator.
+            ASSERT_TRUE(expect_shared_memory);
+            ASSERT_EQ(infoField->fieldType, INFOFIELD_UINT64);
+            ASSERT_EQ(infoField->fieldValue.uintegerValue, VecSim_GetSharedMemory());
         } else {
             FAIL();
         }
     }
 }
+#endif // HAVE_SVS
 
 size_t getLabelsLookupNodeSize() {
     std::shared_ptr<VecSimAllocator> allocator = VecSimAllocator::newVecsimAllocator();
@@ -733,16 +769,19 @@ std::vector<std::string> getCommonFields() {
     };
 }
 
+// Each of these field-list functions mirrors the output of VecSimIndex_DebugInfoIterator (C API),
+// which appends SHARED_MEMORY after the algorithm's own debugInfoIterator() output.
 std::vector<std::string> getFlatFields() {
     std::vector<std::string> fields;
     fields.push_back(VecSimCommonStrings::ALGORITHM_STRING); // ALGORITHM
     auto commonFields = getCommonFields();
     fields.insert(fields.end(), commonFields.begin(), commonFields.end());
     fields.push_back(VecSimCommonStrings::BLOCK_SIZE_STRING); // BLOCK_SIZE
+    fields.push_back(VecSimCommonStrings::SHARED_MEMORY_STRING);
     return fields;
 }
 
-// Imitates HNSWIndex<DataType, DistType>::debugInfoIterator()
+// Imitates HNSWIndex<DataType, DistType>::debugInfoIterator() + C API SHARED_MEMORY field.
 std::vector<std::string> getHNSWFields() {
     std::vector<std::string> fields;
     fields.push_back(VecSimCommonStrings::ALGORITHM_STRING); // ALGORITHM
@@ -757,10 +796,11 @@ std::vector<std::string> getHNSWFields() {
     fields.push_back(VecSimCommonStrings::HNSW_ENTRYPOINT);
     fields.push_back(VecSimCommonStrings::EPSILON_STRING);
     fields.push_back(VecSimCommonStrings::NUM_MARKED_DELETED);
+    fields.push_back(VecSimCommonStrings::SHARED_MEMORY_STRING);
     return fields;
 }
 
-// Imitates SVSIndex<DataType, DistType>::debugInfoIterator()
+// Imitates SVSIndex<DataType, DistType>::debugInfoIterator() + C API SHARED_MEMORY field.
 std::vector<std::string> getSVSFields() {
     std::vector<std::string> fields;
     fields.push_back(VecSimCommonStrings::ALGORITHM_STRING); // ALGORITHM
@@ -782,6 +822,7 @@ std::vector<std::string> getSVSFields() {
     fields.push_back(VecSimCommonStrings::SVS_SEARCH_BC_STRING);
     fields.push_back(VecSimCommonStrings::SVS_LEANVEC_DIM_STRING);
     fields.push_back(VecSimCommonStrings::EPSILON_STRING);
+    fields.push_back(VecSimCommonStrings::SHARED_MEMORY_STRING);
     return fields;
 }
 
@@ -801,28 +842,25 @@ std::vector<std::string> getTieredCommonFields() {
     return fields;
 }
 
-// Imitates TieredSVSIndex<DataType, DistType>::debugInfoIterator()
+// Imitates TieredSVSIndex<DataType, DistType>::debugInfoIterator() + C API SHARED_MEMORY field.
 std::vector<std::string> getTieredSVSFields() {
     auto fields = getTieredCommonFields();
     // Add SVS tiered-specific fields:
-    fields.push_back(
-        VecSimCommonStrings::TIERED_SVS_TRAINING_THRESHOLD_STRING); // 15.
-                                                                    // TIERED_SVS_TRAINING_THRESHOLD
-    fields.push_back(
-        VecSimCommonStrings::TIERED_SVS_UPDATE_THRESHOLD_STRING); // 16. TIERED_SVS_UPDATE_THRESHOLD
-    fields.push_back(
-        VecSimCommonStrings::
-            TIERED_SVS_THREADS_RESERVE_TIMEOUT_STRING); // 17. TIERED_SVS_THREADS_RESERVE_TIMEOUT
+    fields.push_back(VecSimCommonStrings::TIERED_SVS_TRAINING_THRESHOLD_STRING);
+    fields.push_back(VecSimCommonStrings::TIERED_SVS_UPDATE_THRESHOLD_STRING);
+    fields.push_back(VecSimCommonStrings::TIERED_SVS_THREADS_RESERVE_TIMEOUT_STRING);
+    fields.push_back(VecSimCommonStrings::SHARED_MEMORY_STRING);
     return fields;
 }
 
-// Imitates TieredHNSWIndex<DataType, DistType>::debugInfoIterator()
+// Imitates TieredHNSWIndex<DataType, DistType>::debugInfoIterator() + C API SHARED_MEMORY field.
 std::vector<std::string> getTieredHNSWFields() {
     auto fields = getTieredCommonFields();
     // Add HNSW tiered-specific field:
     fields.push_back(
         VecSimCommonStrings::
             TIERED_HNSW_SWAP_JOBS_THRESHOLD_STRING); // 15. TIERED_HNSW_SWAP_JOBS_THRESHOLD
+    fields.push_back(VecSimCommonStrings::SHARED_MEMORY_STRING);
     return fields;
 }
 

--- a/tests/unit/unit_test_utils.h
+++ b/tests/unit/unit_test_utils.h
@@ -169,16 +169,25 @@ void compareSVSInfo(svsInfoStruct info1, svsInfoStruct info2);
 
 void validateSVSIndexAttributesInfo(svsInfoStruct info, SVSParams params);
 
-void compareFlatIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter);
+// When called with a C API iterator (VecSimIndex_DebugInfoIterator), pass the
+// default expect_shared_memory=true so the SHARED_MEMORY field is accounted for.
+// Pass false when comparing nested sub-iterators built by the C++ debugInfoIterator()
+// method directly (e.g. inside compareTieredIndexInfoToIterator).
+void compareFlatIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter,
+                                    bool expect_shared_memory = true);
 
-void compareHNSWIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter);
+void compareHNSWIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter,
+                                    bool expect_shared_memory = true);
 
 void compareTieredIndexInfoToIterator(VecSimIndexDebugInfo info,
                                       VecSimIndexDebugInfo frontendIndexInfo,
                                       VecSimIndexDebugInfo backendIndexInfo,
                                       VecSimDebugInfoIterator *infoIterator);
 
-void compareSVSIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter);
+#if HAVE_SVS
+void compareSVSIndexInfoToIterator(VecSimIndexDebugInfo info, VecSimDebugInfoIterator *infoIter,
+                                   bool expect_shared_memory = true);
+#endif
 
 void runRangeQueryTest(VecSimIndex *index, const void *query, double radius,
                        const std::function<void(size_t, double, size_t)> &ResCB,


### PR DESCRIPTION
**Describe the changes in the pull request**

Backport of the SVS shared thread pool to the `8.4` branch. With this change all SVS indexes share a single pool sized to the RediSearch worker pool (N threads total), with a rental-based execution model.

Four clean cherry-picks from `main` (no code changes needed):

1. #925 — `fa1518d8` refactor: SVS shared thread pool with rental model (the fix)
2. #972 — `bbaa34a0` track shared pool memory (textual dependency of #971)
3. #971 — `947a37b7` lazy pool initialization — no OS threads spawned until the first SVS index attaches, so deployments without SVS indexes see no new threads
4. #979 — `0b975a1e` report 0 shared memory until first index attaches

**Which issues this PR fixes**
1. MOD-17090 (backport ticket)
2. Original work: MOD-9881, MOD-15578, MOD-15579

**Main objects this PR modified**
1. `src/VecSim/algorithms/svs/svs_utils.h` — shared `VecSimSVSThreadPoolImpl` singleton, rental model, lazy init, deferred resize
2. `src/VecSim/algorithms/svs/svs.h`, `svs_tiered.h` — `setParallelism`/`getParallelism`/`getPoolSize`, scheduled-job reservation protocol
3. `src/VecSim/vec_sim.cpp/.h`, `vec_sim_common.h` — new C API `VecSim_UpdateThreadPoolSize()`, `VecSim_GetSharedMemory()`

**Mark if applicable**

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

---

Validation: full unit suite on this branch — 1927 tests, 0 failures (includes new `test_svs_threadpool.cpp` suite: resize grow/shrink, shrink-while-rented, scheduled-job deferred shrink, lazy init). Same 4-commit chain and validation approach as the already-merged [8.6 backport](https://github.com/RedisAI/VectorSimilarity/pull/998).

**Merge note:** please **rebase-merge** (not squash) — the 4 commits are individual cherry-picks from `main`, each carrying its `(cherry picked from ...)` line for traceability on the release branch.

Companion RediSearch backport (submodule bump + worker-pool integration, RediSearch#8956) follows after this merges: targets `8.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core SVS/tiered concurrency, global thread lifecycle, and public C API; incorrect rental or deferred resize could cause crashes, deadlocks, or thread over-subscription in production.
> 
> **Overview**
> **SVS threading moves from per-index pools to a process-wide shared pool** sized via **`VecSim_UpdateThreadPoolSize()`** (replaces **`SVSParams.num_threads`**, which now logs a deprecation warning). Per-index **`setParallelism` / `getParallelism`** and **`getPoolSize()`** replace **`setNumThreads` / `getNumThreads` / `getThreadPoolCapacity`**.
> 
> The pool uses a **rental model** (`ThreadSlot` occupancy, `RentedThreads` RAII): workers are rented for **`parallel_for`**, with **lazy OS thread spawn** on first index attach and **deferred shrink** while scheduled tiered jobs hold reservations (`beginScheduledJob` / `endScheduledJob`, `createScheduledJobs`).
> 
> **New C API:** **`VecSim_GetSharedMemory()`** and a **`SHARED_MEMORY`** debug field on **`VecSimIndex_DebugInfoIterator`** so shared pool bytes are not double-counted in per-index stats. **`VecSim_UpdateThreadPoolSize(0)`** sets write-in-place mode; **`>0`** sets async and resizes the pool.
> 
> Tests and benchmarks updated; **`test_svs_threadpool.cpp`** covers resize, deferred shrink, and concurrent rental.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b975a1ea55044c6dece064cb8b87119370905a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->