### PR TITLE
Add a range constructor to vecsim_stl::vector

### DIFF
--- a/src/VecSim/utils/vecsim_stl.h
+++ b/src/VecSim/utils/vecsim_stl.h
@@ -11,6 +11,7 @@
 #include "VecSim/memory/vecsim_base.h"
 #include <atomic>
 #include <cstdint>
+#include <iterator>
 #include <vector>
 #include <algorithm>
 #include <set>
@@ -33,6 +34,12 @@ public:
         : VecsimBaseObject(alloc), std::vector<T, VecsimSTLAllocator<T>>(cap, alloc) {}
     explicit vector(size_t cap, T val, const std::shared_ptr<VecSimAllocator> &alloc)
         : VecsimBaseObject(alloc), std::vector<T, VecsimSTLAllocator<T>>(cap, val, alloc) {}
+    // Range constructor. Constrained to input iterators (same idiom std::vector uses) so that
+    // calls like vector<size_t>(10, 5, alloc) resolve to the fill constructor above instead of
+    // being deduced as a range of ints.
+    template <std::input_iterator Iter>
+    explicit vector(Iter first, Iter last, const std::shared_ptr<VecSimAllocator> &alloc)
+        : VecsimBaseObject(alloc), std::vector<T, VecsimSTLAllocator<T>>(first, last, alloc) {}
 
     bool remove(T element) {
         auto it = std::find(this->begin(), this->end(), element);

--- a/tests/unit/test_allocator.cpp
+++ b/tests/unit/test_allocator.cpp
@@ -15,7 +15,9 @@
 #include "VecSim/algorithms/hnsw/hnsw_single.h"
 #include "unit_test_utils.h"
 #include "VecSim/utils/serializer.h"
+#include "VecSim/utils/vecsim_stl.h"
 #include "VecSim/index_factories/hnsw_factory.h"
+#include <list>
 
 const size_t vecsimAllocationOverhead = VecSimAllocator::getAllocationOverheadSize();
 
@@ -81,6 +83,41 @@ TEST_F(AllocatorTest, test_nested_object) {
     expectedAllocationSize += sizeof(int) + vecsimAllocationOverhead;
     ASSERT_EQ(allocator->getAllocationSize(), expectedAllocationSize);
     delete obj;
+}
+
+TEST_F(AllocatorTest, test_vector_range_constructor) {
+    std::shared_ptr<VecSimAllocator> allocator = VecSimAllocator::newVecsimAllocator();
+    const int src[] = {1, 2, 3, 4};
+
+    // A range of random access iterators: the exact size is known upfront, so a single allocation
+    // of the vector's data is expected, and it goes through the vecsim allocator.
+    const size_t expectedAllocationSize = allocator->getAllocationSize();
+    {
+        vecsim_stl::vector<int> fromArray(src, src + 4, allocator);
+        ASSERT_EQ(allocator->getAllocationSize(),
+                  expectedAllocationSize + sizeof(src) + vecsimAllocationOverhead);
+        ASSERT_EQ(fromArray.size(), 4);
+        ASSERT_TRUE(std::equal(fromArray.begin(), fromArray.end(), src));
+
+        // A range of another vecsim_stl::vector's iterators.
+        vecsim_stl::vector<int> copy(fromArray.begin(), fromArray.end(), allocator);
+        ASSERT_EQ(copy.size(), fromArray.size());
+        ASSERT_TRUE(std::equal(copy.begin(), copy.end(), src));
+    }
+    // Both vectors were destroyed, so their data was returned to the allocator.
+    ASSERT_EQ(allocator->getAllocationSize(), expectedAllocationSize);
+
+    // A range of non-contiguous iterators (the size is not known upfront).
+    std::list<int> list{7, 8, 9};
+    vecsim_stl::vector<int> fromList(list.begin(), list.end(), allocator);
+    ASSERT_EQ(fromList.size(), list.size());
+    ASSERT_TRUE(std::equal(fromList.begin(), fromList.end(), list.begin()));
+
+    // The range constructor is constrained to input iterators, so it must not be preferred over
+    // the (count, value) constructor when T is an integral type.
+    vecsim_stl::vector<size_t> fill(10, 5, allocator);
+    ASSERT_EQ(fill.size(), 10);
+    ASSERT_EQ(std::count(fill.begin(), fill.end(), 5UL), 10);
 }
 
 template <typename index_type_t>


### PR DESCRIPTION
**Describe the changes in the pull request**

`vecsim_stl::vector` exposes only three constructors: empty, sized, and sized-with-fill-value. Building one from an existing range therefore means constructing it empty and copying the elements in by hand.

This adds the missing iterator-pair constructor, forwarding to the underlying `std::vector` and keeping the allocator as the trailing argument like the existing constructors:

```cpp
template <std::input_iterator Iter>
explicit vector(Iter first, Iter last, const std::shared_ptr<VecSimAllocator> &alloc)
    : VecsimBaseObject(alloc), std::vector<T, VecsimSTLAllocator<T>>(first, last, alloc) {}
```

`<iterator>` is now included explicitly rather than relied upon transitively.

Why the `std::input_iterator` constraint: for a call like `vecsim_stl::vector<size_t> v(10, 5, alloc)` an unconstrained template would win overload resolution against the `(count, value, alloc)` constructor, since `Iter = int` is an exact match for both arguments while the fill constructor needs an `int` to `size_t` conversion, and conversion-sequence ranking is applied before the prefer-non-template tiebreak. In practice libstdc++ recovers (its own range constructor is SFINAE-guarded, so the forwarded `(int, int, alloc)` call lands back on *its* fill constructor), but relying on that is fragile and produces confusing diagnostics for genuinely bad calls. Constraining on `std::input_iterator` is the same idiom `std::vector` itself uses, keeps resolution correct at our own signature, and is free. No behaviour change for any existing call site.

**Which issues this PR fixes**

None. No MOD ticket: this came out of noticing the missing constructor. Happy to attach one if the convention requires it.

**Main objects this PR modified**

1. `vecsim_stl::vector` (`src/VecSim/utils/vecsim_stl.h`) - added the range constructor.
2. `AllocatorTest` (`tests/unit/test_allocator.cpp`) - new `test_vector_range_constructor`.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

Neither box applies: the addition is internal C++ (not the `extern "C"` API in `vec_sim.h`), purely additive, and touches no serialized state.

## Testing

New `AllocatorTest.test_vector_range_constructor` covers:

- a random access iterator range, asserting the data is allocated through `VecSimAllocator` in a single allocation of the exact size, and released on destruction
- a range taken from another `vecsim_stl::vector`
- a `std::list` range (non-contiguous iterators, size not known upfront)
- that `vector<size_t>(10, 5, alloc)` still resolves to the fill constructor

Verified on an Intel Xeon Platinum 8375C box (gcc 13.3, AVX512, SVS enabled):

- full `make build` clean, zero errors
- full `make unit_test`: **2607/2607 passed** (the 8 reported as skipped are the pre-existing SVS quantization / dynamic-info-iterator cases, unrelated to this change)
- targeted run after adding the test: `ctest -R Allocator` 8/8 passed, including the new case
- `make check-format` clean

## Note on scope

Nothing in `src/` calls the new constructor yet. The nearest existing use is `hnsw.h:915` in `mutuallyConnectNewElement`, where a fresh `candidatesList` is immediately filled by `insert(end(), top_candidates.begin(), top_candidates.end())`; converting it is a one-line readability change with identical allocation behaviour, and I left it out of this PR to keep a hot path out of scope. The first real consumer is likely the SQ8-with-norm path, whose `QuantPreprocessor` constructor already takes a `const vecsim_stl::vector<float> &mean_vec` that no `src/` caller builds yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
