### PR TITLE
[MOD-14956] Add SQ8 quantization support for HNSW index

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -118,6 +118,11 @@ public:
     int addVector(const void *vector_data, labelType label) override;
     vecsim_stl::vector<idType> markDelete(labelType label) override;
     double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
+        // See the note in hnsw_single.h: a quantized index cannot answer a raw-blob distance query
+        // without reading past the caller's vector.
+        if (this->isQuantized) {
+            return INVALID_SCORE;
+        }
         return getDistanceFromInternal(label, vector_data);
     }
     int removeLabel(labelType label) override { return labelLookup.erase(label); }

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -118,9 +118,9 @@ public:
     int addVector(const void *vector_data, labelType label) override;
     vecsim_stl::vector<idType> markDelete(labelType label) override;
     double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
-        // Raw queries lack the metadata required by quantized distance kernels.
         if (this->isQuantized) {
-            return INVALID_SCORE;
+            auto processed_query = this->preprocessQuery(vector_data);
+            return getDistanceFromInternal(label, processed_query.get());
         }
         return getDistanceFromInternal(label, vector_data);
     }

--- a/src/VecSim/algorithms/hnsw/hnsw_multi.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_multi.h
@@ -118,8 +118,7 @@ public:
     int addVector(const void *vector_data, labelType label) override;
     vecsim_stl::vector<idType> markDelete(labelType label) override;
     double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
-        // See the note in hnsw_single.h: a quantized index cannot answer a raw-blob distance query
-        // without reading past the caller's vector.
+        // Raw queries lack the metadata required by quantized distance kernels.
         if (this->isQuantized) {
             return INVALID_SCORE;
         }

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer.cpp
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer.cpp
@@ -30,6 +30,7 @@ HNSWSerializer::EncodingVersion HNSWSerializer::ReadVersion(std::ifstream &input
 }
 
 void HNSWSerializer::saveIndex(const std::string &location) {
+    validateSave();
     EncodingVersion version = EncodingVersion::V4;
     std::ofstream output(location, std::ios::binary);
     writeBinaryPOD(output, version);

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer.h
@@ -37,5 +37,6 @@ protected:
     EncodingVersion m_version;
 
 private:
+    virtual void validateSave() const = 0;
     void saveIndexFields(std::ofstream &output) const = 0;
 };

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer_declarations.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer_declarations.h
@@ -27,6 +27,7 @@ void restoreGraph(std::ifstream &input, HNSWSerializer::EncodingVersion version)
 
 private:
 // Functions for index saving.
+void validateSave() const override;
 void saveIndexFields(std::ofstream &output) const override;
 
 void saveGraph(std::ofstream &output) const;

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
@@ -41,6 +41,17 @@ HNSWIndex<DataType, DistType>::HNSWIndex(std::ifstream &input, const HNSWParams 
 
 template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::saveIndexIMP(std::ofstream &output) {
+    // The V4 format records type, dim and metric, but neither quantType nor the mean vector, and
+    // the loading path always builds unquantized components. A saved quantized index would
+    // therefore reload with the wrong stride and consume graph bytes as vector data. Refuse instead
+    // of emitting a file that cannot be decoded. Note the caller has already written the encoding
+    // version by this point, so a rejected save leaves a stub file behind; that still fails closed
+    // on load, unlike a full file with a layout the loader misreads. MOD-14957 adds SQ8
+    // serialization.
+    if (this->isQuantized) {
+        throw std::runtime_error(
+            "Cannot save index: serialization of quantized indexes is not supported");
+    }
     this->saveIndexFields(output);
     this->saveGraph(output);
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
@@ -40,15 +40,17 @@ HNSWIndex<DataType, DistType>::HNSWIndex(std::ifstream &input, const HNSWParams 
 }
 
 template <typename DataType, typename DistType>
-void HNSWIndex<DataType, DistType>::saveIndexIMP(std::ofstream &output) {
+void HNSWIndex<DataType, DistType>::validateSave() const {
     // V4 does not store quantization settings, and its loader always creates unquantized
-    // components. Reject the save rather than write a file the loader would misread. This check
-    // currently runs after the destination is opened and truncated; move it before opening the file
-    // when adding quantized serialization.
+    // components. Reject the save rather than write a file the loader would misread.
     if (this->isQuantized) {
         throw std::runtime_error(
             "Cannot save index: serialization of quantized indexes is not supported");
     }
+}
+
+template <typename DataType, typename DistType>
+void HNSWIndex<DataType, DistType>::saveIndexIMP(std::ofstream &output) {
     this->saveIndexFields(output);
     this->saveGraph(output);
 }

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
@@ -45,9 +45,9 @@ void HNSWIndex<DataType, DistType>::saveIndexIMP(std::ofstream &output) {
     // the loading path always builds unquantized components. A saved quantized index would
     // therefore reload with the wrong stride and consume graph bytes as vector data. Refuse instead
     // of emitting a file that cannot be decoded. Note the caller has already written the encoding
-    // version by this point, so a rejected save leaves a stub file behind; that still fails closed
-    // on load, unlike a full file with a layout the loader misreads. MOD-14957 adds SQ8
-    // serialization.
+    // version by this point, so a rejected save leaves a stub file behind, and worse, it has
+    // already truncated whatever was at that path. Both are tracked separately; whoever adds
+    // quantized serialization should move this check ahead of the file being opened.
     if (this->isQuantized) {
         throw std::runtime_error(
             "Cannot save index: serialization of quantized indexes is not supported");

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
@@ -41,13 +41,10 @@ HNSWIndex<DataType, DistType>::HNSWIndex(std::ifstream &input, const HNSWParams 
 
 template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::saveIndexIMP(std::ofstream &output) {
-    // The V4 format records type, dim and metric, but neither quantType nor the mean vector, and
-    // the loading path always builds unquantized components. A saved quantized index would
-    // therefore reload with the wrong stride and consume graph bytes as vector data. Refuse instead
-    // of emitting a file that cannot be decoded. Note the caller has already written the encoding
-    // version by this point, so a rejected save leaves a stub file behind, and worse, it has
-    // already truncated whatever was at that path. Both are tracked separately; whoever adds
-    // quantized serialization should move this check ahead of the file being opened.
+    // V4 does not store quantization settings, and its loader always creates unquantized
+    // components. Reject the save rather than write a file the loader would misread. This check
+    // currently runs after the destination is opened and truncated; move it before opening the file
+    // when adding quantized serialization.
     if (this->isQuantized) {
         throw std::runtime_error(
             "Cannot save index: serialization of quantized indexes is not supported");

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -88,9 +88,9 @@ public:
     int addVector(const void *vector_data, labelType label) override;
     vecsim_stl::vector<idType> markDelete(labelType label) override;
     double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
-        // Raw queries lack the metadata required by quantized distance kernels.
         if (this->isQuantized) {
-            return INVALID_SCORE;
+            auto processed_query = this->preprocessQuery(vector_data);
+            return getDistanceFromInternal(label, processed_query.get());
         }
         return getDistanceFromInternal(label, vector_data);
     }

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -90,8 +90,9 @@ public:
     double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
         // The public API documents vector_data as a raw dim-by-type vector, but a quantized index's
         // kernels read query metadata appended past that, so honouring the documented contract here
-        // would read out of bounds. There is no public API for producing a quantized query blob;
-        // MOD-14958 owns that decision. Report "no answer" rather than read past the caller's blob.
+        // would read out of bounds. There is no public API for producing a quantized query blob,
+        // and adding one is a separate decision. Report "no answer" rather than read past the
+        // caller's blob. See the note on VecSimIndex_GetDistanceFrom_Unsafe in vec_sim.h.
         if (this->isQuantized) {
             return INVALID_SCORE;
         }

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -88,6 +88,13 @@ public:
     int addVector(const void *vector_data, labelType label) override;
     vecsim_stl::vector<idType> markDelete(labelType label) override;
     double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
+        // The public API documents vector_data as a raw dim-by-type vector, but a quantized index's
+        // kernels read query metadata appended past that, so honouring the documented contract here
+        // would read out of bounds. There is no public API for producing a quantized query blob;
+        // MOD-14958 owns that decision. Report "no answer" rather than read past the caller's blob.
+        if (this->isQuantized) {
+            return INVALID_SCORE;
+        }
         return getDistanceFromInternal(label, vector_data);
     }
     int removeLabel(labelType label) override { return labelLookup.erase(label); }

--- a/src/VecSim/algorithms/hnsw/hnsw_single.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_single.h
@@ -88,11 +88,7 @@ public:
     int addVector(const void *vector_data, labelType label) override;
     vecsim_stl::vector<idType> markDelete(labelType label) override;
     double getDistanceFrom_Unsafe(labelType label, const void *vector_data) const override {
-        // The public API documents vector_data as a raw dim-by-type vector, but a quantized index's
-        // kernels read query metadata appended past that, so honouring the documented contract here
-        // would read out of bounds. There is no public API for producing a quantized query blob,
-        // and adding one is a separate decision. Report "no answer" rather than read past the
-        // caller's blob. See the note on VecSimIndex_GetDistanceFrom_Unsafe in vec_sim.h.
+        // Raw queries lack the metadata required by quantized distance kernels.
         if (this->isQuantized) {
             return INVALID_SCORE;
         }

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -17,6 +17,7 @@
 
 using bfloat16 = vecsim_types::bfloat16;
 using float16 = vecsim_types::float16;
+using sq8 = vecsim_types::sq8;
 
 namespace HNSWFactory {
 
@@ -34,10 +35,116 @@ NewIndex_ChooseMultiOrSingle(const HNSWParams *params,
             HNSWIndex_Single<DataType, DistType>(params, abstractInitParams, components);
 }
 
+template <VecSimMetric Metric>
+size_t GetSQ8StoredDataSize(size_t dim, bool with_norm) {
+    static_assert(Metric == VecSimMetric_L2 || Metric == VecSimMetric_IP);
+
+    const auto metadata_count = with_norm ? sq8::storage_metadata_count<Metric, true>()
+                                          : sq8::storage_metadata_count<Metric, false>();
+
+    return dim + metadata_count * sizeof(float);
+}
+
+// Helper to build an SQ8-quantized HNSW index given compile-time DataType and Metric.
+template <typename DataType, VecSimMetric Metric>
+VecSimIndex *NewIndex_SQ8(const HNSWParams *hnswParams, AbstractIndexInitParams abstractInitParams,
+                          const float *mean_ptr) {
+    auto &allocator = abstractInitParams.allocator;
+    size_t dim = abstractInitParams.dim;
+    unsigned char storage_alignment = 0, asym_storage_alignment = 0, query_alignment = 0;
+    bool with_norm = mean_ptr != nullptr;
+
+    // Override blob size for the SQ8 storage layout.
+    abstractInitParams.storedDataSize = GetSQ8StoredDataSize<Metric>(dim, with_norm);
+
+    // Symmetric: both stored vectors are SQ8 blobs.
+    auto sym_func = spaces::GetDistFunc<sq8, float>(Metric, dim, &storage_alignment);
+    // Asymmetric: stored vector is SQ8 blob, query is DataType.
+    auto asym_func =
+        spaces::GetDistFunc<sq8, float, DataType>(Metric, dim, &asym_storage_alignment);
+    storage_alignment = spaces::combineAlignments(storage_alignment, asym_storage_alignment);
+    spaces::GetDistFunc<DataType, float>(Metric, dim, &query_alignment);
+
+    if (!with_norm) {
+        // plain SQ8 quantization without mean centering.
+        auto *pp = new (allocator) QuantPreprocessor<DataType, Metric>(allocator, dim);
+        auto *container = new (allocator)
+            MultiPreprocessorsContainer<DataType, 1>(allocator, query_alignment, storage_alignment);
+        [[maybe_unused]] int ret = container->addPreprocessor(pp);
+        assert(ret == 0 && "SQ8 preprocessor was not added correctly");
+
+        // sym_func for storage-storage; asym_func for query-storage.
+        auto *calc =
+            new (allocator) DistanceCalculatorCommon<float>(allocator, sym_func, asym_func);
+
+        IndexComponents<DataType, float> components{calc, container};
+        return NewIndex_ChooseMultiOrSingle<DataType, float>(hnswParams, abstractInitParams,
+                                                             components);
+    }
+
+    // With norm: mean-centered SQ8 quantization with norm correction.
+    vecsim_stl::vector<float> mean_vec(dim, 0.0f, allocator);
+    memcpy(mean_vec.data(), mean_ptr, dim * sizeof(float));
+
+    float mean_sum_squares = 0.0f;
+    for (float v : mean_vec) {
+        mean_sum_squares += v * v;
+    }
+
+    auto *pp = new (allocator) QuantPreprocessor<DataType, Metric, true>(allocator, dim, mean_vec);
+    auto *container = new (allocator)
+        MultiPreprocessorsContainer<DataType, 1>(allocator, query_alignment, storage_alignment);
+    [[maybe_unused]] int ret = container->addPreprocessor(pp);
+    assert(ret == 0 && "SQ8 preprocessor was not added correctly");
+
+    auto *calc = new (allocator) DistanceCalculatorWithNorm<DataType, float, Metric>(
+        allocator, asym_func, sym_func, mean_sum_squares);
+
+    IndexComponents<DataType, float> components{calc, container};
+    return NewIndex_ChooseMultiOrSingle<DataType, float>(hnswParams, abstractInitParams,
+                                                         components);
+}
+
 VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
     const HNSWParams *hnswParams = &params->algoParams.hnswParams;
+
     AbstractIndexInitParams abstractInitParams =
         VecSimFactory::NewAbstractInitParams(hnswParams, params->logCtx, is_normalized);
+
+    if (hnswParams->quantType == VecSimQuant_SQ8) {
+        if (hnswParams->type != VecSimType_FLOAT32 && hnswParams->type != VecSimType_FLOAT16) {
+            return NULL; // SQ8 supports FP32 and FP16 only.
+        }
+
+        VecSimMetric metric = hnswParams->metric;
+        if (is_normalized && metric == VecSimMetric_Cosine) {
+            metric = VecSimMetric_IP;
+        }
+
+        if (metric == VecSimMetric_Cosine) {
+            return NULL; // SQ8 does not support cosine metric.
+        }
+
+        const float *mean_ptr = static_cast<const float *>(hnswParams->quantParams);
+
+        if (hnswParams->type == VecSimType_FLOAT32) {
+            if (metric == VecSimMetric_L2) {
+                return NewIndex_SQ8<float, VecSimMetric_L2>(hnswParams, abstractInitParams,
+                                                            mean_ptr);
+            } else if (metric == VecSimMetric_IP) {
+                return NewIndex_SQ8<float, VecSimMetric_IP>(hnswParams, abstractInitParams,
+                                                            mean_ptr);
+            }
+        } else if (hnswParams->type == VecSimType_FLOAT16) {
+            if (metric == VecSimMetric_L2) {
+                return NewIndex_SQ8<float16, VecSimMetric_L2>(hnswParams, abstractInitParams,
+                                                              mean_ptr);
+            } else if (metric == VecSimMetric_IP) {
+                return NewIndex_SQ8<float16, VecSimMetric_IP>(hnswParams, abstractInitParams,
+                                                              mean_ptr);
+            }
+        }
+    }
 
     if (hnswParams->type == VecSimType_FLOAT32) {
         IndexComponents<float, float> indexComponents = CreateIndexComponents<float, float>(
@@ -94,7 +201,27 @@ size_t EstimateInitialSize(const HNSWParams *params, bool is_normalized) {
     size_t allocations_overhead = VecSimAllocator::getAllocationOverheadSize();
 
     size_t est = sizeof(VecSimAllocator) + allocations_overhead;
-    if (params->type == VecSimType_FLOAT32) {
+
+    if (params->quantType == VecSimQuant_SQ8) {
+        if (params->type != VecSimType_FLOAT32 && params->type != VecSimType_FLOAT16) {
+            throw std::invalid_argument("Invalid params->type for VecSimQuant_SQ8");
+        }
+        // Calculator + preprocessor container + preprocessor.
+        // Use representative types; sizeof is independent of the template parameters.
+        if (params->quantParams) { // mean provided, WithNorm = true
+            est += allocations_overhead +
+                   sizeof(DistanceCalculatorWithNorm<float, float, VecSimMetric_L2>);
+            est += allocations_overhead + sizeof(MultiPreprocessorsContainer<float, 1>);
+            est += allocations_overhead + sizeof(QuantPreprocessor<float, VecSimMetric_L2, true>);
+            est += allocations_overhead +
+                   params->dim * sizeof(float); // mean vector in QuantPreprocessor
+        } else {
+            est += allocations_overhead + sizeof(DistanceCalculatorCommon<float>);
+            est += allocations_overhead + sizeof(MultiPreprocessorsContainer<float, 1>);
+            est += allocations_overhead + sizeof(QuantPreprocessor<float, VecSimMetric_L2>);
+        }
+        est += EstimateInitialSize_ChooseMultiOrSingle<float>(params->multi);
+    } else if (params->type == VecSimType_FLOAT32) {
         est += EstimateComponentsMemory<float, float>(params->metric, is_normalized);
         est += EstimateInitialSize_ChooseMultiOrSingle<float>(params->multi);
     } else if (params->type == VecSimType_FLOAT64) {
@@ -125,9 +252,20 @@ size_t EstimateElementSize(const HNSWParams *params) {
     size_t M = (params->M) ? params->M : HNSW_DEFAULT_M;
     size_t elementGraphDataSize = sizeof(ElementGraphData) + sizeof(idType) * M * 2;
 
-    size_t size_total_data_per_element =
-        elementGraphDataSize +
-        VecSimParams_GetStoredDataSize(params->type, params->dim, params->metric);
+    size_t stored_data_size;
+    if (params->quantType == VecSimQuant_SQ8) {
+        bool with_norm = params->quantParams != nullptr;
+        if (params->metric == VecSimMetric_L2) {
+            stored_data_size = GetSQ8StoredDataSize<VecSimMetric_L2>(params->dim, with_norm);
+        } else {
+            stored_data_size = GetSQ8StoredDataSize<VecSimMetric_IP>(params->dim, with_norm);
+        }
+    } else {
+        stored_data_size =
+            VecSimParams_GetStoredDataSize(params->type, params->dim, params->metric);
+    }
+
+    size_t size_total_data_per_element = elementGraphDataSize + stored_data_size;
 
     // when reserving space for new labels in the lookup hash table, each entry is a pointer to a
     // label node (bucket).

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -56,6 +56,38 @@ template <typename DataType>
     return alignment;
 }
 
+// The metric the SQ8 components are actually built for. A Cosine index whose blobs are already
+// normalized by someone else (the frontend of a tiered index) is built as IP.
+[[nodiscard]] constexpr VecSimMetric ResolveSQ8Metric(VecSimMetric metric, bool is_normalized) {
+    return (is_normalized && metric == VecSimMetric_Cosine) ? VecSimMetric_IP : metric;
+}
+
+// Single definition of the SQ8 parameter combinations this factory can build, taking the metric
+// already resolved by ResolveSQ8Metric. NewIndex fails closed when this returns false, and
+// EstimateInitialSize rejects the same set, so it cannot report a size for parameters that cannot
+// produce an index.
+[[nodiscard]] constexpr bool SQ8ParamsSupported(VecSimType type, VecSimMetric resolved_metric,
+                                                bool with_mean) {
+    // Kernels exist for FP32 and FP16 sources only.
+    if (type != VecSimType_FLOAT32 && type != VecSimType_FLOAT16) {
+        return false;
+    }
+    // Cosine needs a normalization step the SQ8 preprocessor does not perform.
+    if (resolved_metric == VecSimMetric_Cosine) {
+        return false;
+    }
+    // Mean-centred FP16 L2 loses correctness: QuantPreprocessor centres the query and narrows the
+    // result back into the FP16 query body, while storage keeps its centred min/delta in FP32. The
+    // two then disagree, so an identical vector and query pair yields a non-zero distance (mean
+    // 10000 gives a per-component error of 1.0), and a large enough mean overflows FP16 to
+    // infinity. Enabling this needs an asymmetric kernel that takes an FP32 centred query. Only the
+    // WithNorm && L2 branch centres the query, so FP16 with a mean and IP is unaffected.
+    if (type == VecSimType_FLOAT16 && with_mean && resolved_metric == VecSimMetric_L2) {
+        return false;
+    }
+    return true;
+}
+
 // Helper to build an SQ8-quantized HNSW index given compile-time DataType and Metric.
 template <typename DataType, VecSimMetric Metric>
 VecSimIndex *NewIndex_SQ8(const HNSWParams *hnswParams, AbstractIndexInitParams abstractInitParams,
@@ -117,30 +149,20 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
     AbstractIndexInitParams abstractInitParams =
         VecSimFactory::NewAbstractInitParams(hnswParams, params->logCtx, is_normalized);
 
-    if (hnswParams->quantType == VecSimQuant_SQ8) {
-        if (hnswParams->type != VecSimType_FLOAT32 && hnswParams->type != VecSimType_FLOAT16) {
-            return NULL; // SQ8 supports FP32 and FP16 only.
+    if (hnswParams->quantType != VecSimQuant_NONE) {
+        // Any quantization type this factory does not implement must fail closed. Falling through
+        // to the plain path below would silently build a full-precision index for a caller that
+        // asked for a quantized one. Unreachable while VecSimQuantType holds only NONE and SQ8, and
+        // not covered by a test because forming an out-of-range enumerator is undefined behaviour;
+        // the guard is what keeps adding SQ4 to the enum from becoming a silent fallthrough.
+        if (hnswParams->quantType != VecSimQuant_SQ8) {
+            return NULL;
         }
 
-        VecSimMetric metric = hnswParams->metric;
-        if (is_normalized && metric == VecSimMetric_Cosine) {
-            metric = VecSimMetric_IP;
-        }
-
-        if (metric == VecSimMetric_Cosine) {
-            return NULL; // SQ8 does not support cosine metric.
-        }
-
+        const VecSimMetric metric = ResolveSQ8Metric(hnswParams->metric, is_normalized);
         const float *mean_ptr = static_cast<const float *>(hnswParams->quantParams);
 
-        // Mean-centred FP16 L2 is not supported: QuantPreprocessor centres the query and narrows
-        // the result back into the FP16 query body, while storage keeps its centred min/delta in
-        // FP32. The two then disagree, so an identical vector and query pair yields a non-zero
-        // distance (mean 10000 gives a per-component error of 1.0), and a large enough mean
-        // overflows FP16 to infinity. Enabling this needs an asymmetric kernel that takes an FP32
-        // centred query.
-        if (hnswParams->type == VecSimType_FLOAT16 && mean_ptr != nullptr &&
-            metric == VecSimMetric_L2) {
+        if (!SQ8ParamsSupported(hnswParams->type, metric, mean_ptr != nullptr)) {
             return NULL;
         }
 
@@ -226,9 +248,13 @@ size_t EstimateInitialSize(const HNSWParams *params, bool is_normalized) {
 
     size_t est = sizeof(VecSimAllocator) + allocations_overhead;
 
-    if (params->quantType == VecSimQuant_SQ8) {
-        if (params->type != VecSimType_FLOAT32 && params->type != VecSimType_FLOAT16) {
-            throw std::invalid_argument("Invalid params->type for VecSimQuant_SQ8");
+    if (params->quantType != VecSimQuant_NONE) {
+        // Reject exactly what NewIndex rejects. Reporting a size for a combination that cannot be
+        // built lets a caller size its capacity from an index it will then fail to create.
+        if (params->quantType != VecSimQuant_SQ8 ||
+            !SQ8ParamsSupported(params->type, ResolveSQ8Metric(params->metric, is_normalized),
+                                params->quantParams != nullptr)) {
+            throw std::invalid_argument("Unsupported quantization params for HNSW index");
         }
         // Calculator + preprocessor container + preprocessor.
         // Use representative types; sizeof is independent of the template parameters.
@@ -277,6 +303,11 @@ size_t EstimateElementSize(const HNSWParams *params) {
     size_t elementGraphDataSize = sizeof(ElementGraphData) + sizeof(idType) * M * 2;
 
     size_t stored_data_size;
+    // Unlike EstimateInitialSize, this does not reject unsupported combinations: the return type is
+    // size_t with no sentinel, and VecSimIndex_EstimateElementSize is extern "C", so throwing here
+    // would carry an exception into the C host. It therefore answers for whatever params it is
+    // handed, exactly as VecSimParams_GetStoredDataSize does on the unquantized path. Index
+    // creation is the boundary that enforces the supported set (see SQ8ParamsSupported).
     if (params->quantType == VecSimQuant_SQ8) {
         bool with_norm = params->quantParams != nullptr;
         if (params->metric == VecSimMetric_L2) {

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -36,13 +36,24 @@ NewIndex_ChooseMultiOrSingle(const HNSWParams *params,
 }
 
 template <VecSimMetric Metric>
-size_t GetSQ8StoredDataSize(size_t dim, bool with_norm) {
+[[nodiscard]] constexpr size_t GetSQ8StoredDataSize(size_t dim, bool with_norm) {
     static_assert(Metric == VecSimMetric_L2 || Metric == VecSimMetric_IP);
 
-    const auto metadata_count = with_norm ? sq8::storage_metadata_count<Metric, true>()
-                                          : sq8::storage_metadata_count<Metric, false>();
+    // WithNorm is a template parameter, so dispatch the runtime flag to the two instantiations.
+    return with_norm ? sq8::storage_bytes_count<Metric, true>(dim)
+                     : sq8::storage_bytes_count<Metric, false>(dim);
+}
 
-    return dim + metadata_count * sizeof(float);
+// Alignment required by a query blob of type DataType. Per the asymmetric-types contract in
+// spaces.h, the hint returned alongside an asymmetric distance function describes its first
+// (storage) operand, so the query side must be obtained from the symmetric dispatcher for the
+// query's own type. Only that hint is wanted here, never the function it returns, so the call is
+// contained in this adapter instead of leaving a discarded value at the call site.
+template <typename DataType>
+[[nodiscard]] unsigned char GetQueryAlignment(VecSimMetric metric, size_t dim) {
+    unsigned char alignment = 0;
+    spaces::GetDistFunc<DataType, float>(metric, dim, &alignment);
+    return alignment;
 }
 
 // Helper to build an SQ8-quantized HNSW index given compile-time DataType and Metric.
@@ -50,9 +61,9 @@ template <typename DataType, VecSimMetric Metric>
 VecSimIndex *NewIndex_SQ8(const HNSWParams *hnswParams, AbstractIndexInitParams abstractInitParams,
                           const float *mean_ptr) {
     auto &allocator = abstractInitParams.allocator;
-    size_t dim = abstractInitParams.dim;
-    unsigned char storage_alignment = 0, asym_storage_alignment = 0, query_alignment = 0;
-    bool with_norm = mean_ptr != nullptr;
+    const size_t dim = abstractInitParams.dim;
+    const bool with_norm = mean_ptr != nullptr;
+    unsigned char storage_alignment = 0, asym_storage_alignment = 0;
 
     // Override blob size for the SQ8 storage layout.
     abstractInitParams.storedDataSize = GetSQ8StoredDataSize<Metric>(dim, with_norm);
@@ -62,43 +73,38 @@ VecSimIndex *NewIndex_SQ8(const HNSWParams *hnswParams, AbstractIndexInitParams 
     // Asymmetric: stored vector is SQ8 blob, query is DataType.
     auto asym_func =
         spaces::GetDistFunc<sq8, float, DataType>(Metric, dim, &asym_storage_alignment);
+    // Both hints describe the same stored blob, so they must be combined rather than overwritten.
     storage_alignment = spaces::combineAlignments(storage_alignment, asym_storage_alignment);
-    spaces::GetDistFunc<DataType, float>(Metric, dim, &query_alignment);
+    // Queries stay in DataType and are compared against stored blobs by asym_func.
+    const unsigned char query_alignment = GetQueryAlignment<DataType>(Metric, dim);
 
-    if (!with_norm) {
-        // plain SQ8 quantization without mean centering.
-        auto *pp = new (allocator) QuantPreprocessor<DataType, Metric>(allocator, dim);
-        auto *container = new (allocator)
-            MultiPreprocessorsContainer<DataType, 1>(allocator, query_alignment, storage_alignment);
-        [[maybe_unused]] int ret = container->addPreprocessor(pp);
-        assert(ret == 0 && "SQ8 preprocessor was not added correctly");
+    PreprocessorInterface *pp = nullptr;
+    IndexCalculatorInterface<float> *calc = nullptr;
 
+    if (with_norm) {
+        // Mean-centered SQ8 quantization with norm correction.
+        vecsim_stl::vector<float> mean_vec(allocator);
+        mean_vec.assign(mean_ptr, mean_ptr + dim);
+
+        float mean_sum_squares = 0.0f;
+        for (float v : mean_vec) {
+            mean_sum_squares += v * v;
+        }
+
+        pp = new (allocator) QuantPreprocessor<DataType, Metric, true>(allocator, dim, mean_vec);
+        calc = new (allocator) DistanceCalculatorWithNorm<DataType, float, Metric>(
+            allocator, asym_func, sym_func, mean_sum_squares);
+    } else {
+        // Plain SQ8 quantization without mean centering.
+        pp = new (allocator) QuantPreprocessor<DataType, Metric>(allocator, dim);
         // sym_func for storage-storage; asym_func for query-storage.
-        auto *calc =
-            new (allocator) DistanceCalculatorCommon<float>(allocator, sym_func, asym_func);
-
-        IndexComponents<DataType, float> components{calc, container};
-        return NewIndex_ChooseMultiOrSingle<DataType, float>(hnswParams, abstractInitParams,
-                                                             components);
+        calc = new (allocator) DistanceCalculatorCommon<float>(allocator, sym_func, asym_func);
     }
 
-    // With norm: mean-centered SQ8 quantization with norm correction.
-    vecsim_stl::vector<float> mean_vec(dim, 0.0f, allocator);
-    memcpy(mean_vec.data(), mean_ptr, dim * sizeof(float));
-
-    float mean_sum_squares = 0.0f;
-    for (float v : mean_vec) {
-        mean_sum_squares += v * v;
-    }
-
-    auto *pp = new (allocator) QuantPreprocessor<DataType, Metric, true>(allocator, dim, mean_vec);
     auto *container = new (allocator)
         MultiPreprocessorsContainer<DataType, 1>(allocator, query_alignment, storage_alignment);
-    [[maybe_unused]] int ret = container->addPreprocessor(pp);
-    assert(ret == 0 && "SQ8 preprocessor was not added correctly");
-
-    auto *calc = new (allocator) DistanceCalculatorWithNorm<DataType, float, Metric>(
-        allocator, asym_func, sym_func, mean_sum_squares);
+    [[maybe_unused]] const int ret = container->addPreprocessor(pp);
+    assert(ret != -1 && "SQ8 preprocessor was not added correctly");
 
     IndexComponents<DataType, float> components{calc, container};
     return NewIndex_ChooseMultiOrSingle<DataType, float>(hnswParams, abstractInitParams,
@@ -144,6 +150,10 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
                                                               mean_ptr);
             }
         }
+
+        // Unreachable today: the checks above leave only FP32/FP16 x L2/IP. Kept so that adding a
+        // type or metric cannot silently fall through and build an unquantized index instead.
+        return NULL;
     }
 
     if (hnswParams->type == VecSimType_FLOAT32) {

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -39,16 +39,12 @@ template <VecSimMetric Metric>
 [[nodiscard]] constexpr size_t GetSQ8StoredDataSize(size_t dim, bool with_norm) {
     static_assert(Metric == VecSimMetric_L2 || Metric == VecSimMetric_IP);
 
-    // WithNorm is a template parameter, so dispatch the runtime flag to the two instantiations.
     return with_norm ? sq8::storage_bytes_count<Metric, true>(dim)
                      : sq8::storage_bytes_count<Metric, false>(dim);
 }
 
-// Alignment required by a query blob of type DataType. Per the asymmetric-types contract in
-// spaces.h, the hint returned alongside an asymmetric distance function describes its first
-// (storage) operand, so the query side must be obtained from the symmetric dispatcher for the
-// query's own type. Only that hint is wanted here, never the function it returns, so the call is
-// contained in this adapter instead of leaving a discarded value at the call site.
+// Asymmetric dispatch reports alignment for the stored operand only. Ask the query type's
+// dispatcher for the query allocation alignment.
 template <typename DataType>
 [[nodiscard]] unsigned char GetQueryAlignment(VecSimMetric metric, size_t dim) {
     unsigned char alignment = 0;
@@ -56,42 +52,30 @@ template <typename DataType>
     return alignment;
 }
 
-// The metric the SQ8 components are actually built for. A Cosine index whose blobs are already
-// normalized by someone else (the frontend of a tiered index) is built as IP.
+// Cosine over pre-normalized vectors is computed as inner product.
 [[nodiscard]] constexpr VecSimMetric ResolveSQ8Metric(VecSimMetric metric, bool is_normalized) {
     return (is_normalized && metric == VecSimMetric_Cosine) ? VecSimMetric_IP : metric;
 }
 
-// Single definition of the SQ8 parameter combinations this factory can build, taking the metric
-// already resolved by ResolveSQ8Metric. NewIndex fails closed when this returns false, and
-// EstimateInitialSize rejects the same set, so it cannot report a size for parameters that cannot
-// produce an index.
+// Keep construction and initial-size validation in sync.
 [[nodiscard]] constexpr bool SQ8ParamsSupported(VecSimType type, VecSimMetric resolved_metric,
                                                 bool with_mean) {
-    // Kernels exist for FP32 and FP16 sources only.
+    // SQ8 kernels accept only FLOAT32 and FLOAT16 input.
     if (type != VecSimType_FLOAT32 && type != VecSimType_FLOAT16) {
         return false;
     }
-    // Only L2 and IP have SQ8 kernels. Cosine needs a normalization step the SQ8 preprocessor does
-    // not perform, and anything outside the enum has to be rejected here as well: the dispatch in
-    // NewIndex would otherwise fall through to its unreachable-branch assert and abort an
-    // assertions-enabled host, where the unquantized path throws and is caught by VecSimIndex_New.
+    // Only L2 and inner product have SQ8 kernels.
     if (resolved_metric != VecSimMetric_L2 && resolved_metric != VecSimMetric_IP) {
         return false;
     }
-    // Mean-centred FP16 L2 loses correctness: QuantPreprocessor centres the query and narrows the
-    // result back into the FP16 query body, while storage keeps its centred min/delta in FP32. The
-    // two then disagree, so an identical vector and query pair yields a non-zero distance (mean
-    // 10000 gives a per-component error of 1.0), and a large enough mean overflows FP16 to
-    // infinity. Enabling this needs an asymmetric kernel that takes an FP32 centred query. Only the
-    // WithNorm && L2 branch centres the query, so FP16 with a mean and IP is unaffected.
+    // Mean-centered L2 queries are narrowed back to FLOAT16 while the stored metadata remains
+    // FLOAT32. Support requires a kernel that keeps the centered query in FLOAT32.
     if (type == VecSimType_FLOAT16 && with_mean && resolved_metric == VecSimMetric_L2) {
         return false;
     }
     return true;
 }
 
-// Helper to build an SQ8-quantized HNSW index given compile-time DataType and Metric.
 template <typename DataType, VecSimMetric Metric>
 VecSimIndex *NewIndex_SQ8(const HNSWParams *hnswParams, AbstractIndexInitParams abstractInitParams,
                           const float *mean_ptr) {
@@ -100,25 +84,21 @@ VecSimIndex *NewIndex_SQ8(const HNSWParams *hnswParams, AbstractIndexInitParams 
     const bool with_norm = mean_ptr != nullptr;
     unsigned char storage_alignment = 0, asym_storage_alignment = 0;
 
-    // Override blob size for the SQ8 storage layout.
     abstractInitParams.storedDataSize = GetSQ8StoredDataSize<Metric>(dim, with_norm);
     abstractInitParams.isQuantized = true;
 
-    // Symmetric: both stored vectors are SQ8 blobs.
+    // Graph construction compares two stored SQ8 blobs; search compares a stored blob with a
+    // DataType query. Both dispatchers report alignment for the stored operand.
     auto sym_func = spaces::GetDistFunc<sq8, float>(Metric, dim, &storage_alignment);
-    // Asymmetric: stored vector is SQ8 blob, query is DataType.
     auto asym_func =
         spaces::GetDistFunc<sq8, float, DataType>(Metric, dim, &asym_storage_alignment);
-    // Both hints describe the same stored blob, so they must be combined rather than overwritten.
     storage_alignment = spaces::combineAlignments(storage_alignment, asym_storage_alignment);
-    // Queries stay in DataType and are compared against stored blobs by asym_func.
     const unsigned char query_alignment = GetQueryAlignment<DataType>(Metric, dim);
 
     PreprocessorInterface *pp = nullptr;
     IndexCalculatorInterface<float> *calc = nullptr;
 
     if (with_norm) {
-        // Mean-centered SQ8 quantization with norm correction.
         vecsim_stl::vector<float> mean_vec(allocator);
         mean_vec.assign(mean_ptr, mean_ptr + dim);
 
@@ -131,9 +111,7 @@ VecSimIndex *NewIndex_SQ8(const HNSWParams *hnswParams, AbstractIndexInitParams 
         calc = new (allocator) DistanceCalculatorWithNorm<DataType, float, Metric>(
             allocator, asym_func, sym_func, mean_sum_squares);
     } else {
-        // Plain SQ8 quantization without mean centering.
         pp = new (allocator) QuantPreprocessor<DataType, Metric>(allocator, dim);
-        // sym_func for storage-storage; asym_func for query-storage.
         calc = new (allocator) DistanceCalculatorCommon<float>(allocator, sym_func, asym_func);
     }
 
@@ -153,11 +131,7 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
         VecSimFactory::NewAbstractInitParams(hnswParams, params->logCtx, is_normalized);
 
     if (hnswParams->quantType != VecSimQuant_NONE) {
-        // Any quantization type this factory does not implement must fail closed. Falling through
-        // to the plain path below would silently build a full-precision index for a caller that
-        // asked for a quantized one. Unreachable while VecSimQuantType holds only NONE and SQ8, and
-        // not covered by a test because forming an out-of-range enumerator is undefined behaviour;
-        // the guard is what keeps adding SQ4 to the enum from becoming a silent fallthrough.
+        // Reject unknown quantizers instead of silently creating an unquantized index.
         if (hnswParams->quantType != VecSimQuant_SQ8) {
             return NULL;
         }
@@ -187,10 +161,7 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
             }
         }
 
-        // Unreachable today: the checks above leave only FP32/FP16 x L2/IP. The assert makes a
-        // debug build shout if a new type or metric ever reaches here, and the return keeps a
-        // release build failing closed rather than falling through and silently building an
-        // unquantized index instead.
+        // Keep the return for release builds so future dispatch changes cannot fall through.
         assert(false && "unhandled SQ8 data type and metric combination");
         return NULL;
     }
@@ -252,22 +223,19 @@ size_t EstimateInitialSize(const HNSWParams *params, bool is_normalized) {
     size_t est = sizeof(VecSimAllocator) + allocations_overhead;
 
     if (params->quantType != VecSimQuant_NONE) {
-        // Reject exactly what NewIndex rejects. Reporting a size for a combination that cannot be
-        // built lets a caller size its capacity from an index it will then fail to create.
+        // Keep construction and initial-size validation in sync.
         if (params->quantType != VecSimQuant_SQ8 ||
             !SQ8ParamsSupported(params->type, ResolveSQ8Metric(params->metric, is_normalized),
                                 params->quantParams != nullptr)) {
             throw std::invalid_argument("Unsupported quantization params for HNSW index");
         }
-        // Calculator + preprocessor container + preprocessor.
-        // Use representative types; sizeof is independent of the template parameters.
-        if (params->quantParams) { // mean provided, WithNorm = true
+        // Template arguments do not affect these component sizes.
+        if (params->quantParams) {
             est += allocations_overhead +
                    sizeof(DistanceCalculatorWithNorm<float, float, VecSimMetric_L2>);
             est += allocations_overhead + sizeof(MultiPreprocessorsContainer<float, 1>);
             est += allocations_overhead + sizeof(QuantPreprocessor<float, VecSimMetric_L2, true>);
-            est += allocations_overhead +
-                   params->dim * sizeof(float); // mean vector in QuantPreprocessor
+            est += allocations_overhead + params->dim * sizeof(float);
         } else {
             est += allocations_overhead + sizeof(DistanceCalculatorCommon<float>);
             est += allocations_overhead + sizeof(MultiPreprocessorsContainer<float, 1>);
@@ -306,11 +274,7 @@ size_t EstimateElementSize(const HNSWParams *params) {
     size_t elementGraphDataSize = sizeof(ElementGraphData) + sizeof(idType) * M * 2;
 
     size_t stored_data_size;
-    // Unlike EstimateInitialSize, this does not reject unsupported combinations: the return type is
-    // size_t with no sentinel, and VecSimIndex_EstimateElementSize is extern "C", so throwing here
-    // would carry an exception into the C host. It therefore answers for whatever params it is
-    // handed, exactly as VecSimParams_GetStoredDataSize does on the unquantized path. Index
-    // creation is the boundary that enforces the supported set (see SQ8ParamsSupported).
+    // Preserve the element estimator's existing contract: return a size and validate in NewIndex.
     if (params->quantType == VecSimQuant_SQ8) {
         bool with_norm = params->quantParams != nullptr;
         if (params->metric == VecSimMetric_L2) {

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -114,7 +114,6 @@ VecSimIndex *NewIndex_SQ8(const HNSWParams *hnswParams, AbstractIndexInitParams 
 
 VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
     const HNSWParams *hnswParams = &params->algoParams.hnswParams;
-
     AbstractIndexInitParams abstractInitParams =
         VecSimFactory::NewAbstractInitParams(hnswParams, params->logCtx, is_normalized);
 
@@ -163,8 +162,11 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
             }
         }
 
-        // Unreachable today: the checks above leave only FP32/FP16 x L2/IP. Kept so that adding a
-        // type or metric cannot silently fall through and build an unquantized index instead.
+        // Unreachable today: the checks above leave only FP32/FP16 x L2/IP. The assert makes a
+        // debug build shout if a new type or metric ever reaches here, and the return keeps a
+        // release build failing closed rather than falling through and silently building an
+        // unquantized index instead.
+        assert(false && "unhandled SQ8 data type and metric combination");
         return NULL;
     }
 

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -72,8 +72,11 @@ template <typename DataType>
     if (type != VecSimType_FLOAT32 && type != VecSimType_FLOAT16) {
         return false;
     }
-    // Cosine needs a normalization step the SQ8 preprocessor does not perform.
-    if (resolved_metric == VecSimMetric_Cosine) {
+    // Only L2 and IP have SQ8 kernels. Cosine needs a normalization step the SQ8 preprocessor does
+    // not perform, and anything outside the enum has to be rejected here as well: the dispatch in
+    // NewIndex would otherwise fall through to its unreachable-branch assert and abort an
+    // assertions-enabled host, where the unquantized path throws and is caught by VecSimIndex_New.
+    if (resolved_metric != VecSimMetric_L2 && resolved_metric != VecSimMetric_IP) {
         return false;
     }
     // Mean-centred FP16 L2 loses correctness: QuantPreprocessor centres the query and narrows the

--- a/src/VecSim/index_factories/hnsw_factory.cpp
+++ b/src/VecSim/index_factories/hnsw_factory.cpp
@@ -67,6 +67,7 @@ VecSimIndex *NewIndex_SQ8(const HNSWParams *hnswParams, AbstractIndexInitParams 
 
     // Override blob size for the SQ8 storage layout.
     abstractInitParams.storedDataSize = GetSQ8StoredDataSize<Metric>(dim, with_norm);
+    abstractInitParams.isQuantized = true;
 
     // Symmetric: both stored vectors are SQ8 blobs.
     auto sym_func = spaces::GetDistFunc<sq8, float>(Metric, dim, &storage_alignment);
@@ -132,6 +133,17 @@ VecSimIndex *NewIndex(const VecSimParams *params, bool is_normalized) {
         }
 
         const float *mean_ptr = static_cast<const float *>(hnswParams->quantParams);
+
+        // Mean-centred FP16 L2 is not supported: QuantPreprocessor centres the query and narrows
+        // the result back into the FP16 query body, while storage keeps its centred min/delta in
+        // FP32. The two then disagree, so an identical vector and query pair yields a non-zero
+        // distance (mean 10000 gives a per-component error of 1.0), and a large enough mean
+        // overflows FP16 to infinity. Enabling this needs an asymmetric kernel that takes an FP32
+        // centred query.
+        if (hnswParams->type == VecSimType_FLOAT16 && mean_ptr != nullptr &&
+            metric == VecSimMetric_L2) {
+            return NULL;
+        }
 
         if (hnswParams->type == VecSimType_FLOAT32) {
             if (metric == VecSimMetric_L2) {

--- a/src/VecSim/index_factories/tiered_factory.cpp
+++ b/src/VecSim/index_factories/tiered_factory.cpp
@@ -66,9 +66,7 @@ inline VecSimIndex *NewIndex(const TieredIndexParams *params) {
 inline size_t EstimateInitialSize(const TieredIndexParams *params) {
     HNSWParams hnsw_params = params->primaryIndexParams->algoParams.hnswParams;
 
-    // NewIndex below rejects quantization until the tiered index handles it, so refuse to size it
-    // too. The primary index on its own would accept these params, so without this check the
-    // estimate reports a number for an index that cannot be created.
+    // Keep size estimation consistent with NewIndex, which rejects quantized tiered indexes.
     if (hnsw_params.quantType != VecSimQuant_NONE) {
         throw std::invalid_argument("Quantization is not supported for tiered HNSW indexes");
     }
@@ -102,10 +100,8 @@ inline size_t EstimateInitialSize(const TieredIndexParams *params) {
 }
 
 VecSimIndex *NewIndex(const TieredIndexParams *params) {
-    // Quantization is not wired into the tiered index yet. Reject it here rather than let it
-    // through: the primary index would be built from these params and quantize its storage, while
-    // NewBFParams does not carry quantType, so the frontend would stay unquantized and the two
-    // would disagree on the stored blob layout.
+    // The brute-force frontend is not quantized, so an SQ8 primary index would use an incompatible
+    // stored-vector layout.
     if (params->primaryIndexParams->algoParams.hnswParams.quantType != VecSimQuant_NONE) {
         return nullptr;
     }
@@ -248,8 +244,7 @@ size_t EstimateInitialSize(const TieredIndexParams *params) {
 }
 
 size_t EstimateElementSize(const TieredIndexParams *params) {
-    // Deliberately not validated here, unlike EstimateInitialSize above: see the note in
-    // HNSWFactory::EstimateElementSize on why this function has no error channel.
+    // Match HNSW's element estimator, which leaves validation to NewIndex.
     size_t est = 0;
     if (params->primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
         est = HNSWFactory::EstimateElementSize(&params->primaryIndexParams->algoParams.hnswParams);

--- a/src/VecSim/index_factories/tiered_factory.cpp
+++ b/src/VecSim/index_factories/tiered_factory.cpp
@@ -66,6 +66,13 @@ inline VecSimIndex *NewIndex(const TieredIndexParams *params) {
 inline size_t EstimateInitialSize(const TieredIndexParams *params) {
     HNSWParams hnsw_params = params->primaryIndexParams->algoParams.hnswParams;
 
+    // NewIndex below rejects quantization until MOD-14957 wires it, so refuse to size it too. The
+    // primary index on its own would accept these params, so without this check the estimate
+    // reports a number for an index that cannot be created.
+    if (hnsw_params.quantType != VecSimQuant_NONE) {
+        throw std::invalid_argument("Quantization is not supported for tiered HNSW indexes");
+    }
+
     // Add size estimation of VecSimTieredIndex sub indexes.
     // Normalization is done by the frontend index.
     size_t est = HNSWFactory::EstimateInitialSize(&hnsw_params, true);
@@ -241,6 +248,8 @@ size_t EstimateInitialSize(const TieredIndexParams *params) {
 }
 
 size_t EstimateElementSize(const TieredIndexParams *params) {
+    // Deliberately not validated here, unlike EstimateInitialSize above: see the note in
+    // HNSWFactory::EstimateElementSize on why this function has no error channel.
     size_t est = 0;
     if (params->primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
         est = HNSWFactory::EstimateElementSize(&params->primaryIndexParams->algoParams.hnswParams);

--- a/src/VecSim/index_factories/tiered_factory.cpp
+++ b/src/VecSim/index_factories/tiered_factory.cpp
@@ -95,6 +95,14 @@ inline size_t EstimateInitialSize(const TieredIndexParams *params) {
 }
 
 VecSimIndex *NewIndex(const TieredIndexParams *params) {
+    // Quantization is not wired into the tiered index yet (MOD-14957). Reject it here rather than
+    // let it through: the primary index would be built from these params and quantize its storage,
+    // while NewBFParams does not carry quantType, so the frontend would stay unquantized and the
+    // two would disagree on the stored blob layout.
+    if (params->primaryIndexParams->algoParams.hnswParams.quantType != VecSimQuant_NONE) {
+        return nullptr;
+    }
+
     // Tiered index that contains HNSW index as primary index
     VecSimType type = params->primaryIndexParams->algoParams.hnswParams.type;
     if (type == VecSimType_FLOAT32) {

--- a/src/VecSim/index_factories/tiered_factory.cpp
+++ b/src/VecSim/index_factories/tiered_factory.cpp
@@ -66,9 +66,9 @@ inline VecSimIndex *NewIndex(const TieredIndexParams *params) {
 inline size_t EstimateInitialSize(const TieredIndexParams *params) {
     HNSWParams hnsw_params = params->primaryIndexParams->algoParams.hnswParams;
 
-    // NewIndex below rejects quantization until MOD-14957 wires it, so refuse to size it too. The
-    // primary index on its own would accept these params, so without this check the estimate
-    // reports a number for an index that cannot be created.
+    // NewIndex below rejects quantization until the tiered index handles it, so refuse to size it
+    // too. The primary index on its own would accept these params, so without this check the
+    // estimate reports a number for an index that cannot be created.
     if (hnsw_params.quantType != VecSimQuant_NONE) {
         throw std::invalid_argument("Quantization is not supported for tiered HNSW indexes");
     }
@@ -102,10 +102,10 @@ inline size_t EstimateInitialSize(const TieredIndexParams *params) {
 }
 
 VecSimIndex *NewIndex(const TieredIndexParams *params) {
-    // Quantization is not wired into the tiered index yet (MOD-14957). Reject it here rather than
-    // let it through: the primary index would be built from these params and quantize its storage,
-    // while NewBFParams does not carry quantType, so the frontend would stay unquantized and the
-    // two would disagree on the stored blob layout.
+    // Quantization is not wired into the tiered index yet. Reject it here rather than let it
+    // through: the primary index would be built from these params and quantize its storage, while
+    // NewBFParams does not carry quantType, so the frontend would stay unquantized and the two
+    // would disagree on the stored blob layout.
     if (params->primaryIndexParams->algoParams.hnswParams.quantType != VecSimQuant_NONE) {
         return nullptr;
     }

--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -476,8 +476,7 @@ public:
     QuantPreprocessor(std::shared_ptr<VecSimAllocator> allocator, size_t dim)
         requires(!WithNorm)
         : PreprocessorInterface(allocator), dim(dim),
-          storage_bytes_count(dim * sizeof(OUTPUT_TYPE) +
-                              sq8::storage_metadata_count<Metric>() * sizeof(MetadataType)),
+          storage_bytes_count(sq8::storage_bytes_count<Metric>(dim)),
           query_bytes_count(dim * sizeof(DataType) +
                             sq8::query_metadata_count<Metric>() * sizeof(MetadataType)) {}
 
@@ -486,9 +485,7 @@ public:
                       const vecsim_stl::vector<float> &mean_vec)
         requires(WithNorm)
         : PreprocessorInterface(allocator), mean(mean_vec), dim(dim),
-          storage_bytes_count(dim * sizeof(OUTPUT_TYPE) +
-                              sq8::storage_metadata_count<Metric, WithNorm>() *
-                                  sizeof(MetadataType)),
+          storage_bytes_count(sq8::storage_bytes_count<Metric, WithNorm>(dim)),
           query_bytes_count(dim * sizeof(DataType) +
                             sq8::query_metadata_count<Metric, WithNorm>() * sizeof(MetadataType)) {
         assert(this->mean.size() == dim && "mean vector size must equal dim");

--- a/src/VecSim/types/sq8.h
+++ b/src/VecSim/types/sq8.h
@@ -47,6 +47,15 @@ struct sq8 {
                ((WithNorm && Metric == VecSimMetric_IP) ? 1 : 0);
     }
 
+    // Size of a stored SQ8 blob: one byte per dimension, followed by FP32 metadata. Single source
+    // of truth for the storage layout: every caller that sizes or allocates a stored blob must use
+    // this, so the layout cannot drift between the preprocessor and the index factories.
+    template <VecSimMetric Metric, bool WithNorm = false>
+    static constexpr size_t storage_bytes_count(size_t dim) {
+        return dim * sizeof(value_type) +
+               storage_metadata_count<Metric, WithNorm>() * sizeof(float);
+    }
+
     // Index of x_mean_ip / y_mean_ip in the last slot in metadata array
     template <VecSimMetric Metric>
     static constexpr size_t mean_ip_index() {

--- a/src/VecSim/types/sq8.h
+++ b/src/VecSim/types/sq8.h
@@ -47,9 +47,7 @@ struct sq8 {
                ((WithNorm && Metric == VecSimMetric_IP) ? 1 : 0);
     }
 
-    // Size of a stored SQ8 blob: one byte per dimension, followed by FP32 metadata. Single source
-    // of truth for the storage layout: every caller that sizes or allocates a stored blob must use
-    // this, so the layout cannot drift between the preprocessor and the index factories.
+    // Stored layout: one quantized byte per dimension, followed by metric-specific FP32 metadata.
     template <VecSimMetric Metric, bool WithNorm = false>
     static constexpr size_t storage_bytes_count(size_t dim) {
         return dim * sizeof(value_type) +

--- a/src/VecSim/vec_sim.cpp
+++ b/src/VecSim/vec_sim.cpp
@@ -215,7 +215,11 @@ extern "C" VecSimIndex *VecSimIndex_New(const VecSimParams *params) {
 }
 
 extern "C" size_t VecSimIndex_EstimateInitialSize(const VecSimParams *params) {
-    return VecSimFactory::EstimateInitialSize(params);
+    try {
+        return VecSimFactory::EstimateInitialSize(params);
+    } catch (...) {
+        return SIZE_MAX;
+    }
 }
 
 extern "C" int VecSimIndex_AddVector(VecSimIndex *index, const void *blob, size_t label) {

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -86,6 +86,13 @@ int VecSimIndex_DeleteVector(VecSimIndex *index, size_t label);
  * type and dimension, and pre-normalized if needed.
  * @return The distance (according to the index's distance metric) between `blob` and the vector
  * with label  label`.
+ * NOT SUPPORTED for a quantized index (HNSWParams::quantType != VecSimQuant_NONE), which always
+ * returns INVALID_SCORE here, for every label. The quantized kernels read query metadata appended
+ * past the raw vector, which a blob matching the documented type and dimension does not carry, so
+ * honouring the contract above would read past the caller's buffer. Note that INVALID_SCORE is the
+ * same NaN returned when the label is absent, so a caller cannot distinguish the two: check
+ * quantType rather than inferring it from the result. Obtaining a real distance needs a prepared
+ * query, which has no public API yet.
  */
 double VecSimIndex_GetDistanceFrom_Unsafe(VecSimIndex *index, size_t label, const void *blob);
 

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -31,7 +31,7 @@ VecSimIndex *VecSimIndex_New(const VecSimParams *params);
  * @brief Estimates the size of an empty index according to the parameters.
  * @param params index configurations (initial size, data type, dimension, metric, algorithm and the
  * algorithm-related params).
- * @return Estimated index size.
+ * @return Estimated index size, or SIZE_MAX if the parameters are invalid or unsupported.
  */
 size_t VecSimIndex_EstimateInitialSize(const VecSimParams *params);
 

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -84,15 +84,10 @@ int VecSimIndex_DeleteVector(VecSimIndex *index, size_t label);
  * @param label the label of the vector in the index.
  * @param blob binary representation of the second vector. Blob size should match the index data
  * type and dimension, and pre-normalized if needed.
- * @return The distance (according to the index's distance metric) between `blob` and the vector
- * with label  label`.
- * NOT SUPPORTED for a quantized index (HNSWParams::quantType != VecSimQuant_NONE), which always
- * returns INVALID_SCORE here, for every label. The quantized kernels read query metadata appended
- * past the raw vector, which a blob matching the documented type and dimension does not carry, so
- * honouring the contract above would read past the caller's buffer. Note that INVALID_SCORE is the
- * same NaN returned when the label is absent, so a caller cannot distinguish the two: check
- * quantType rather than inferring it from the result. Obtaining a real distance needs a prepared
- * query, which has no public API yet.
+ * @return The distance between `blob` and the vector with `label`, or INVALID_SCORE if the label is
+ * absent or the index is quantized.
+ * @note Quantized kernels require a prepared query that this API does not create. Callers must
+ * check the index's `quantType` setting to distinguish this case from a missing label.
  */
 double VecSimIndex_GetDistanceFrom_Unsafe(VecSimIndex *index, size_t label, const void *blob);
 

--- a/src/VecSim/vec_sim.h
+++ b/src/VecSim/vec_sim.h
@@ -85,9 +85,8 @@ int VecSimIndex_DeleteVector(VecSimIndex *index, size_t label);
  * @param blob binary representation of the second vector. Blob size should match the index data
  * type and dimension, and pre-normalized if needed.
  * @return The distance between `blob` and the vector with `label`, or INVALID_SCORE if the label is
- * absent or the index is quantized.
- * @note Quantized kernels require a prepared query that this API does not create. Callers must
- * check the index's `quantType` setting to distinguish this case from a missing label.
+ * absent.
+ * @note Quantized indexes allocate and preprocess a temporary query blob on each call.
  */
 double VecSimIndex_GetDistanceFrom_Unsafe(VecSimIndex *index, size_t label, const void *blob);
 

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -68,6 +68,12 @@ typedef enum {
     VecSimType_INT64
 } VecSimType;
 
+// Quantization type for HNSW indices.
+typedef enum {
+    VecSimQuant_NONE = 0, // No quantization (default).
+    VecSimQuant_SQ8 = 1,  // 8-bit scalar quantization with mean normalization.
+} VecSimQuantType;
+
 // Algorithm type/library.
 typedef enum { VecSimAlgo_BF, VecSimAlgo_HNSWLIB, VecSimAlgo_TIERED, VecSimAlgo_SVS } VecSimAlgo;
 
@@ -156,6 +162,8 @@ typedef struct {
     size_t efConstruction;
     size_t efRuntime;
     double epsilon;
+    VecSimQuantType quantType; // Quantization type. Default: VecSimQuant_NONE.
+    void *quantParams; // For VecSimQuant_SQ8: pointer to float mean[dim], or NULL for zero mean.
 } HNSWParams;
 
 typedef struct {

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -71,7 +71,8 @@ typedef enum {
 // Quantization type for HNSW indices.
 typedef enum {
     VecSimQuant_NONE = 0, // No quantization (default).
-    VecSimQuant_SQ8 = 1,  // 8-bit scalar quantization with mean normalization.
+    // 8-bit scalar quantization. Mean normalization is optional, selected by quantParams below.
+    VecSimQuant_SQ8 = 1,
 } VecSimQuantType;
 
 // Algorithm type/library.
@@ -163,7 +164,9 @@ typedef struct {
     size_t efRuntime;
     double epsilon;
     VecSimQuantType quantType; // Quantization type. Default: VecSimQuant_NONE.
-    void *quantParams; // For VecSimQuant_SQ8: pointer to float mean[dim], or NULL for zero mean.
+    // For VecSimQuant_SQ8: pointer to float mean[dim], or NULL for zero mean. Read only, never
+    // retained: the index copies the mean vector during construction.
+    const void *quantParams;
 } HNSWParams;
 
 typedef struct {

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -68,10 +68,10 @@ typedef enum {
     VecSimType_INT64
 } VecSimType;
 
-// Quantization type for HNSW indices.
+// Quantization schemes supported by HNSW.
 typedef enum {
     VecSimQuant_NONE = 0, // No quantization (default).
-    // 8-bit scalar quantization. Mean normalization is optional, selected by quantParams below.
+    // 8-bit scalar quantization with optional mean centering.
     VecSimQuant_SQ8 = 1,
 } VecSimQuantType;
 
@@ -163,9 +163,8 @@ typedef struct {
     size_t efConstruction;
     size_t efRuntime;
     double epsilon;
-    VecSimQuantType quantType; // Quantization type. Default: VecSimQuant_NONE.
-    // For VecSimQuant_SQ8: pointer to float mean[dim], or NULL for zero mean. Read only, never
-    // retained: the index copies the mean vector during construction.
+    VecSimQuantType quantType; // Defaults to VecSimQuant_NONE.
+    // SQ8 mean vector (float[dim]); NULL disables mean centering. Copied during construction.
     const void *quantParams;
 } HNSWParams;
 

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -47,11 +47,8 @@ struct AbstractIndexInitParams {
     VecSimMetric metric;
     size_t blockSize;
     bool multi;
-    bool isDisk; // Whether the index stores vectors on disk
-    // Whether stored vectors are quantized. A quantized index's blobs, both stored and query, carry
-    // metadata the distance kernels read, so a caller's raw dim-by-type vector is not a usable
-    // query blob for it.
-    bool isQuantized;
+    bool isDisk;      // Whether the index stores vectors on disk
+    bool isQuantized; // Whether the index uses quantized storage.
     void *logCtx;
     size_t inputBlobSize;
 };

--- a/src/VecSim/vec_sim_index.h
+++ b/src/VecSim/vec_sim_index.h
@@ -48,6 +48,10 @@ struct AbstractIndexInitParams {
     size_t blockSize;
     bool multi;
     bool isDisk; // Whether the index stores vectors on disk
+    // Whether stored vectors are quantized. A quantized index's blobs, both stored and query, carry
+    // metadata the distance kernels read, so a caller's raw dim-by-type vector is not a usable
+    // query blob for it.
+    bool isQuantized;
     void *logCtx;
     size_t inputBlobSize;
 };
@@ -82,6 +86,7 @@ protected:
     mutable VecSearchMode lastMode; // The last search mode in RediSearch (used for debug/testing).
     bool isMulti;                   // Determines if the index should multi-index or not.
     bool isDisk;                    // Whether the index stores vectors on disk.
+    bool isQuantized;               // Whether stored vectors are quantized.
     void *logCallbackCtx;           // Context for the log callback.
     RawDataContainer *vectors;      // The raw vectors data container.
 private:
@@ -125,8 +130,8 @@ public:
         : VecSimIndexInterface(params.allocator), dim(params.dim), vecType(params.vecType),
           metric(params.metric),
           blockSize(params.blockSize ? params.blockSize : DEFAULT_BLOCK_SIZE), lastMode(EMPTY_MODE),
-          isMulti(params.multi), isDisk(params.isDisk), logCallbackCtx(params.logCtx),
-          indexCalculator(components.indexCalculator),
+          isMulti(params.multi), isDisk(params.isDisk), isQuantized(params.isQuantized),
+          logCallbackCtx(params.logCtx), indexCalculator(components.indexCalculator),
           storedDistanceDispatch(
               components.indexCalculator
                   ? components.indexCalculator->getDistanceDispatch(DistanceMode::StoredToStored)

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -62,7 +62,7 @@ public:
      * @param blob binary representation of the second vector. Blob size should match the index data
      * type and dimension, and pre-normalized if needed.
      * @return The distance (according to the index's distance metric) between `blob` and the vector
-     * with id `id`.
+     * with id `id`. Quantized indexes preprocess `blob` before calculating the distance.
      */
     virtual double getDistanceFrom_Unsafe(labelType id, const void *blob) const = 0;
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 
 add_executable(test_hnsw ../utils/test_main_with_timeout.cpp ../utils/mock_thread_pool.cpp test_hnsw.cpp test_hnsw_multi.cpp test_hnsw_tiered.cpp unit_test_utils.cpp)
 add_executable(test_hnsw_parallel ../utils/test_main_with_timeout.cpp test_hnsw_parallel.cpp ../utils/mock_thread_pool.cpp unit_test_utils.cpp)
+add_executable(test_hnsw_sq8 ../utils/test_main_with_timeout.cpp ../utils/mock_thread_pool.cpp test_hnsw_sq8.cpp unit_test_utils.cpp)
 add_executable(test_bruteforce ../utils/test_main_with_timeout.cpp test_bruteforce.cpp test_bruteforce_multi.cpp ../utils/mock_thread_pool.cpp unit_test_utils.cpp)
 add_executable(test_allocator ../utils/test_main_with_timeout.cpp test_allocator.cpp ../utils/mock_thread_pool.cpp unit_test_utils.cpp)
 add_executable(test_spaces ../utils/test_main_with_timeout.cpp test_spaces.cpp)
@@ -51,6 +52,7 @@ add_executable(test_svs ../utils/test_main_with_timeout.cpp ../utils/mock_thread
 
 target_link_libraries(test_hnsw PUBLIC gtest VectorSimilarity)
 target_link_libraries(test_hnsw_parallel PUBLIC gtest VectorSimilarity)
+target_link_libraries(test_hnsw_sq8 PUBLIC gtest VectorSimilarity)
 target_link_libraries(test_bruteforce PUBLIC gtest VectorSimilarity)
 target_link_libraries(test_allocator PUBLIC gtest VectorSimilarity)
 target_link_libraries(test_spaces PUBLIC gtest VectorSimilarity)
@@ -68,6 +70,7 @@ include(GoogleTest)
 
 gtest_discover_tests(test_hnsw)
 gtest_discover_tests(test_hnsw_parallel)
+gtest_discover_tests(test_hnsw_sq8)
 gtest_discover_tests(test_bruteforce)
 gtest_discover_tests(test_allocator)
 gtest_discover_tests(test_spaces)

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -151,7 +151,7 @@ TYPED_TEST(HNSWSQ8Test, RejectStandaloneCosine) {
     this->index = VecSimIndex_New(&vecsim_params);
     EXPECT_EQ(this->index, nullptr);
 
-    EXPECT_THROW(EstimateInitialSize(params), std::invalid_argument);
+    EXPECT_EQ(VecSimIndex_EstimateInitialSize(&vecsim_params), SIZE_MAX);
 }
 
 // Size estimation
@@ -386,8 +386,7 @@ TEST(HNSWSQ8ParamsTest, RejectsUnsupportedDataType) {
         VecSimParams params = CreateParams(hnsw_params);
 
         EXPECT_EQ(VecSimIndex_New(&params), nullptr) << "data type " << type;
-        EXPECT_THROW(EstimateInitialSize(hnsw_params), std::invalid_argument)
-            << "data type " << type;
+        EXPECT_EQ(EstimateInitialSize(hnsw_params), SIZE_MAX) << "data type " << type;
     }
 }
 
@@ -401,7 +400,7 @@ TEST(HNSWSQ8ParamsTest, RejectsOutOfRangeMetric) {
     VecSimParams params = CreateParams(hnsw_params);
 
     EXPECT_EQ(VecSimIndex_New(&params), nullptr);
-    EXPECT_THROW(EstimateInitialSize(hnsw_params), std::invalid_argument);
+    EXPECT_EQ(EstimateInitialSize(hnsw_params), SIZE_MAX);
 }
 
 // Mean-centering a FLOAT16 L2 query can lose precision or overflow when it is narrowed back to
@@ -416,7 +415,7 @@ TEST(HNSWSQ8ParamsTest, RejectsMeanCenteredFP16L2) {
                      .quantParams = mean.data()};
     VecSimParams l2_params = CreateParams(l2);
     EXPECT_EQ(VecSimIndex_New(&l2_params), nullptr);
-    EXPECT_THROW(EstimateInitialSize(l2), std::invalid_argument);
+    EXPECT_EQ(EstimateInitialSize(l2), SIZE_MAX);
 
     HNSWParams ip = {.type = VecSimType_FLOAT16,
                      .dim = 4,
@@ -427,7 +426,7 @@ TEST(HNSWSQ8ParamsTest, RejectsMeanCenteredFP16L2) {
     VecSimIndex *ip_index = VecSimIndex_New(&ip_params);
     ASSERT_NE(ip_index, nullptr);
     VecSimIndex_Free(ip_index);
-    EXPECT_NO_THROW(EstimateInitialSize(ip));
+    EXPECT_NE(EstimateInitialSize(ip), SIZE_MAX);
 }
 
 // V4 cannot encode the quantization settings needed to reload an SQ8 index.
@@ -489,5 +488,5 @@ TEST(HNSWSQ8TieredTest, RejectsQuantizedTieredIndex) {
     VecSimParams params = CreateParams(tiered_params);
 
     EXPECT_EQ(VecSimIndex_New(&params), nullptr);
-    EXPECT_THROW(EstimateInitialSize(tiered_params), std::invalid_argument);
+    EXPECT_EQ(EstimateInitialSize(tiered_params), SIZE_MAX);
 }

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -26,9 +26,8 @@ struct HNSWSQ8IndexType : IndexType<type, DataType, float> {
     static constexpr bool with_quant_params = WithQuantParams;
 };
 
-// FLOAT16 with a mean vector is absent on purpose: the functional tests below all use L2, and
-// mean-centred FP16 L2 is rejected at construction (see HNSWFactory::NewIndex). That combination is
-// covered explicitly by HNSWSQ8ParamsTest.RejectsMeanCenteredFP16L2 instead.
+// Typed tests default to L2, where mean-centered FLOAT16 is unsupported. A parameter test below
+// covers both that restriction and the supported inner-product case.
 using HNSWSQ8DataTypeSet =
     ::testing::Types<HNSWSQ8IndexType<VecSimType_FLOAT32, float, false>,
                      HNSWSQ8IndexType<VecSimType_FLOAT32, float, true>,
@@ -101,7 +100,7 @@ protected:
 
 TYPED_TEST_SUITE(HNSWSQ8Test, HNSWSQ8DataTypeSet);
 
-/* ---------------------------- Create index tests ---------------------------- */
+// Index creation
 
 template <typename index_type_t>
 void HNSWSQ8Test<index_type_t>::create_index_test() {
@@ -120,7 +119,7 @@ void HNSWSQ8Test<index_type_t>::create_index_test() {
     EXPECT_EQ(stored[0], 0);
     EXPECT_EQ(stored[dim - 1], 255);
 
-    // The quantized vector is followed by the minimum value and quantization delta.
+    // Stored layout: quantized bytes followed by the minimum value and quantization delta.
     float stored_min;
     float stored_delta;
     std::memcpy(&stored_min, stored + dim + sq8::MIN_VAL * sizeof(float), sizeof(float));
@@ -150,20 +149,17 @@ TYPED_TEST(HNSWSQ8Test, RejectStandaloneCosine) {
     this->index = VecSimIndex_New(&vecsim_params);
     EXPECT_EQ(this->index, nullptr);
 
-    // The size estimate must reject what creation rejects, so a caller cannot size its capacity
-    // from a configuration it will then fail to build.
     EXPECT_THROW(EstimateInitialSize(params), std::invalid_argument);
 }
 
-/* ---------------------------- Size Estimation tests ---------------------------- */
+// Size estimation
 
 TYPED_TEST(HNSWSQ8Test, SizeEstimation) {
     constexpr size_t block_size = 256;
     HNSWParams params = {.dim = 128, .blockSize = block_size, .M = 64};
     this->SetUp(params);
 
-    // EstimateInitialSize is called after creating the index because index creation normalizes
-    // the parameters.
+    // SetUp fills the data type and SQ8 settings used by the estimator.
     EXPECT_EQ(EstimateInitialSize(params), this->index->getAllocationSize());
 
     size_t label = 0;
@@ -172,18 +168,17 @@ TYPED_TEST(HNSWSQ8Test, SizeEstimation) {
         label++;
     }
 
-    // Estimate the memory delta of adding a vector that requires a full new block.
+    // Measure the allocation caused by growing the index by one block.
     const size_t estimation = EstimateElementSize(params) * block_size;
     const size_t before = this->index->getAllocationSize();
     ASSERT_EQ(this->GenerateAndAddVector(label, static_cast<float>(label)), 1);
     const size_t actual = this->index->getAllocationSize() - before;
 
-    // Check that the actual size is within 1% of the estimation.
     EXPECT_GE(estimation, actual * 0.99);
     EXPECT_LE(estimation, actual * 1.01);
 }
 
-/* ---------------------------- Functionality tests ---------------------------- */
+// Search behavior
 
 template <typename index_type_t>
 void HNSWSQ8Test<index_type_t>::search_by_id_test() {
@@ -197,12 +192,11 @@ void HNSWSQ8Test<index_type_t>::search_by_id_test() {
 
     data_t query[4];
     GenerateVector(query, 50.0f);
-    // Vector values are equal to their labels, so the closest vectors have labels 45 through 55.
+    // BY_ID returns the 11 nearest labels (45 through 55) in label order.
     static constexpr size_t expected[] = {45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55};
     auto verify = [&](size_t id, double score, size_t result_index) {
-        // Results are sorted by ID.
         EXPECT_EQ(id, expected[result_index]);
-        EXPECT_FLOAT_EQ(score, 4.0f * (50.0f - id) * (50.0f - id)); // L2 distance.
+        EXPECT_FLOAT_EQ(score, 4.0f * (50.0f - id) * (50.0f - id));
     };
     runTopKSearchTest(index, query, std::size(expected), verify, nullptr, BY_ID);
 }
@@ -221,7 +215,7 @@ void HNSWSQ8Test<index_type_t>::search_by_score_test() {
 
     data_t query[4];
     GenerateVector(query, 50.0f);
-    // Vector values are equal to their labels, so results are ordered by distance from label 50.
+    // BY_SCORE orders labels by their distance from label 50.
     static constexpr size_t expected[] = {50, 49, 51, 48, 52, 47, 53, 46, 54, 45, 55};
     auto verify = [&](size_t id, double score, size_t result_index) {
         EXPECT_EQ(id, expected[result_index]);
@@ -240,7 +234,6 @@ void HNSWSQ8Test<index_type_t>::search_empty_index_test() {
     data_t query[4];
     GenerateVector(query, 50.0f);
 
-    // We do not expect any results.
     VecSimQueryReply *reply = VecSimIndex_TopKQuery(index, query, 11, nullptr, BY_SCORE);
     ASSERT_EQ(VecSimQueryReply_Len(reply), 0u);
     VecSimQueryReply_Free(reply);
@@ -249,7 +242,6 @@ void HNSWSQ8Test<index_type_t>::search_empty_index_test() {
     ASSERT_EQ(VecSimQueryReply_Len(reply), 0u);
     VecSimQueryReply_Free(reply);
 
-    // Add some vectors and remove them all from the index, so it will be empty again.
     for (size_t i = 0; i < 100; i++) {
         GenerateAndAddVector(i, static_cast<float>(i));
     }
@@ -258,7 +250,6 @@ void HNSWSQ8Test<index_type_t>::search_empty_index_test() {
     }
     ASSERT_EQ(VecSimIndex_IndexSize(index), 0u);
 
-    // Again, we do not expect any results.
     reply = VecSimIndex_TopKQuery(index, query, 11, nullptr, BY_SCORE);
     ASSERT_EQ(VecSimQueryReply_Len(reply), 0u);
     VecSimQueryReply_Free(reply);
@@ -277,19 +268,17 @@ void HNSWSQ8Test<index_type_t>::test_override() {
         .dim = 4, .initialCapacity = 100, .M = 8, .efConstruction = 20, .efRuntime = count};
     SetUp(params);
 
-    // Insert 100 vectors and then overwrite each one with the same value.
     for (size_t i = 0; i < 100; i++) {
         ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 1);
         ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 0);
     }
-    // Add vectors up to count.
     for (size_t i = 100; i < count; i++) {
         ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 1);
     }
 
     data_t query[4];
     GenerateVector(query, static_cast<float>(count));
-    // The largest label is closest to the query, so labels are returned in descending order.
+    // Distance decreases as the label increases, so results are in descending label order.
     auto verify = [&](size_t id, double score, size_t result_index) {
         EXPECT_EQ(id, count - result_index - 1);
         EXPECT_FLOAT_EQ(score, 4.0f * (count - id) * (count - id));
@@ -310,11 +299,9 @@ void HNSWSQ8Test<index_type_t>::test_range_query() {
     constexpr float value_radius = 1.5f;
     std::mt19937 generator(42);
     std::uniform_real_distribution<float> distribution(pivot - value_radius, pivot + value_radius);
-    // Insert close_count vectors near the pivot vector.
     for (size_t i = 0; i < close_count; i++) {
         GenerateAndAddVector(i, distribution(generator));
     }
-    // Add the remaining vectors far from the pivot vector.
     for (size_t i = close_count; i < count; i++) {
         GenerateAndAddVector(i, 5.0f + distribution(generator));
     }
@@ -340,8 +327,7 @@ void HNSWSQ8Test<index_type_t>::test_get_distance(VecSimMetric metric) {
     data_t query[4];
     GenerateVector(query, 0.5f, 0.25f);
 
-    // Values were chosen so the expected distances can be calculated exactly. Comparing against a
-    // stored SQ8 blob needs a preprocessed query, which only the index itself can produce.
+    // SQ8 distance kernels require the index's preprocessed query format.
     auto *hnsw_index = CastToHNSW();
     auto processed_query = hnsw_index->preprocessQuery(query);
     const double expected = metric == VecSimMetric_L2 ? 0.25 : -1.5;
@@ -349,16 +335,14 @@ void HNSWSQ8Test<index_type_t>::test_get_distance(VecSimMetric metric) {
         hnsw_index->calcDistanceForQuery(hnsw_index->getDataByInternalId(0), processed_query.get()),
         expected, 1e-5);
 
-    // The public API documents blob as a raw dim-by-type vector, which is not a usable query blob
-    // for a quantized index: the kernels read query metadata appended past it. It must report no
-    // answer rather than read past the caller's buffer.
+    // The public raw-vector API cannot supply SQ8 query metadata and returns INVALID_SCORE.
     EXPECT_TRUE(std::isnan(VecSimIndex_GetDistanceFrom_Unsafe(index, 0, query)));
 }
 
 TYPED_TEST(HNSWSQ8Test, GetDistanceL2) { this->test_get_distance(VecSimMetric_L2); }
 TYPED_TEST(HNSWSQ8Test, GetDistanceIP) { this->test_get_distance(VecSimMetric_IP); }
 
-/* ---------------------------- Batch iterator tests ---------------------------- */
+// Batch iteration
 
 template <typename index_type_t>
 void HNSWSQ8Test<index_type_t>::test_batch_iterator_basic() {
@@ -368,7 +352,7 @@ void HNSWSQ8Test<index_type_t>::test_batch_iterator_basic() {
         .dim = 4, .initialCapacity = count, .M = 8, .efConstruction = 20, .efRuntime = count};
     SetUp(params);
 
-    // For every i, add the vector (i, i, i, i) under label i.
+    // Store [i, i, i, i] under label i.
     for (size_t i = 0; i < count; i++) {
         ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 1);
     }
@@ -378,8 +362,7 @@ void HNSWSQ8Test<index_type_t>::test_batch_iterator_basic() {
     VecSimBatchIterator *iterator = VecSimBatchIterator_New(index, query, nullptr);
     ASSERT_NE(iterator, nullptr);
 
-    // Get the five largest remaining labels in each iteration. Since vector values equal their
-    // labels, this is also their order by distance from the query vector.
+    // Each batch contains the five largest remaining labels, ordered by distance.
     size_t iteration = 0;
     while (VecSimBatchIterator_HasNext(iterator)) {
         auto verify = [&](size_t id, double, size_t result_index) {
@@ -394,10 +377,7 @@ void HNSWSQ8Test<index_type_t>::test_batch_iterator_basic() {
 
 TYPED_TEST(HNSWSQ8Test, BatchIteratorBasic) { this->test_batch_iterator_basic(); }
 
-// SQ8 quantizes to uint8 with FP32 metadata and only has kernels for FP32 and FP16 sources, so
-// every other data type must be rejected outright rather than produce an index. EstimateInitialSize
-// rejects the same set; EstimateElementSize deliberately does not, because it has no error channel
-// (see the note at its definition).
+// SQ8 kernels support only FLOAT32 and FLOAT16 input vectors.
 TEST(HNSWSQ8ParamsTest, RejectsUnsupportedDataType) {
     for (auto type : {VecSimType_FLOAT64, VecSimType_BFLOAT16, VecSimType_INT8, VecSimType_UINT8}) {
         HNSWParams hnsw_params = {
@@ -410,10 +390,8 @@ TEST(HNSWSQ8ParamsTest, RejectsUnsupportedDataType) {
     }
 }
 
-// An out-of-range metric must be rejected before dispatch. Reaching the unreachable-branch assert
-// in the SQ8 dispatcher would abort an assertions-enabled host, where the unquantized path throws
-// and VecSimIndex_New catches it. VecSimMetric has three enumerators, so 3 is the smallest value
-// outside the valid set that is still inside the enum's value range and therefore safe to form.
+// Value 3 has no VecSimMetric enumerator but is within the enum's representable range, so the
+// factory must reject it before dispatch.
 TEST(HNSWSQ8ParamsTest, RejectsOutOfRangeMetric) {
     HNSWParams hnsw_params = {.type = VecSimType_FLOAT32,
                               .dim = 4,
@@ -425,10 +403,8 @@ TEST(HNSWSQ8ParamsTest, RejectsOutOfRangeMetric) {
     EXPECT_THROW(EstimateInitialSize(hnsw_params), std::invalid_argument);
 }
 
-// Mean-centred FP16 with L2 must be rejected: QuantPreprocessor narrows the centred query back into
-// the FP16 query body while storage keeps its centred min/delta in FP32, so identical vector and
-// query pairs diverge and a large mean overflows FP16 to infinity. The same combination with IP is
-// supported, because that path does not centre the query.
+// Mean-centering a FLOAT16 L2 query can lose precision or overflow when it is narrowed back to
+// FLOAT16. Inner-product queries are not centered and remain supported.
 TEST(HNSWSQ8ParamsTest, RejectsMeanCenteredFP16L2) {
     std::vector<float> mean(4, 1.0f);
 
@@ -453,9 +429,7 @@ TEST(HNSWSQ8ParamsTest, RejectsMeanCenteredFP16L2) {
     EXPECT_NO_THROW(EstimateInitialSize(ip));
 }
 
-// Serialization does not record quantType or the mean vector, and the loading path always builds
-// unquantized components, so saving a quantized index would produce a file the loader misreads.
-// saveIndex must refuse rather than emit one.
+// V4 cannot encode the quantization settings needed to reload an SQ8 index.
 TYPED_TEST(HNSWSQ8Test, RejectsSerialization) {
     HNSWParams params = {.dim = 4, .initialCapacity = 1};
     this->SetUp(params);
@@ -466,9 +440,7 @@ TYPED_TEST(HNSWSQ8Test, RejectsSerialization) {
     std::remove(file_name.c_str());
 }
 
-// Every other functional test uses L2, so without this the symmetric SQ8-to-SQ8 IP kernel that
-// graph construction selects for an IP index would never run. Vectors vary per component as well as
-// per label, so quantization does not collapse into the degenerate min == max branch.
+// Exercise graph construction's stored-to-stored IP kernel with non-degenerate quantization ranges.
 TYPED_TEST(HNSWSQ8Test, GraphConstructionIP) {
     constexpr size_t n = 100;
     constexpr size_t dim = 16;
@@ -476,17 +448,13 @@ TYPED_TEST(HNSWSQ8Test, GraphConstructionIP) {
         .dim = dim, .metric = VecSimMetric_IP, .initialCapacity = n, .M = 16, .efRuntime = n};
     this->SetUp(params);
 
-    // Each label i gets a vector whose components ramp from i upward, so no two vectors share a
-    // quantization range and every vector has a non-zero delta.
     for (size_t i = 0; i < n; i++) {
         ASSERT_EQ(this->GenerateAndAddVector(i, static_cast<float>(i) * 0.5f, 0.25f), 1);
     }
     ASSERT_EQ(VecSimIndex_IndexSize(this->index), n);
 
-    // This is plain inner product, not cosine: the distance is 1 - IP, so the closest vector is the
-    // one with the largest projection onto the query rather than the query's own twin. Every vector
-    // and the query are positive and magnitude grows with the label, so IP is strictly increasing
-    // in the label and results must come back from the highest label downward.
+    // For inner-product distance (1 - dot product), these positive vectors rank by descending
+    // label.
     std::vector<typename TestFixture::data_t> query(dim);
     this->GenerateVector(query.data(), 1.0f, 0.25f);
 
@@ -496,23 +464,18 @@ TYPED_TEST(HNSWSQ8Test, GraphConstructionIP) {
     runTopKSearchTest(this->index, query.data(), 10, verify);
 }
 
-// SQ8 is not wired into the tiered index yet, so the tiered factory must reject it instead of
-// building a quantized primary index against an unquantized frontend. Without the guard this aborts
-// on a debug build and silently mismatches the two blob layouts on a release one. Whoever wires
-// quantization through the tiered index should replace this expectation rather than delete it.
+// The tiered frontend does not propagate SQ8 settings, so creation and initial-size estimation must
+// reject quantization.
 TEST(HNSWSQ8TieredTest, RejectsQuantizedTieredIndex) {
     HNSWParams hnsw_params = {.type = VecSimType_FLOAT32,
                               .dim = 4,
                               .metric = VecSimMetric_L2,
                               .quantType = VecSimQuant_SQ8};
     VecSimParams primary_params = CreateParams(hnsw_params);
-    // No job queue or thread pool is needed: the factory rejects these params before it reaches
-    // anything that would use them.
+    // Rejection happens before the factory needs a job queue or thread pool.
     TieredIndexParams tiered_params = {.primaryIndexParams = &primary_params};
     VecSimParams params = CreateParams(tiered_params);
 
     EXPECT_EQ(VecSimIndex_New(&params), nullptr);
-    // The primary index alone would accept these params, so the tiered estimate needs its own check
-    // rather than inheriting one from HNSWFactory.
     EXPECT_THROW(EstimateInitialSize(tiered_params), std::invalid_argument);
 }

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -90,7 +90,7 @@ protected:
     void search_empty_index_test();
     void test_override();
     void test_range_query();
-    void test_get_distance(VecSimMetric metric);
+    void test_get_distance(VecSimMetric metric, bool multi);
     void test_batch_iterator_basic();
 
     VecSimIndex *index = nullptr;
@@ -319,28 +319,27 @@ void HNSWSQ8Test<index_type_t>::test_range_query() {
 TYPED_TEST(HNSWSQ8Test, RangeQuery) { this->test_range_query(); }
 
 template <typename index_type_t>
-void HNSWSQ8Test<index_type_t>::test_get_distance(VecSimMetric metric) {
+void HNSWSQ8Test<index_type_t>::test_get_distance(VecSimMetric metric, bool multi) {
     HNSWParams params = {.dim = 4, .metric = metric, .initialCapacity = 1};
+    params.multi = multi;
     SetUp(params);
 
     ASSERT_EQ(GenerateAndAddVector(0, 0.25f, 0.25f), 1);
+    if (multi) {
+        ASSERT_EQ(GenerateAndAddVector(0, -2.0f, 0.25f), 1);
+    }
     data_t query[4];
     GenerateVector(query, 0.5f, 0.25f);
 
-    // SQ8 distance kernels require the index's preprocessed query format.
-    auto *hnsw_index = CastToHNSW();
-    auto processed_query = hnsw_index->preprocessQuery(query);
     const double expected = metric == VecSimMetric_L2 ? 0.25 : -1.5;
-    EXPECT_NEAR(
-        hnsw_index->calcDistanceForQuery(hnsw_index->getDataByInternalId(0), processed_query.get()),
-        expected, 1e-5);
-
-    // The public raw-vector API cannot supply SQ8 query metadata and returns INVALID_SCORE.
-    EXPECT_TRUE(std::isnan(VecSimIndex_GetDistanceFrom_Unsafe(index, 0, query)));
+    EXPECT_NEAR(VecSimIndex_GetDistanceFrom_Unsafe(index, 0, query), expected, 1e-5);
+    EXPECT_TRUE(std::isnan(VecSimIndex_GetDistanceFrom_Unsafe(index, 1, query)));
 }
 
-TYPED_TEST(HNSWSQ8Test, GetDistanceL2) { this->test_get_distance(VecSimMetric_L2); }
-TYPED_TEST(HNSWSQ8Test, GetDistanceIP) { this->test_get_distance(VecSimMetric_IP); }
+TYPED_TEST(HNSWSQ8Test, GetDistanceL2) { this->test_get_distance(VecSimMetric_L2, false); }
+TYPED_TEST(HNSWSQ8Test, GetDistanceIP) { this->test_get_distance(VecSimMetric_IP, false); }
+TYPED_TEST(HNSWSQ8Test, GetDistanceMultiL2) { this->test_get_distance(VecSimMetric_L2, true); }
+TYPED_TEST(HNSWSQ8Test, GetDistanceMultiIP) { this->test_get_distance(VecSimMetric_IP, true); }
 
 // Batch iteration
 

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -431,6 +431,49 @@ TEST(HNSWSQ8ParamsTest, RejectsMeanCenteredFP16L2) {
     VecSimIndex_Free(ip_index);
 }
 
+// Serialization does not record quantType or the mean vector, and the loading path always builds
+// unquantized components, so saving a quantized index would produce a file the loader misreads.
+// saveIndex must refuse rather than emit one.
+TYPED_TEST(HNSWSQ8Test, RejectsSerialization) {
+    HNSWParams params = {.dim = 4, .initialCapacity = 1};
+    this->SetUp(params);
+    ASSERT_EQ(this->GenerateAndAddVector(0, 0.25f, 0.25f), 1);
+
+    const auto file_name = std::string(getenv("ROOT")) + "/tests/unit/sq8_should_not_be_written";
+    EXPECT_THROW(this->CastToHNSW()->saveIndex(file_name), std::runtime_error);
+    std::remove(file_name.c_str());
+}
+
+// Every other functional test uses L2, so without this the symmetric SQ8-to-SQ8 IP kernel that
+// graph construction selects for an IP index would never run. Vectors vary per component as well as
+// per label, so quantization does not collapse into the degenerate min == max branch.
+TYPED_TEST(HNSWSQ8Test, GraphConstructionIP) {
+    constexpr size_t n = 100;
+    constexpr size_t dim = 16;
+    HNSWParams params = {
+        .dim = dim, .metric = VecSimMetric_IP, .initialCapacity = n, .M = 16, .efRuntime = n};
+    this->SetUp(params);
+
+    // Each label i gets a vector whose components ramp from i upward, so no two vectors share a
+    // quantization range and every vector has a non-zero delta.
+    for (size_t i = 0; i < n; i++) {
+        ASSERT_EQ(this->GenerateAndAddVector(i, static_cast<float>(i) * 0.5f, 0.25f), 1);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(this->index), n);
+
+    // This is plain inner product, not cosine: the distance is 1 - IP, so the closest vector is the
+    // one with the largest projection onto the query rather than the query's own twin. Every vector
+    // and the query are positive and magnitude grows with the label, so IP is strictly increasing
+    // in the label and results must come back from the highest label downward.
+    std::vector<typename TestFixture::data_t> query(dim);
+    this->GenerateVector(query.data(), 1.0f, 0.25f);
+
+    auto verify = [&](size_t id, double, size_t result_index) {
+        EXPECT_EQ(id, n - 1 - result_index);
+    };
+    runTopKSearchTest(this->index, query.data(), 10, verify);
+}
+
 // SQ8 is not wired into the tiered index yet (MOD-14957), so the tiered factory must reject it
 // instead of building a quantized primary index against an unquantized frontend. Without the
 // guard this aborts on a debug build and silently mismatches the two blob layouts on a release

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -379,6 +379,21 @@ void HNSWSQ8Test<index_type_t>::test_batch_iterator_basic() {
 
 TYPED_TEST(HNSWSQ8Test, BatchIteratorBasic) { this->test_batch_iterator_basic(); }
 
+// SQ8 quantizes to uint8 with FP32 metadata and only has kernels for FP32 and FP16 sources, so
+// every other data type must be rejected outright rather than produce an index. Note that
+// EstimateElementSize deliberately does not re-check this: like VecSimParams_GetStoredDataSize on
+// the unquantized path, it answers for whatever params it is handed, so index creation is the
+// boundary that enforces the supported set.
+TEST(HNSWSQ8ParamsTest, RejectsUnsupportedDataType) {
+    for (auto type : {VecSimType_FLOAT64, VecSimType_BFLOAT16, VecSimType_INT8, VecSimType_UINT8}) {
+        HNSWParams hnsw_params = {
+            .type = type, .dim = 4, .metric = VecSimMetric_L2, .quantType = VecSimQuant_SQ8};
+        VecSimParams params = CreateParams(hnsw_params);
+
+        EXPECT_EQ(VecSimIndex_New(&params), nullptr) << "data type " << type;
+    }
+}
+
 // SQ8 is not wired into the tiered index yet (MOD-14957), so the tiered factory must reject it
 // instead of building a quantized primary index against an unquantized frontend. Without the
 // guard this aborts on a debug build and silently mismatches the two blob layouts on a release

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -149,6 +149,10 @@ TYPED_TEST(HNSWSQ8Test, RejectStandaloneCosine) {
     VecSimParams vecsim_params = CreateParams(params);
     this->index = VecSimIndex_New(&vecsim_params);
     EXPECT_EQ(this->index, nullptr);
+
+    // The size estimate must reject what creation rejects, so a caller cannot size its capacity
+    // from a configuration it will then fail to build.
+    EXPECT_THROW(EstimateInitialSize(params), std::invalid_argument);
 }
 
 /* ---------------------------- Size Estimation tests ---------------------------- */
@@ -391,10 +395,9 @@ void HNSWSQ8Test<index_type_t>::test_batch_iterator_basic() {
 TYPED_TEST(HNSWSQ8Test, BatchIteratorBasic) { this->test_batch_iterator_basic(); }
 
 // SQ8 quantizes to uint8 with FP32 metadata and only has kernels for FP32 and FP16 sources, so
-// every other data type must be rejected outright rather than produce an index. Note that
-// EstimateElementSize deliberately does not re-check this: like VecSimParams_GetStoredDataSize on
-// the unquantized path, it answers for whatever params it is handed, so index creation is the
-// boundary that enforces the supported set.
+// every other data type must be rejected outright rather than produce an index. EstimateInitialSize
+// rejects the same set; EstimateElementSize deliberately does not, because it has no error channel
+// (see the note at its definition).
 TEST(HNSWSQ8ParamsTest, RejectsUnsupportedDataType) {
     for (auto type : {VecSimType_FLOAT64, VecSimType_BFLOAT16, VecSimType_INT8, VecSimType_UINT8}) {
         HNSWParams hnsw_params = {
@@ -402,6 +405,8 @@ TEST(HNSWSQ8ParamsTest, RejectsUnsupportedDataType) {
         VecSimParams params = CreateParams(hnsw_params);
 
         EXPECT_EQ(VecSimIndex_New(&params), nullptr) << "data type " << type;
+        EXPECT_THROW(EstimateInitialSize(hnsw_params), std::invalid_argument)
+            << "data type " << type;
     }
 }
 
@@ -419,6 +424,7 @@ TEST(HNSWSQ8ParamsTest, RejectsMeanCenteredFP16L2) {
                      .quantParams = mean.data()};
     VecSimParams l2_params = CreateParams(l2);
     EXPECT_EQ(VecSimIndex_New(&l2_params), nullptr);
+    EXPECT_THROW(EstimateInitialSize(l2), std::invalid_argument);
 
     HNSWParams ip = {.type = VecSimType_FLOAT16,
                      .dim = 4,
@@ -429,6 +435,7 @@ TEST(HNSWSQ8ParamsTest, RejectsMeanCenteredFP16L2) {
     VecSimIndex *ip_index = VecSimIndex_New(&ip_params);
     ASSERT_NE(ip_index, nullptr);
     VecSimIndex_Free(ip_index);
+    EXPECT_NO_THROW(EstimateInitialSize(ip));
 }
 
 // Serialization does not record quantType or the mean vector, and the loading path always builds
@@ -490,4 +497,7 @@ TEST(HNSWSQ8TieredTest, RejectsQuantizedTieredIndex) {
     VecSimParams params = CreateParams(tiered_params);
 
     EXPECT_EQ(VecSimIndex_New(&params), nullptr);
+    // The primary index alone would accept these params, so the tiered estimate needs its own check
+    // rather than inheriting one from HNSWFactory.
+    EXPECT_THROW(EstimateInitialSize(tiered_params), std::invalid_argument);
 }

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -378,3 +378,21 @@ void HNSWSQ8Test<index_type_t>::test_batch_iterator_basic() {
 }
 
 TYPED_TEST(HNSWSQ8Test, BatchIteratorBasic) { this->test_batch_iterator_basic(); }
+
+// SQ8 is not wired into the tiered index yet (MOD-14957), so the tiered factory must reject it
+// instead of building a quantized primary index against an unquantized frontend. Without the
+// guard this aborts on a debug build and silently mismatches the two blob layouts on a release
+// one. MOD-14957 should replace this expectation rather than delete it.
+TEST(HNSWSQ8TieredTest, RejectsQuantizedTieredIndex) {
+    HNSWParams hnsw_params = {.type = VecSimType_FLOAT32,
+                              .dim = 4,
+                              .metric = VecSimMetric_L2,
+                              .quantType = VecSimQuant_SQ8};
+    VecSimParams primary_params = CreateParams(hnsw_params);
+    // No job queue or thread pool is needed: the factory rejects these params before it reaches
+    // anything that would use them.
+    TieredIndexParams tiered_params = {.primaryIndexParams = &primary_params};
+    VecSimParams params = CreateParams(tiered_params);
+
+    EXPECT_EQ(VecSimIndex_New(&params), nullptr);
+}

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -410,6 +410,21 @@ TEST(HNSWSQ8ParamsTest, RejectsUnsupportedDataType) {
     }
 }
 
+// An out-of-range metric must be rejected before dispatch. Reaching the unreachable-branch assert
+// in the SQ8 dispatcher would abort an assertions-enabled host, where the unquantized path throws
+// and VecSimIndex_New catches it. VecSimMetric has three enumerators, so 3 is the smallest value
+// outside the valid set that is still inside the enum's value range and therefore safe to form.
+TEST(HNSWSQ8ParamsTest, RejectsOutOfRangeMetric) {
+    HNSWParams hnsw_params = {.type = VecSimType_FLOAT32,
+                              .dim = 4,
+                              .metric = static_cast<VecSimMetric>(3),
+                              .quantType = VecSimQuant_SQ8};
+    VecSimParams params = CreateParams(hnsw_params);
+
+    EXPECT_EQ(VecSimIndex_New(&params), nullptr);
+    EXPECT_THROW(EstimateInitialSize(hnsw_params), std::invalid_argument);
+}
+
 // Mean-centred FP16 with L2 must be rejected: QuantPreprocessor narrows the centred query back into
 // the FP16 query body while storage keeps its centred min/delta in FP32, so identical vector and
 // query pairs diverge and a large mean overflows FP16 to infinity. The same combination with IP is

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates
+ * <open-source-office@arm.com>
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#include "gtest/gtest.h"
+#include "VecSim/algorithms/hnsw/hnsw_single.h"
+#include "VecSim/types/float16.h"
+#include "VecSim/types/sq8.h"
+#include "VecSim/vec_sim.h"
+#include "unit_test_utils.h"
+
+#include <cmath>
+#include <cstring>
+#include <random>
+#include <type_traits>
+
+template <VecSimType type, typename DataType, bool WithQuantParams>
+struct HNSWSQ8IndexType : IndexType<type, DataType, float> {
+    static constexpr bool with_quant_params = WithQuantParams;
+};
+
+using HNSWSQ8DataTypeSet =
+    ::testing::Types<HNSWSQ8IndexType<VecSimType_FLOAT32, float, false>,
+                     HNSWSQ8IndexType<VecSimType_FLOAT32, float, true>,
+                     HNSWSQ8IndexType<VecSimType_FLOAT16, vecsim_types::float16, false>,
+                     HNSWSQ8IndexType<VecSimType_FLOAT16, vecsim_types::float16, true>>;
+
+template <typename index_type_t>
+class HNSWSQ8Test : public ::testing::Test {
+public:
+    using data_t = typename index_type_t::data_t;
+
+protected:
+    static constexpr float quantization_mean_value = 1.0f;
+
+    static data_t ToDataType(float value) {
+        if constexpr (std::is_same_v<data_t, vecsim_types::float16>) {
+            return vecsim_types::FP32_to_FP16(value);
+        } else {
+            return value;
+        }
+    }
+
+    void SetUp(HNSWParams &params) {
+        params.type = index_type_t::get_index_type();
+        params.quantType = VecSimQuant_SQ8;
+        if constexpr (index_type_t::with_quant_params) {
+            quantization_mean.assign(params.dim, quantization_mean_value);
+            params.quantParams = quantization_mean.data();
+        }
+        VecSimParams vecsim_params = CreateParams(params);
+        index = VecSimIndex_New(&vecsim_params);
+        ASSERT_NE(index, nullptr);
+        dim = params.dim;
+    }
+
+    void TearDown() override {
+        if (index) {
+            VecSimIndex_Free(index);
+        }
+    }
+
+    HNSWIndex<data_t, float> *CastToHNSW() {
+        return dynamic_cast<HNSWIndex<data_t, float> *>(index);
+    }
+
+    void GenerateVector(data_t *out_vec, float initial_value = 0.25f, float step = 0.0f) {
+        for (size_t i = 0; i < dim; i++) {
+            out_vec[i] = ToDataType(initial_value + step * static_cast<float>(i));
+        }
+    }
+
+    int GenerateAndAddVector(size_t label, float initial_value = 0.25f, float step = 0.0f) {
+        std::vector<data_t> vector(dim);
+        GenerateVector(vector.data(), initial_value, step);
+        return VecSimIndex_AddVector(index, vector.data(), label);
+    }
+
+    void create_index_test();
+    void search_by_id_test();
+    void search_by_score_test();
+    void search_empty_index_test();
+    void test_override();
+    void test_range_query();
+    void test_get_distance(VecSimMetric metric);
+    void test_batch_iterator_basic();
+
+    VecSimIndex *index = nullptr;
+    size_t dim = 0;
+    std::vector<float> quantization_mean;
+};
+
+TYPED_TEST_SUITE(HNSWSQ8Test, HNSWSQ8DataTypeSet);
+
+/* ---------------------------- Create index tests ---------------------------- */
+
+template <typename index_type_t>
+void HNSWSQ8Test<index_type_t>::create_index_test() {
+    HNSWParams params = {.dim = 40, .M = 16, .efConstruction = 200};
+    SetUp(params);
+
+    constexpr float initial_value = 0.5f;
+    constexpr float step = 1.0f;
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0u);
+    ASSERT_EQ(GenerateAndAddVector(0, initial_value, step), 1);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 1u);
+
+    auto *hnsw_index = CastToHNSW();
+    ASSERT_NE(hnsw_index, nullptr);
+    const auto *stored = reinterpret_cast<const uint8_t *>(hnsw_index->getDataByInternalId(0));
+    EXPECT_EQ(stored[0], 0);
+    EXPECT_EQ(stored[dim - 1], 255);
+
+    // The quantized vector is followed by the minimum value and quantization delta.
+    float stored_min;
+    float stored_delta;
+    std::memcpy(&stored_min, stored + dim + sq8::MIN_VAL * sizeof(float), sizeof(float));
+    std::memcpy(&stored_delta, stored + dim + sq8::DELTA * sizeof(float), sizeof(float));
+    const float expected_min =
+        initial_value - (index_type_t::with_quant_params ? quantization_mean_value : 0.0f);
+    EXPECT_FLOAT_EQ(stored_min, expected_min);
+    EXPECT_FLOAT_EQ(stored_delta, step * static_cast<float>(dim - 1) / 255.0f);
+
+    EXPECT_EQ(index->basicInfo().type, index_type_t::get_index_type());
+    EXPECT_EQ(index->basicInfo().algo, VecSimAlgo_HNSWLIB);
+}
+
+TYPED_TEST(HNSWSQ8Test, CreateIndex) { this->create_index_test(); }
+
+TYPED_TEST(HNSWSQ8Test, RejectStandaloneCosine) {
+    HNSWParams params = {.type = TypeParam::get_index_type(),
+                         .dim = 4,
+                         .metric = VecSimMetric_Cosine,
+                         .quantType = VecSimQuant_SQ8};
+    if constexpr (TypeParam::with_quant_params) {
+        this->quantization_mean.assign(params.dim, this->quantization_mean_value);
+        params.quantParams = this->quantization_mean.data();
+    }
+
+    VecSimParams vecsim_params = CreateParams(params);
+    this->index = VecSimIndex_New(&vecsim_params);
+    EXPECT_EQ(this->index, nullptr);
+}
+
+/* ---------------------------- Size Estimation tests ---------------------------- */
+
+TYPED_TEST(HNSWSQ8Test, SizeEstimation) {
+    constexpr size_t block_size = 256;
+    HNSWParams params = {.dim = 128, .blockSize = block_size, .M = 64};
+    this->SetUp(params);
+
+    // EstimateInitialSize is called after creating the index because index creation normalizes
+    // the parameters.
+    EXPECT_EQ(EstimateInitialSize(params), this->index->getAllocationSize());
+
+    size_t label = 0;
+    while (this->index->indexSize() < 200 || this->index->indexSize() % block_size != 0) {
+        ASSERT_EQ(this->GenerateAndAddVector(label, static_cast<float>(label)), 1);
+        label++;
+    }
+
+    // Estimate the memory delta of adding a vector that requires a full new block.
+    const size_t estimation = EstimateElementSize(params) * block_size;
+    const size_t before = this->index->getAllocationSize();
+    ASSERT_EQ(this->GenerateAndAddVector(label, static_cast<float>(label)), 1);
+    const size_t actual = this->index->getAllocationSize() - before;
+
+    // Check that the actual size is within 1% of the estimation.
+    EXPECT_GE(estimation, actual * 0.99);
+    EXPECT_LE(estimation, actual * 1.01);
+}
+
+/* ---------------------------- Functionality tests ---------------------------- */
+
+template <typename index_type_t>
+void HNSWSQ8Test<index_type_t>::search_by_id_test() {
+    HNSWParams params = {
+        .dim = 4, .initialCapacity = 200, .M = 16, .efConstruction = 200, .efRuntime = 100};
+    SetUp(params);
+
+    for (size_t i = 0; i < 100; i++) {
+        ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 1);
+    }
+
+    data_t query[4];
+    GenerateVector(query, 50.0f);
+    // Vector values are equal to their labels, so the closest vectors have labels 45 through 55.
+    static constexpr size_t expected[] = {45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55};
+    auto verify = [&](size_t id, double score, size_t result_index) {
+        // Results are sorted by ID.
+        EXPECT_EQ(id, expected[result_index]);
+        EXPECT_FLOAT_EQ(score, 4.0f * (50.0f - id) * (50.0f - id)); // L2 distance.
+    };
+    runTopKSearchTest(index, query, std::size(expected), verify, nullptr, BY_ID);
+}
+
+TYPED_TEST(HNSWSQ8Test, SearchByID) { this->search_by_id_test(); }
+
+template <typename index_type_t>
+void HNSWSQ8Test<index_type_t>::search_by_score_test() {
+    HNSWParams params = {
+        .dim = 4, .initialCapacity = 200, .M = 16, .efConstruction = 200, .efRuntime = 100};
+    SetUp(params);
+
+    for (size_t i = 0; i < 100; i++) {
+        ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 1);
+    }
+
+    data_t query[4];
+    GenerateVector(query, 50.0f);
+    // Vector values are equal to their labels, so results are ordered by distance from label 50.
+    static constexpr size_t expected[] = {50, 49, 51, 48, 52, 47, 53, 46, 54, 45, 55};
+    auto verify = [&](size_t id, double score, size_t result_index) {
+        EXPECT_EQ(id, expected[result_index]);
+        EXPECT_FLOAT_EQ(score, 4.0f * (50.0f - id) * (50.0f - id));
+    };
+    runTopKSearchTest(index, query, std::size(expected), verify);
+}
+
+TYPED_TEST(HNSWSQ8Test, SearchByScore) { this->search_by_score_test(); }
+
+template <typename index_type_t>
+void HNSWSQ8Test<index_type_t>::search_empty_index_test() {
+    HNSWParams params = {.dim = 4, .initialCapacity = 0};
+    SetUp(params);
+
+    data_t query[4];
+    GenerateVector(query, 50.0f);
+
+    // We do not expect any results.
+    VecSimQueryReply *reply = VecSimIndex_TopKQuery(index, query, 11, nullptr, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(reply), 0u);
+    VecSimQueryReply_Free(reply);
+
+    reply = VecSimIndex_RangeQuery(index, query, 1.0, nullptr, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(reply), 0u);
+    VecSimQueryReply_Free(reply);
+
+    // Add some vectors and remove them all from the index, so it will be empty again.
+    for (size_t i = 0; i < 100; i++) {
+        GenerateAndAddVector(i, static_cast<float>(i));
+    }
+    for (size_t i = 0; i < 100; i++) {
+        VecSimIndex_DeleteVector(index, i);
+    }
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 0u);
+
+    // Again, we do not expect any results.
+    reply = VecSimIndex_TopKQuery(index, query, 11, nullptr, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(reply), 0u);
+    VecSimQueryReply_Free(reply);
+
+    reply = VecSimIndex_RangeQuery(index, query, 1.0, nullptr, BY_SCORE);
+    ASSERT_EQ(VecSimQueryReply_Len(reply), 0u);
+    VecSimQueryReply_Free(reply);
+}
+
+TYPED_TEST(HNSWSQ8Test, SearchEmptyIndex) { this->search_empty_index_test(); }
+
+template <typename index_type_t>
+void HNSWSQ8Test<index_type_t>::test_override() {
+    constexpr size_t count = 250;
+    HNSWParams params = {
+        .dim = 4, .initialCapacity = 100, .M = 8, .efConstruction = 20, .efRuntime = count};
+    SetUp(params);
+
+    // Insert 100 vectors and then overwrite each one with the same value.
+    for (size_t i = 0; i < 100; i++) {
+        ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 1);
+        ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 0);
+    }
+    // Add vectors up to count.
+    for (size_t i = 100; i < count; i++) {
+        ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 1);
+    }
+
+    data_t query[4];
+    GenerateVector(query, static_cast<float>(count));
+    // The largest label is closest to the query, so labels are returned in descending order.
+    auto verify = [&](size_t id, double score, size_t result_index) {
+        EXPECT_EQ(id, count - result_index - 1);
+        EXPECT_FLOAT_EQ(score, 4.0f * (count - id) * (count - id));
+    };
+    runTopKSearchTest(index, query, count, verify);
+}
+
+TYPED_TEST(HNSWSQ8Test, Override) { this->test_override(); }
+
+template <typename index_type_t>
+void HNSWSQ8Test<index_type_t>::test_range_query() {
+    constexpr size_t count = 100;
+    constexpr size_t close_count = 20;
+    HNSWParams params = {.dim = 4, .initialCapacity = count, .efRuntime = count};
+    SetUp(params);
+
+    constexpr float pivot = 1.0f;
+    constexpr float value_radius = 1.5f;
+    std::mt19937 generator(42);
+    std::uniform_real_distribution<float> distribution(pivot - value_radius, pivot + value_radius);
+    // Insert close_count vectors near the pivot vector.
+    for (size_t i = 0; i < close_count; i++) {
+        GenerateAndAddVector(i, distribution(generator));
+    }
+    // Add the remaining vectors far from the pivot vector.
+    for (size_t i = close_count; i < count; i++) {
+        GenerateAndAddVector(i, 5.0f + distribution(generator));
+    }
+
+    data_t query[4];
+    GenerateVector(query, pivot);
+    constexpr double max_distance = 4.0 * value_radius * value_radius;
+    auto verify = [&](size_t id, double score, size_t) {
+        EXPECT_LT(id, close_count);
+        EXPECT_LE(score, max_distance);
+    };
+    runRangeQueryTest(index, query, max_distance, verify, close_count, BY_SCORE);
+}
+
+TYPED_TEST(HNSWSQ8Test, RangeQuery) { this->test_range_query(); }
+
+template <typename index_type_t>
+void HNSWSQ8Test<index_type_t>::test_get_distance(VecSimMetric metric) {
+    HNSWParams params = {.dim = 4, .metric = metric, .initialCapacity = 1};
+    SetUp(params);
+
+    ASSERT_EQ(GenerateAndAddVector(0, 0.25f, 0.25f), 1);
+    data_t query[4];
+    GenerateVector(query, 0.5f, 0.25f);
+    auto processed_query = CastToHNSW()->preprocessQuery(query);
+    const double expected = metric == VecSimMetric_L2 ? 0.25 : -1.5;
+    // Values were chosen so the expected distances can be calculated exactly.
+    EXPECT_NEAR(VecSimIndex_GetDistanceFrom_Unsafe(index, 0, processed_query.get()), expected,
+                1e-5);
+}
+
+TYPED_TEST(HNSWSQ8Test, GetDistanceL2) { this->test_get_distance(VecSimMetric_L2); }
+TYPED_TEST(HNSWSQ8Test, GetDistanceIP) { this->test_get_distance(VecSimMetric_IP); }
+
+/* ---------------------------- Batch iterator tests ---------------------------- */
+
+template <typename index_type_t>
+void HNSWSQ8Test<index_type_t>::test_batch_iterator_basic() {
+    constexpr size_t count = 250;
+    constexpr size_t batch_size = 5;
+    HNSWParams params = {
+        .dim = 4, .initialCapacity = count, .M = 8, .efConstruction = 20, .efRuntime = count};
+    SetUp(params);
+
+    // For every i, add the vector (i, i, i, i) under label i.
+    for (size_t i = 0; i < count; i++) {
+        ASSERT_EQ(GenerateAndAddVector(i, static_cast<float>(i)), 1);
+    }
+
+    data_t query[4];
+    GenerateVector(query, static_cast<float>(count));
+    VecSimBatchIterator *iterator = VecSimBatchIterator_New(index, query, nullptr);
+    ASSERT_NE(iterator, nullptr);
+
+    // Get the five largest remaining labels in each iteration. Since vector values equal their
+    // labels, this is also their order by distance from the query vector.
+    size_t iteration = 0;
+    while (VecSimBatchIterator_HasNext(iterator)) {
+        auto verify = [&](size_t id, double, size_t result_index) {
+            EXPECT_EQ(id, count - iteration * batch_size - result_index - 1);
+        };
+        runBatchIteratorSearchTest(iterator, batch_size, verify);
+        iteration++;
+    }
+    EXPECT_EQ(iteration, count / batch_size);
+    VecSimBatchIterator_Free(iterator);
+}
+
+TYPED_TEST(HNSWSQ8Test, BatchIteratorBasic) { this->test_batch_iterator_basic(); }

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -18,6 +18,8 @@
 
 #include <cmath>
 #include <cstring>
+#include <fstream>
+#include <iterator>
 #include <random>
 #include <type_traits>
 
@@ -435,7 +437,18 @@ TYPED_TEST(HNSWSQ8Test, RejectsSerialization) {
     ASSERT_EQ(this->GenerateAndAddVector(0, 0.25f, 0.25f), 1);
 
     const auto file_name = std::string(getenv("ROOT")) + "/tests/unit/sq8_should_not_be_written";
+    const std::string existing_contents = "existing snapshot";
+    {
+        std::ofstream output(file_name, std::ios::binary);
+        output.write(existing_contents.data(), existing_contents.size());
+    }
+
     EXPECT_THROW(this->CastToHNSW()->saveIndex(file_name), std::runtime_error);
+
+    std::ifstream input(file_name, std::ios::binary);
+    const std::string saved_contents{std::istreambuf_iterator<char>(input),
+                                     std::istreambuf_iterator<char>()};
+    EXPECT_EQ(saved_contents, existing_contents);
     std::remove(file_name.c_str());
 }
 

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -26,11 +26,13 @@ struct HNSWSQ8IndexType : IndexType<type, DataType, float> {
     static constexpr bool with_quant_params = WithQuantParams;
 };
 
+// FLOAT16 with a mean vector is absent on purpose: the functional tests below all use L2, and
+// mean-centred FP16 L2 is rejected at construction (see HNSWFactory::NewIndex). That combination is
+// covered explicitly by HNSWSQ8ParamsTest.RejectsMeanCenteredFP16L2 instead.
 using HNSWSQ8DataTypeSet =
     ::testing::Types<HNSWSQ8IndexType<VecSimType_FLOAT32, float, false>,
                      HNSWSQ8IndexType<VecSimType_FLOAT32, float, true>,
-                     HNSWSQ8IndexType<VecSimType_FLOAT16, vecsim_types::float16, false>,
-                     HNSWSQ8IndexType<VecSimType_FLOAT16, vecsim_types::float16, true>>;
+                     HNSWSQ8IndexType<VecSimType_FLOAT16, vecsim_types::float16, false>>;
 
 template <typename index_type_t>
 class HNSWSQ8Test : public ::testing::Test {
@@ -333,11 +335,20 @@ void HNSWSQ8Test<index_type_t>::test_get_distance(VecSimMetric metric) {
     ASSERT_EQ(GenerateAndAddVector(0, 0.25f, 0.25f), 1);
     data_t query[4];
     GenerateVector(query, 0.5f, 0.25f);
-    auto processed_query = CastToHNSW()->preprocessQuery(query);
+
+    // Values were chosen so the expected distances can be calculated exactly. Comparing against a
+    // stored SQ8 blob needs a preprocessed query, which only the index itself can produce.
+    auto *hnsw_index = CastToHNSW();
+    auto processed_query = hnsw_index->preprocessQuery(query);
     const double expected = metric == VecSimMetric_L2 ? 0.25 : -1.5;
-    // Values were chosen so the expected distances can be calculated exactly.
-    EXPECT_NEAR(VecSimIndex_GetDistanceFrom_Unsafe(index, 0, processed_query.get()), expected,
-                1e-5);
+    EXPECT_NEAR(
+        hnsw_index->calcDistanceForQuery(hnsw_index->getDataByInternalId(0), processed_query.get()),
+        expected, 1e-5);
+
+    // The public API documents blob as a raw dim-by-type vector, which is not a usable query blob
+    // for a quantized index: the kernels read query metadata appended past it. It must report no
+    // answer rather than read past the caller's buffer.
+    EXPECT_TRUE(std::isnan(VecSimIndex_GetDistanceFrom_Unsafe(index, 0, query)));
 }
 
 TYPED_TEST(HNSWSQ8Test, GetDistanceL2) { this->test_get_distance(VecSimMetric_L2); }
@@ -392,6 +403,32 @@ TEST(HNSWSQ8ParamsTest, RejectsUnsupportedDataType) {
 
         EXPECT_EQ(VecSimIndex_New(&params), nullptr) << "data type " << type;
     }
+}
+
+// Mean-centred FP16 with L2 must be rejected: QuantPreprocessor narrows the centred query back into
+// the FP16 query body while storage keeps its centred min/delta in FP32, so identical vector and
+// query pairs diverge and a large mean overflows FP16 to infinity. The same combination with IP is
+// supported, because that path does not centre the query.
+TEST(HNSWSQ8ParamsTest, RejectsMeanCenteredFP16L2) {
+    std::vector<float> mean(4, 1.0f);
+
+    HNSWParams l2 = {.type = VecSimType_FLOAT16,
+                     .dim = 4,
+                     .metric = VecSimMetric_L2,
+                     .quantType = VecSimQuant_SQ8,
+                     .quantParams = mean.data()};
+    VecSimParams l2_params = CreateParams(l2);
+    EXPECT_EQ(VecSimIndex_New(&l2_params), nullptr);
+
+    HNSWParams ip = {.type = VecSimType_FLOAT16,
+                     .dim = 4,
+                     .metric = VecSimMetric_IP,
+                     .quantType = VecSimQuant_SQ8,
+                     .quantParams = mean.data()};
+    VecSimParams ip_params = CreateParams(ip);
+    VecSimIndex *ip_index = VecSimIndex_New(&ip_params);
+    ASSERT_NE(ip_index, nullptr);
+    VecSimIndex_Free(ip_index);
 }
 
 // SQ8 is not wired into the tiered index yet (MOD-14957), so the tiered factory must reject it

--- a/tests/unit/test_hnsw_sq8.cpp
+++ b/tests/unit/test_hnsw_sq8.cpp
@@ -496,10 +496,10 @@ TYPED_TEST(HNSWSQ8Test, GraphConstructionIP) {
     runTopKSearchTest(this->index, query.data(), 10, verify);
 }
 
-// SQ8 is not wired into the tiered index yet (MOD-14957), so the tiered factory must reject it
-// instead of building a quantized primary index against an unquantized frontend. Without the
-// guard this aborts on a debug build and silently mismatches the two blob layouts on a release
-// one. MOD-14957 should replace this expectation rather than delete it.
+// SQ8 is not wired into the tiered index yet, so the tiered factory must reject it instead of
+// building a quantized primary index against an unquantized frontend. Without the guard this aborts
+// on a debug build and silently mismatches the two blob layouts on a release one. Whoever wires
+// quantization through the tiered index should replace this expectation rather than delete it.
 TEST(HNSWSQ8TieredTest, RejectsQuantizedTieredIndex) {
     HNSWParams hnsw_params = {.type = VecSimType_FLOAT32,
                               .dim = 4,


### PR DESCRIPTION
**Describe the changes in the pull request**

Cherry-pick of [ARM-software/VectorSimilarity-for-Arm#4](https://github.com/ARM-software/VectorSimilarity-for-Arm/pull/4) (head `125ea15d`), plus a follow-up review pass. Fourth PR in the SQ8 series, after #999, #1000 and #1002.

Adds 8-bit scalar quantization (SQ8) to the standalone HNSW index:

* `VecSimQuantType` plus `quantType` / `quantParams` on `HNSWParams`. Both fields are appended at the end of the struct and `VecSimQuant_NONE` is 0, so existing zero-initialized and designated-initializer construction is unaffected.
* `HNSWFactory` can build SQ8 indexes for FLOAT32 and FLOAT16 data types with the L2 and IP metrics, wiring `QuantPreprocessor` and `DistanceCalculatorWithNorm`, and accounts for SQ8 in `EstimateInitialSize` and `EstimateElementSize`.
* For SQ8, `quantParams` points to a `float[dim]` mean vector; a null pointer selects quantization without mean normalization.
* New `test_hnsw_sq8` unit-test target and suite (44 tests: FP32/FP16 x L2/IP).

SQ8 support for the tiered HNSW index, serialization and benchmarks is deferred to later PRs in the series.

**Commit 1: the cherry-pick**

ARM's four commits squashed into one, with no functional change to their code. Two Redis-side adjustments:

* Dropped the added `SPDX-FileCopyrightText` Arm line from the two modified files, matching how #999, #1000 and #1002 landed. It is kept on the new `tests/unit/test_hnsw_sq8.cpp`, where the `BSD-3-Clause` identifier was replaced by this repo's Redis tri-license header.
* Wrapped that header so `make check-format` passes at the 100-column limit.

**Commit 2: review follow-up**

No behavioural change intended. Interface, single-source-of-truth and idiom fixes:

* `quantParams` is now `const void *`. Every use reads it and two already cast to `const float *`. Layout-identical, so not an ABI break, and callers passing non-const still compile. Better to fix before the field ships and freezes.
* The `VecSimQuant_SQ8` comment claimed "with mean normalization", but mean normalization is optional and selected by `quantParams`. Reworded.
* `GetSQ8StoredDataSize` re-derived the stored blob size that `QuantPreprocessor`'s constructors already computed. Two formulas for one layout drift silently, which is the bug class fixed in MOD-15303. The formula now lives once as `sq8::storage_bytes_count<Metric, WithNorm>(dim)`, beside the `storage_metadata_count` it builds on, and both callers use it. **This is why the diff touches `types/sq8.h` and `spaces/computer/preprocessors.h`, two files beyond ARM's original four:** having one shared definition is the entire point of the fix.
* Restored the `return NULL` closing the SQ8 branch. Unreachable today, since the type and metric checks leave only FP32/FP16 x L2/IP, but without it adding a type or metric silently falls through and builds an unquantized index.
* `assert(ret == 0)` on `addPreprocessor` is now `assert(ret != -1)`. The function returns -1 on failure, 0 when the container is full, and the next free index otherwise, so 0 is merely the only success value at the current container size of one. `!= -1` is the documented contract and the existing repo idiom.
* Hoisted the tail both branches duplicated (container construction, `addPreprocessor`, assert, `IndexComponents`, return); only the preprocessor and calculator differ.
* The mean vector is copied with one `assign` instead of a zero-filling constructor followed by `memcpy`, which wrote every element twice.
* Obtaining the query alignment required calling `GetDistFunc` for a function that is never used, since `spaces.h` offers no alignment-only query and the asymmetric hint covers the storage operand. That call now lives in a small `GetQueryAlignment<DataType>` adapter returning the hint, so the call site neither discards a value nor keeps a third distance function in scope beside `sym_func` and `asym_func` that must never be called. `query_alignment` is const.
* `GetSQ8StoredDataSize` is `[[nodiscard]] constexpr` and `dim` / `with_norm` are const.

**Commit 3: reject quantized tiered indexes until MOD-14957**

Adding `quantType` to `HNSWParams` makes it reachable on the tiered path, where nothing handles it. `TieredHNSWFactory::NewIndex` forwards `primaryIndexParams` into `HNSWFactory::NewIndex`, so the primary index quantizes its storage, while `NewBFParams` does not copy `quantType` and the frontend stays unquantized. Reachable from any direct C API caller with `algo = VecSimAlgo_TIERED` and `quantType = VecSimQuant_SQ8`:

* FP32/FP16: the `getStoredDataSize()` assert at `tiered_factory.cpp:54` aborts on a debug build; under `NDEBUG` the index is built with mismatched frontend and backend layouts.
* FP64/BF16/INT8/UINT8: `HNSWFactory::NewIndex` returns NULL for these types under SQ8, and the result is `reinterpret_cast` and dereferenced with no null check, so the process segfaults.

The `catch (...)` in `index_factory.cpp` does not help, since neither an abort nor a null dereference is an exception. RediSearch cannot set `quantType` until MOD-14958, so there is no product exposure today; the guard exists so main does not carry the defect between cherry-picks. **MOD-14957 should replace this check and its test rather than delete them.**

**Commit 4: cover SQ8 rejection of unsupported data types**

`HNSWSQ8ParamsTest.RejectsUnsupportedDataType` asserts that FLOAT64, BFLOAT16, INT8 and UINT8 with `VecSimQuant_SQ8` all return `NULL` from index creation. Verified red without the fix: with both the type fence and the fall-through `return NULL` removed, all four are silently built as unquantized indexes. Also documents at `EstimateElementSize` why the estimate deliberately does not repeat the check (see the Bugbot thread on this PR).

**Commit 5: fix two defects found in review (63271c14)**

Both raised by @lerman25, both verified before fixing.

* **Out-of-bounds read through the public C API.** `VecSimIndex_GetDistanceFrom_Unsafe` documents `blob` as a raw dim-by-type vector, but the SQ8 kernels read query metadata appended past that, so honouring the documented contract read past the caller's buffer. Reproduced under ASan: `heap-buffer-overflow, READ of size 4` in `SQ8_FP32_InnerProduct_Impl` via `vec_sim.cpp:231`. `getDistanceFrom_Unsafe` now returns `INVALID_SCORE` for a quantized index, the value `getDistanceFromInternal` already uses for "no answer". `AbstractIndexInitParams` gains `isQuantized` for this, parallel to `isDisk`. Preprocessing internally was rejected because `preprocessQuery` also normalizes cosine queries, so it would change behaviour for every existing cosine index; a public prepared-query API is the real answer and belongs with MOD-14958.
* **Mean-centred FP16 L2 loses correctness.** The query is centred then narrowed back to FP16 while storage keeps FP32 min/delta. Verified numerically: mean 10000 gives a per-component error of 1.0 and a self-distance of 4.0 for an identical vector/query pair, and centring -40000 with mean 40000 gives `-inf`. Now rejected at construction. FP16 + mean + **IP** is unaffected and still supported, since that path does not centre the query.

The test that should have caught the first one passed a preprocessed blob obtained through a C++-only path no C caller has. It now checks the maths via `calcDistanceForQuery` and separately asserts the public API reports no answer for a raw vector.

**Commit 6: serialization guard and IP graph coverage (9e69259c)**

* **`saveIndexIMP` refuses a quantized index.** The V4 format records neither `quantType` nor the mean, and the loading path always builds unquantized components, so a saved SQ8 index reloaded with the wrong stride and consumed graph bytes as vector data. Same argument as the tiered guard: fail closed. Caveat: the encoding version is written before this check runs, so a rejected save leaves a stub file, which still fails closed on load.
* **`GraphConstructionIP`.** Every other functional test uses L2, so the symmetric SQ8-to-SQ8 IP kernel that graph construction selects was never executed, and this series is the first thing to put it on the insert path. Its vectors vary per component, so it avoids the degenerate `min == max` branch the other tests take.
* Review nits: `assert(false && "...")` before the unreachable `return NULL` (kept alongside it, since assert-only would reopen the silent-fallthrough hole under `NDEBUG`), and the stray blank line removed.

**Commit 7: make the size estimates reject what index creation rejects (d5d93d61)**

Closes the three Bugbot findings that were still open, plus one gap none of them covered. No behavioural change on any supported configuration.

The supported-SQ8-combination test now lives in one place instead of being open-coded in `NewIndex` only: `ResolveSQ8Metric` applies the `is_normalized` Cosine-to-IP remap, and `SQ8ParamsSupported` holds all the fences. Same single-source-of-truth argument as `sq8::storage_bytes_count` in commit 2.

* `NewIndex` rejects a `quantType` that is neither `NONE` nor `SQ8`. Previously any other value fell through to the full-precision path and silently built an unquantized index for a caller that asked for a quantized one. Deliberately untested: the enum holds only those two values, so forming a third is undefined behaviour. The guard is what stops adding `SQ4` from reopening the hole.
* `EstimateInitialSize` rejects the same set as `NewIndex`, replacing a check that validated only the data type. This closes the reported metric gap and one nobody raised: the mean-centred FP16 L2 fence added in `63271c14` was never mirrored into the estimate, so that combination still reported a size.
* `TieredHNSWFactory::EstimateInitialSize` rejects `quantType != NONE`, matching its `NewIndex` guard. It needs its own check rather than inheriting one, since the primary index accepts FP32 with L2 and SQ8 happily and nothing propagates up.

`EstimateElementSize` is left lax on purpose: `size_t` return with no sentinel, and `VecSimIndex_EstimateElementSize` is `extern "C"`, so a throw would carry an exception into the C host. It answers for whatever params it is handed, exactly as `VecSimParams_GetStoredDataSize` always has on the unquantized path. Both functions now say which one validates and why the other cannot.

Flagged rather than buried: this adds two `throw` sites reachable through `VecSimIndex_EstimateInitialSize`, which has no `try`/`catch`. That is the existing idiom in both files rather than a new hazard, but the error model for the estimate functions is unsettled and belongs with MOD-14958.

Verified red without the fix: 5 failures, all "throws nothing". `RejectsUnsupportedDataType` stayed green, since the old code already threw for a bad type.

**Commit 8: reject an out-of-range metric, and document the SQ8 distance sentinel (9b1615c6)**

The two findings from @lerman25's second review round that are inside MOD-14956.

* **An out-of-range `VecSimMetric` aborted the process.** FP32 with SQ8 and `metric = (VecSimMetric)123` passed the Cosine-only check, matched neither dispatch branch, and hit the `assert(false)` added in `9e69259c`. The unquantized dispatcher throws and `VecSimIndex_New` catches it, so quantized params were the only way to abort an assertions-enabled host. `SQ8ParamsSupported` now whitelists L2 and IP. Note commit 7's refactor preserved this hole verbatim rather than introducing it: the check it replaced also tested only for Cosine. `RejectsOutOfRangeMetric` uses `(VecSimMetric)3`, outside the valid set but inside the enum's value range, so the test does not itself rely on UB.
* **The `INVALID_SCORE` sentinel is now documented on `vec_sim.h`.** `63271c14` made `getDistanceFrom_Unsafe` return it for a quantized index, but the declaration still promised a distance, and it is the same NaN used for a missing label, so a caller could treat valid candidates as absent. The declaration now states the restriction, the collision, and that callers must check `quantType`.

**Deferred to new tickets, all under epic MOD-6132**

Findings from the second review round that fall outside MOD-14956 ("wire SQ8 into HNSWIndex + factory") and outside the HLD. Each ticket carries the reproduction and the boundary.

| Ticket | Finding | Why not here |
|---|---|---|
| MOD-17526 | Both FP32 SQ8 L2 kernels lose precision through `\|\|x\|\|^2 + \|\|y\|\|^2 - 2*IP` in FP32. Stored `[100000, 100008]` against query `[100000, 100000]` returns 0.0 where the truth is 64.0, and quantization is exact for that input. Onset around `offset / spread > ~4000`. | Pre-existing kernels. The identity is what makes the SQ8-to-SQ8 inner loop a uint8 dot product, so a direct-difference rewrite trades a rare wrong answer for a slowdown nobody measured. Mean normalization removes it entirely, verified to offset 1e6, so the HLD default `TRAINING_THRESHOLD` is the safe configuration. |
| MOD-17527 | SQ8-to-SQ8 IP SIMD kernels overflow int32 from dim 33,027 (boundary corrected from 33,026: every non-constant quantization has one `q = 0`). | Pre-existing kernels, and the shared uint8 helper means a fix changes int8/uint8 behaviour too. |
| MOD-17528 | `QuantPreprocessor` casts NaN to `uint8` for finite input when the derived range overflows to infinity. UB on `AddVector`. | MOD-14952's component. Needs a contract decision, since `AddVector` cannot report "unquantizable". |
| MOD-17529 | `HNSWSerializer::saveIndex` truncates the destination before validating, so a rejected save destroys a valid existing snapshot. | Pre-existing ordering that applies to any validation failure, not only the SQ8 guard. Correcting my own earlier claim on that thread that the stub "fails closed". |
| MOD-17530 | `BUILD_TESTS` `getDataByLabel` copies `dim * sizeof(DataType)` from a shorter SQ8 blob. | Test-only, no current caller, so the ASan run here is clean. A landmine for MOD-14957 and MOD-14959. |
| MOD-17531 | `GraphConstructionIP` executes the symmetric IP kernel but never validates its result (every vector quantizes to the same byte payload); metric and `multi` axes still uncovered. | Adding the metric axis means reworking hard-coded L2 expectations across several tests, and this is ARM's suite. |

**Verification**

Run on the final tree, after both commits:

| Check | Result |
|---|---|
| `./check-format.sh` | clean |
| `g++ -Wall -Werror -fsyntax-only`, with and without `-DNDEBUG` | clean |
| `make build DEBUG=1` | clean, no warnings |
| `test_hnsw_sq8` | 43/43 passed |
| `make unit_test DEBUG=1` | 2650/2650 passed |
| `make asan` | 2649/2649 passed, 0 sanitizer reports |

Not run: `FP_64=1` variants, since this change is FP32/FP16 only.
Both new guards were confirmed red without their fix, and the ASan repro above is clean after it.

Test count moved 2653 -> 2650. Dropping FLOAT16-with-mean from the functional type set removed 11 typed tests for a combination that is now rejected, and the two new tests added 6 back. FP16 + mean + IP is left with construction coverage only, and the multi-label path and full metric parameterization remain uncovered; both are tracked in MOD-17531 rather than silently dropped.


**Reviewed and deliberately left alone**

* The `query_alignment` hint comes from the symmetric `DataType` dispatcher while the asymmetric kernel that consumes the query uses unaligned loads (`_mm512_loadu_ps`). This costs nothing: `QuantPreprocessor::preprocessQuery` always allocates a fresh blob via `allocate_aligned`, so the hint only selects that allocation's alignment. It matches the asymmetric-types contract in `spaces.h`.
* The SQ8 branch of `EstimateInitialSize` uses `<float>` for the index class even on the FP16 path. Verified correct with a `static_assert` on `sizeof` for both the single and multi index classes.
* `mean_sum_squares` accumulates in `float`. It is a constant additive term on the IP path only, identical for every candidate, so it cannot affect ranking, only the absolute reported distance. Left as is.
* Three raw `new (allocator)` calls with no RAII between them leak if a later constructor throws. `preprocessors_factory.h` does the same, so this is repo-wide debt rather than something this PR introduced.

**Which issues this PR fixes**
1. MOD-14956

**Main objects this PR modified**
1. `HNSWFactory` index creation and memory estimation
2. `HNSWParams` and the new `VecSimQuantType` public API
3. `sq8::storage_bytes_count`, now the single definition of the SQ8 storage layout size
4. SQ8 HNSW unit-test target and test suite

**Mark if applicable**

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Extends the public HNSW API and index construction path with quantized storage, distance kernels, and C-API error handling. Unsupported paths (tiered indexes, serialization, some type/metric combos) are rejected, but this still changes core search and memory-layout behavior.
> 
> **Overview**
> Adds **SQ8 quantization** to standalone HNSW via new `quantType` / `quantParams` fields on `HNSWParams`. FLOAT32 and FLOAT16 indexes can store 8-bit vectors with optional mean centering for L2 and IP (pre-normalized cosine maps to IP).
> 
> `HNSWFactory` builds quantized indexes with `QuantPreprocessor` and SQ8 distance kernels, and size estimates follow the same supported-params rules. Unsupported combinations (other types, standalone cosine, mean-centered FP16 L2, unknown quantizers) return `NULL` / `SIZE_MAX` instead of silently building a full-precision index.
> 
> Quantized indexes preprocess the query in `getDistanceFrom_Unsafe`. Saving a quantized index and creating a quantized **tiered** HNSW index are rejected until later work. Storage blob size is centralized in `sq8::storage_bytes_count`. New `test_hnsw_sq8` covers construction, search, estimates, and the rejection paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3131cffc63f3af51fc2450155649e3d658ea1755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


