### PR TITLE
HNSW: reuse pooled id sets in the delete and repair paths

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -10,6 +10,7 @@
 
 #include "graph_data.h"
 #include "visited_nodes_handler.h"
+#include "id_flag_set.h"
 #include "VecSim/memory/vecsim_malloc.h"
 #include "VecSim/utils/vecsim_stl.h"
 #include "VecSim/utils/vec_utils.h"
@@ -122,6 +123,8 @@ protected:
     // Used for marking the visited nodes in graph scans (the pool supports parallel graph scans).
     // This is mutable since the object changes upon search operations as well (which are const).
     mutable VisitedNodesHandlerPool visitedNodesHandlerPool;
+    // Reusable id sets for the delete and repair paths, see id_flag_set.h.
+    mutable IdFlagSetPool idFlagSetPool;
     mutable std::shared_mutex indexDataGuard;
 
 #ifdef BUILD_TESTS
@@ -182,7 +185,8 @@ protected:
     void repairConnectionsForDeletion(idType element_internal_id, idType neighbour_id,
                                       ElementLevelData &node_level,
                                       ElementLevelData &neighbor_level, size_t level,
-                                      vecsim_stl::vector<bool> &neighbours_bitmap);
+                                      IdFlagSet &neighbours_set,
+                                      IdFlagSet &orig_neighbours_scratch);
     void replaceEntryPoint();
 
     void SwapLastIdWithDeletedId(idType element_internal_id, ElementGraphData *last_element,
@@ -946,7 +950,8 @@ idType HNSWIndex<DataType, DistType>::mutuallyConnectNewElement(
 template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::repairConnectionsForDeletion(
     idType element_internal_id, idType neighbour_id, ElementLevelData &node_level,
-    ElementLevelData &neighbor_level, size_t level, vecsim_stl::vector<bool> &neighbours_bitmap) {
+    ElementLevelData &neighbor_level, size_t level, IdFlagSet &neighbours_set,
+    IdFlagSet &orig_neighbours_scratch) {
 
     if (isMarkedDeleted(neighbour_id)) {
         // Just remove the deleted element from the neighbor's neighbors list. No need to repair as
@@ -958,13 +963,15 @@ void HNSWIndex<DataType, DistType>::repairConnectionsForDeletion(
     // Add the deleted element's neighbour's original neighbors in the candidates.
     vecsim_stl::vector<idType> candidate_ids(this->allocator);
     candidate_ids.reserve(node_level.getNumLinks() + neighbor_level.getNumLinks());
-    vecsim_stl::vector<bool> neighbour_orig_neighbours_set(curElementCount, false, this->allocator);
+    // Reused across the calls this delete makes, so it starts from whatever the last call left.
+    IdFlagSet &neighbour_orig_neighbours_set = orig_neighbours_scratch;
+    neighbour_orig_neighbours_set.clear();
     for (size_t j = 0; j < neighbor_level.getNumLinks(); j++) {
         idType cand = neighbor_level.getLinkAtPos(j);
-        neighbour_orig_neighbours_set[cand] = true;
+        neighbour_orig_neighbours_set.insert(cand);
         // Don't add the removed element to the candidates, nor nodes that are neighbors of the
         // original deleted element and will also be added to the candidates set.
-        if (cand != element_internal_id && !neighbours_bitmap[cand]) {
+        if (cand != element_internal_id && !neighbours_set.contains(cand)) {
             candidate_ids.push_back(cand);
         }
     }
@@ -974,7 +981,7 @@ void HNSWIndex<DataType, DistType>::repairConnectionsForDeletion(
         // were not neighbors before.
         idType cand = node_level.getLinkAtPos(j);
         if (cand != neighbour_id &&
-            (!isMarkedDeleted(cand) || neighbour_orig_neighbours_set[cand])) {
+            (!isMarkedDeleted(cand) || neighbour_orig_neighbours_set.contains(cand))) {
             candidate_ids.push_back(cand);
         }
     }
@@ -999,7 +1006,7 @@ void HNSWIndex<DataType, DistType>::repairConnectionsForDeletion(
 
         // Update unidirectional incoming edges w.r.t. the edges that were removed.
         for (auto node_id : not_chosen_candidates) {
-            if (neighbour_orig_neighbours_set[node_id]) {
+            if (neighbour_orig_neighbours_set.contains(node_id)) {
                 // if the node id (the neighbour's neighbour to be removed)
                 // wasn't pointing to the neighbour (edge was one directional),
                 // we should remove it from the node's incoming edges.
@@ -1019,7 +1026,7 @@ void HNSWIndex<DataType, DistType>::repairConnectionsForDeletion(
     // Updates for the new edges created
     for (size_t i = 0; i < neighbor_level.getNumLinks(); i++) {
         idType node_id = neighbor_level.getLinkAtPos(i);
-        if (!neighbour_orig_neighbours_set[node_id]) {
+        if (!neighbour_orig_neighbours_set.contains(node_id)) {
             ElementLevelData &node_level = getElementLevelData(node_id, level);
             // If the node has an edge to the neighbour as well, remove it from the incoming nodes
             // of the neighbour. Otherwise, we need to update the edge as unidirectional incoming.
@@ -1289,6 +1296,7 @@ void HNSWIndex<DataType, DistType>::resizeIndexCommon(size_t new_max_elements) {
               idToMetaData.capacity(), new_max_elements);
     resizeLabelLookup(new_max_elements);
     visitedNodesHandlerPool.resize(new_max_elements);
+    idFlagSetPool.resize(new_max_elements);
     elementLocks.resize(new_max_elements);
     elementLocks.shrink_to_fit();
     assert(idToMetaData.capacity() == idToMetaData.size());
@@ -1426,14 +1434,17 @@ template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::repairNodeConnections(idType node_id, size_t level) {
 
     vecsim_stl::vector<idType> neighbors_candidate_ids(this->allocator);
-    // Use bitmaps for fast accesses:
+    // Use id sets for fast accesses. They are taken from the pool rather than built here, since
+    // each holds at most a handful of ids while a freshly built one costs a zero fill over the
+    // whole index capacity, on every repair job.
     // node_orig_neighbours_set is used to differentiate between the neighbors that will *not* be
     // selected by the heuristics - only the ones that were originally neighbors should be removed.
-    vecsim_stl::vector<bool> node_orig_neighbours_set(maxElements, false, this->allocator);
+    PooledIdFlagSets scratch(idFlagSetPool);
+    IdFlagSet &node_orig_neighbours_set = scratch.first();
     // neighbors_candidates_set is used to store the nodes that were already collected as
     // candidates, so we will not collect them again as candidates if we run into them from another
     // path.
-    vecsim_stl::vector<bool> neighbors_candidates_set(maxElements, false, this->allocator);
+    IdFlagSet &neighbors_candidates_set = scratch.second();
     vecsim_stl::vector<idType> deleted_neighbors(this->allocator);
 
     // Go over the repaired node neighbors, collect the non-deleted ones to be neighbors candidates
@@ -1442,13 +1453,13 @@ void HNSWIndex<DataType, DistType>::repairNodeConnections(idType node_id, size_t
     lockNodeLinks(node_id);
     ElementLevelData &node_level_data = getElementLevelData(element, level);
     for (size_t j = 0; j < node_level_data.getNumLinks(); j++) {
-        node_orig_neighbours_set[node_level_data.getLinkAtPos(j)] = true;
+        node_orig_neighbours_set.insert(node_level_data.getLinkAtPos(j));
         // Don't add the removed element to the candidates.
         if (isMarkedDeleted(node_level_data.getLinkAtPos(j))) {
             deleted_neighbors.push_back(node_level_data.getLinkAtPos(j));
             continue;
         }
-        neighbors_candidates_set[node_level_data.getLinkAtPos(j)] = true;
+        neighbors_candidates_set.insert(node_level_data.getLinkAtPos(j));
         neighbors_candidate_ids.push_back(node_level_data.getLinkAtPos(j));
     }
     unlockNodeLinks(node_id);
@@ -1477,11 +1488,11 @@ void HNSWIndex<DataType, DistType>::repairNodeConnections(idType node_id, size_t
             // Don't add removed elements to the candidates, nor nodes that are already in the
             // candidates set, nor the original node to repair itself.
             if (isMarkedDeleted(neighbor_level_data.getLinkAtPos(j)) ||
-                neighbors_candidates_set[neighbor_level_data.getLinkAtPos(j)] ||
+                neighbors_candidates_set.contains(neighbor_level_data.getLinkAtPos(j)) ||
                 neighbor_level_data.getLinkAtPos(j) == node_id) {
                 continue;
             }
-            neighbors_candidates_set[neighbor_level_data.getLinkAtPos(j)] = true;
+            neighbors_candidates_set.insert(neighbor_level_data.getLinkAtPos(j));
             neighbors_candidate_ids.push_back(neighbor_level_data.getLinkAtPos(j));
         }
         unlockNodeLinks(deleted_neighbor_id);
@@ -1503,7 +1514,7 @@ void HNSWIndex<DataType, DistType>::repairNodeConnections(idType node_id, size_t
         getNeighborsByHeuristic2(neighbors_candidates, max_M_cur, not_chosen_neighbors);
 
         for (idType not_chosen_neighbor : not_chosen_neighbors) {
-            if (node_orig_neighbours_set[not_chosen_neighbor]) {
+            if (node_orig_neighbours_set.contains(not_chosen_neighbor)) {
                 nodes_to_update.push_back(not_chosen_neighbor);
             }
         }
@@ -1604,7 +1615,7 @@ HNSWIndex<DataType, DistType>::HNSWIndex(const HNSWParams *params,
     : VecSimIndexAbstract<DataType, DistType>(abstractInitParams, components),
       VecSimIndexTombstone(), maxElements(0), graphDataBlocks(this->allocator),
       elementLocks(this->allocator), idToMetaData(this->allocator),
-      visitedNodesHandlerPool(0, this->allocator) {
+      visitedNodesHandlerPool(0, this->allocator), idFlagSetPool(0, this->allocator) {
 
     M = params->M ? params->M : HNSW_DEFAULT_M;
     M0 = M * 2;
@@ -1701,52 +1712,58 @@ void HNSWIndex<DataType, DistType>::removeAndSwapMarkDeletedElement(idType inter
 template <typename DataType, typename DistType>
 void HNSWIndex<DataType, DistType>::removeVectorInPlace(const idType element_internal_id) {
 
-    vecsim_stl::vector<bool> neighbours_bitmap(this->allocator);
-
-    // Go over the element's nodes at every level and repair the effected connections.
+    // Scoped, so that the id set is back in the pool before removeAndSwap() below may shrink the
+    // index, and with it the pool.
     auto element = getGraphDataByInternalId(element_internal_id);
-    for (size_t level = 0; level <= element->toplevel; level++) {
-        ElementLevelData &cur_level = getElementLevelData(element, level);
-        // Reset the neighbours' bitmap for the current level.
-        neighbours_bitmap.assign(curElementCount, false);
-        // Store the deleted element's neighbours set in a bitmap for fast access.
-        for (size_t j = 0; j < cur_level.getNumLinks(); j++) {
-            neighbours_bitmap[cur_level.getLinkAtPos(j)] = true;
-        }
-        // Go over the neighbours that also points back to the removed point and make a local
-        // repair.
-        for (size_t i = 0; i < cur_level.getNumLinks(); i++) {
-            idType neighbour_id = cur_level.getLinkAtPos(i);
-            ElementLevelData &neighbor_level = getElementLevelData(neighbour_id, level);
+    {
+        PooledIdFlagSets scratch(idFlagSetPool);
+        IdFlagSet &neighbours_set = scratch.first();
 
-            bool bidirectional_edge = false;
-            for (size_t j = 0; j < neighbor_level.getNumLinks(); j++) {
-                // If the edge is bidirectional, do repair for this neighbor.
-                if (neighbor_level.getLinkAtPos(j) == element_internal_id) {
-                    bidirectional_edge = true;
-                    repairConnectionsForDeletion(element_internal_id, neighbour_id, cur_level,
-                                                 neighbor_level, level, neighbours_bitmap);
-                    break;
+        // Go over the element's nodes at every level and repair the effected connections.
+        for (size_t level = 0; level <= element->toplevel; level++) {
+            ElementLevelData &cur_level = getElementLevelData(element, level);
+            // Reset the neighbours' bitmap for the current level.
+            neighbours_set.clear();
+            // Store the deleted element's neighbours set in a bitmap for fast access.
+            for (size_t j = 0; j < cur_level.getNumLinks(); j++) {
+                neighbours_set.insert(cur_level.getLinkAtPos(j));
+            }
+            // Go over the neighbours that also points back to the removed point and make a local
+            // repair.
+            for (size_t i = 0; i < cur_level.getNumLinks(); i++) {
+                idType neighbour_id = cur_level.getLinkAtPos(i);
+                ElementLevelData &neighbor_level = getElementLevelData(neighbour_id, level);
+
+                bool bidirectional_edge = false;
+                for (size_t j = 0; j < neighbor_level.getNumLinks(); j++) {
+                    // If the edge is bidirectional, do repair for this neighbor.
+                    if (neighbor_level.getLinkAtPos(j) == element_internal_id) {
+                        bidirectional_edge = true;
+                        repairConnectionsForDeletion(element_internal_id, neighbour_id, cur_level,
+                                                     neighbor_level, level, neighbours_set,
+                                                     scratch.second());
+                        break;
+                    }
+                }
+
+                // If this edge is uni-directional, we should remove the element from the neighbor's
+                // incoming edges.
+                if (!bidirectional_edge) {
+                    // This should always return true (remove should succeed).
+                    bool res = neighbor_level.removeIncomingUnidirectionalEdgeIfExists(
+                        element_internal_id);
+                    (void)res;
+                    assert(res && "The edge should be in the incoming unidirectional edges");
                 }
             }
 
-            // If this edge is uni-directional, we should remove the element from the neighbor's
-            // incoming edges.
-            if (!bidirectional_edge) {
-                // This should always return true (remove should succeed).
-                bool res =
-                    neighbor_level.removeIncomingUnidirectionalEdgeIfExists(element_internal_id);
-                (void)res;
-                assert(res && "The edge should be in the incoming unidirectional edges");
+            // Next, go over the rest of incoming edges (the ones that are not bidirectional) and
+            // make repairs.
+            for (auto incoming_edge : cur_level.getIncomingEdges()) {
+                repairConnectionsForDeletion(element_internal_id, incoming_edge, cur_level,
+                                             getElementLevelData(incoming_edge, level), level,
+                                             neighbours_set, scratch.second());
             }
-        }
-
-        // Next, go over the rest of incoming edges (the ones that are not bidirectional) and make
-        // repairs.
-        for (auto incoming_edge : cur_level.getIncomingEdges()) {
-            repairConnectionsForDeletion(element_internal_id, incoming_edge, cur_level,
-                                         getElementLevelData(incoming_edge, level), level,
-                                         neighbours_bitmap);
         }
     }
     if (entrypointNode == element_internal_id) {

--- a/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_serializer_impl.h
@@ -19,7 +19,7 @@ HNSWIndex<DataType, DistType>::HNSWIndex(std::ifstream &input, const HNSWParams 
     : VecSimIndexAbstract<DataType, DistType>(abstractInitParams, components),
       HNSWSerializer(version), epsilon(params->epsilon), graphDataBlocks(this->allocator),
       elementLocks(this->allocator), idToMetaData(this->allocator),
-      visitedNodesHandlerPool(0, this->allocator) {
+      visitedNodesHandlerPool(0, this->allocator), idFlagSetPool(0, this->allocator) {
 
     this->restoreIndexFields(input);
     this->fieldsValidation();
@@ -34,6 +34,7 @@ HNSWIndex<DataType, DistType>::HNSWIndex(std::ifstream &input, const HNSWParams 
     this->elementLocks.resize(maxElements);
     this->idToMetaData.resize(maxElements);
     this->visitedNodesHandlerPool.resize(maxElements);
+    this->idFlagSetPool.resize(maxElements);
 
     size_t initial_vector_size = maxElements / this->blockSize;
     graphDataBlocks.reserve(initial_vector_size);

--- a/src/VecSim/algorithms/hnsw/id_flag_set.h
+++ b/src/VecSim/algorithms/hnsw/id_flag_set.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+#pragma once
+
+#include "VecSim/memory/vecsim_base.h"
+#include "VecSim/utils/vecsim_stl.h"
+#include "VecSim/vec_sim_common.h"
+
+#include <cassert>
+#include <mutex>
+
+/**
+ * A set of internal ids, backed by one bit per id in the index. insert() and contains() are O(1),
+ * and clear() resets only the bits that were actually set, so the same set can serve call after
+ * call without a zero fill proportional to the index capacity.
+ *
+ * The delete and repair paths need such a set per call, but never put more than a handful of ids
+ * in it (a node's links, and its neighbors' links). Building a fresh bitmap per call costs an
+ * allocation plus a zero fill over the whole index; reusing a pooled set costs neither.
+ */
+class IdFlagSet : public VecsimBaseObject {
+public:
+    IdFlagSet(size_t capacity, const std::shared_ptr<VecSimAllocator> &allocator)
+        : VecsimBaseObject(allocator), flags(capacity, false, allocator), set_ids(allocator) {}
+
+    void insert(idType id) {
+        assert(id < flags.size());
+        if (!flags[id]) {
+            flags[id] = true;
+            set_ids.push_back(id);
+        }
+    }
+
+    bool contains(idType id) const {
+        assert(id < flags.size());
+        return flags[id];
+    }
+
+    void clear() {
+        for (idType id : set_ids) {
+            flags[id] = false;
+        }
+        set_ids.clear();
+    }
+
+    // Assumes the set is empty, so that dropping the flags cannot lose a set bit.
+    void resize(size_t capacity) {
+        assert(set_ids.empty() && "an id set must be cleared before it is resized");
+        flags.resize(capacity, false);
+        flags.shrink_to_fit();
+        set_ids.shrink_to_fit();
+    }
+
+private:
+    vecsim_stl::vector<bool> flags;
+    // The ids whose bit is currently set, so that clear() is proportional to the set's size and
+    // not to the index capacity.
+    vecsim_stl::vector<idType> set_ids;
+};
+
+/**
+ * The two id sets that one delete or one repair job needs, handed out together so that a caller
+ * takes and returns them in a single pool round-trip.
+ */
+class IdFlagSetPair : public VecsimBaseObject {
+public:
+    IdFlagSetPair(size_t capacity, const std::shared_ptr<VecSimAllocator> &allocator)
+        : VecsimBaseObject(allocator), first(capacity, allocator), second(capacity, allocator) {}
+
+    void clear() {
+        first.clear();
+        second.clear();
+    }
+
+    void resize(size_t capacity) {
+        first.resize(capacity);
+        second.resize(capacity);
+    }
+
+    IdFlagSet first;
+    IdFlagSet second;
+};
+
+/**
+ * A pool of id set pairs, so that concurrent repair jobs each get their own sets without
+ * allocating them per call. Mirrors VisitedNodesHandlerPool, which plays the same role for graph
+ * scans.
+ */
+class IdFlagSetPool : public VecsimBaseObject {
+public:
+    IdFlagSetPool(size_t capacity, const std::shared_ptr<VecSimAllocator> &allocator)
+        : VecsimBaseObject(allocator), pool(allocator), capacity(capacity), sets_in_use(0) {}
+
+    IdFlagSetPair *get() {
+        std::unique_lock<std::mutex> lock(pool_guard);
+        if (pool.empty()) {
+            sets_in_use++;
+            return new (this->allocator) IdFlagSetPair(capacity, this->allocator);
+        }
+        IdFlagSetPair *set = pool.back();
+        pool.pop_back();
+        return set;
+    }
+
+    // Takes a set back, cleared and ready for the next caller.
+    void put(IdFlagSetPair *set) {
+        set->clear();
+        std::unique_lock<std::mutex> lock(pool_guard);
+        pool.push_back(set);
+    }
+
+    // This should be called under a guarded section only (NOT in parallel), like the equivalent
+    // VisitedNodesHandlerPool::resize.
+    void resize(size_t new_capacity) {
+        assert(sets_in_use == pool.size()); // validate that no set is in use outside the pool.
+        capacity = new_capacity;
+        if (new_capacity == 0) {
+            // The index holds no elements, so hand the scratch memory back rather than keeping
+            // empty sets around.
+            clearPool();
+            return;
+        }
+        for (auto *set : pool) {
+            set->resize(new_capacity);
+        }
+    }
+
+    void clearPool() {
+        for (auto *set : pool) {
+            delete set;
+        }
+        pool.clear();
+        pool.shrink_to_fit();
+        sets_in_use = 0;
+    }
+
+    size_t getPoolSize() const { return pool.size(); }
+
+    ~IdFlagSetPool() override { clearPool(); }
+
+private:
+    vecsim_stl::vector<IdFlagSetPair *> pool;
+    std::mutex pool_guard;
+    size_t capacity;
+    size_t sets_in_use;
+};
+
+/**
+ * Takes a pair of sets from the pool and returns them, cleared, on scope exit, so that an early
+ * return or an exception cannot leak them out of the pool.
+ */
+class PooledIdFlagSets {
+public:
+    explicit PooledIdFlagSets(IdFlagSetPool &pool) : pool(pool), sets(pool.get()) {}
+    ~PooledIdFlagSets() { pool.put(sets); }
+
+    PooledIdFlagSets(const PooledIdFlagSets &) = delete;
+    PooledIdFlagSets &operator=(const PooledIdFlagSets &) = delete;
+
+    IdFlagSet &first() const { return sets->first; }
+    IdFlagSet &second() const { return sets->second; }
+
+private:
+    IdFlagSetPool &pool;
+    IdFlagSetPair *sets;
+};


### PR DESCRIPTION
> **Draft.** Numbers are in, but one design decision is open (see *Open decision*) and one unit test needs a call on it before this is ready for review.

**Describe the changes in the pull request**

Three places in the HNSW delete paths build a `vecsim_stl::vector<bool>` sized by the whole index, per call, to hold at most a node's links plus its neighbours' links (order tens of ids):

| Location | Cost today |
|---|---|
| `repairNodeConnections` | **two** bitmaps sized `maxElements`, allocated + zero-filled per background repair job |
| `repairConnectionsForDeletion` | one bitmap sized `curElementCount` per call: once per bidirectional neighbour and once per incoming edge, per level |
| `removeVectorInPlace` | `assign(curElementCount, false)` once per level (buffer reused, but the zero fill is O(N) each time) |

At 2M vectors that is roughly 250 KB of allocate-and-zero per repair job, for a job whose real work is a few hundred distance computations.

This PR replaces them with a pooled set that keeps O(1) lookup but clears in time proportional to its own size: in-place deletes get **35% faster at 2M vectors** and the gain grows with index size; the async repair path saves CPU but not wall-clock time.

One hazard worth reviewer attention: `removeVectorInPlace` ends in `removeAndSwap` -> `shrinkByBlock` -> `resizeIndexCommon`, which resizes the pool. Holding a checked-out set across that trips the pool's "nothing in use" assertion, so the scratch is scoped to end before it.

**Which issues this PR fixes**

None. This came out of profiling the delete paths, not a planned task, so there is no MOD ticket. Happy to file one if the convention requires it.

Not MOD-9645, though it overlaps it: that task reuses internal element **ids** for new inserts to avoid swap jobs, which is a different mechanism (this PR changes no id allocation and removes no swap job). It will edit `repairNodeConnections` too, and its reported blocker is a repair-job race in this same code, so the two should be sequenced rather than merged blind. The pooled sets are id-indexed and cleared per call, so recycled ids do not break them.

**Main objects this PR modified**

1. `IdFlagSet` (new, `src/VecSim/algorithms/hnsw/id_flag_set.h`) - one bit per id plus the list of ids it set, so `clear()` is proportional to the set's size rather than the index capacity.
2. `IdFlagSetPair` / `IdFlagSetPool` (new) - hands out both sets a delete or repair job needs in a single pool round-trip, mirroring `VisitedNodesHandlerPool`. Releases its sets when index capacity drops to zero, so an emptied index returns to baseline memory.
3. `PooledIdFlagSets` (new) - RAII holder, so an early return cannot leak a set out of the pool.
4. `HNSWIndex::repairNodeConnections`, `::repairConnectionsForDeletion` (signature now takes both sets from its caller), `::removeVectorInPlace` - switched to the pooled sets.
5. `HNSWIndex::resizeIndexCommon` and both `HNSWIndex` constructors - pool lifecycle, next to the existing `visitedNodesHandlerPool` calls.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

Neither box applies. `hnsw_serializer_impl.h` is touched, but only to initialize and size the new pool in the deserializing constructor; the on-disk format and the encoding version are unchanged.

## Results

Xeon Platinum 8375C, 16 cores, gcc 13.3, RelWithDebInfo, tiered HNSW, dim 32, M 16, 3000 deletes per phase, 16 background threads. Two clones of the same commit (one patched), binaries run alternately, 3 reps each, mean reported.

**In-place delete path** (single-threaded: `removeVectorInPlace` / `repairConnectionsForDeletion`), us per delete:

| N | baseline | patched | change |
|---|---|---|---|
| 250K | 214.4 | 199.0 | **-7.2%** |
| 1M | 405.2 | 288.2 | **-28.9%** |
| 2M | 533.1 | 342.7 | **-35.7%** |

Patched run-to-run spread also collapses (287.6 / 287.8 / 289.1 at 1M, against 377.6 / 414.0 / 424.0 baseline), which is what removing a size-dependent memset looks like.

**Async repair path**, us per delete:

| N | metric | baseline | patched | change |
|---|---|---|---|---|
| 1M | CPU (all threads) | 3060.4 | 2906.3 | -5.0% |
| 2M | CPU (all threads) | 3678.8 | 3227.2 | **-12.3%** |
| 1M | wall | 514.7 | 529.9 | +3.0% |
| 2M | wall | 584.0 | 597.4 | +2.3% |

The async path saves CPU (throughput headroom) but not latency: the zero fill it removes was already spread across the 16 background threads, and what remains is one pool mutex round-trip per job. Cutting the lock traffic (one scratch *pair* per job rather than per call, which is what this branch does) narrowed that but did not close it.

## Tests

`2606 / 2607` unit tests pass on the patched tree.

- `HNSWTieredIndexTest.swapJobBasic` (x2) failed at first and now passes: that is what drove the pool releasing its sets at zero capacity, so an emptied index still returns to its baseline memory.
- `IndexAllocatorTest.test_hnsw_reclaim_memory` **fails**: 849,620 actual vs 848,680 expected, i.e. exactly the 940 bytes of pooled scratch retained while the index is non-empty. `test_allocator.cpp:606` is a whitebox model of every allocation, so any new accounted consumer breaks it by construction. Nothing leaks: the memory is accounted through `VecSimAllocator` and released when the index empties.

## Open decision

1. **Keep both paths and extend the accounting test's expectation** (my preference): keeps the 35% in-place win and the 12% async CPU headroom. Cost: the host sees a small bounded reservation (one scratch pair per concurrent deleter) while an index is non-empty, exactly as the visited-nodes pool already behaves.
2. **In-place path only**: revert the async change, since that is where the wall-clock gain is absent. Smaller diff, less concurrency surface. Still needs the same test update, because the failing test exercises the in-place path.
3. **Zero retained memory**: drop the pool to empty whenever no delete is in flight. Leaves the accounting invariant untouched, at the cost of more lifecycle logic.

## Notes

Unrelated papercuts found while measuring, not fixed here:

- `make unit_test CTEST_ARGS='-R A|B'` breaks: the Makefile passes it unquoted, so the shell splits on `|`.
- Running `ctest` directly needs `ROOT=<repo>`, or 14 serialization tests fail inside `getenv("ROOT")` with "basic_string: construction from null is not valid".
- `-DUSE_SVS=OFF` does not build on main: `svs.h` / `svs_utils.h` are included even with `HAVE_SVS=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core graph repair and deletion concurrency (pooled scratch, resize ordering); behavior should be equivalent but mistakes could corrupt edges or assert under shrink during delete.
> 
> **Overview**
> HNSW delete and repair no longer allocate and zero-fill full-index `vector<bool>` bitmaps on every call. They now use **pooled `IdFlagSet`** pairs (`id_flag_set.h`): O(1) membership with **`clear()` proportional to how many ids were inserted**, matching the small neighbor sets these paths actually use.
> 
> **`removeVectorInPlace`**, **`repairNodeConnections`**, and **`repairConnectionsForDeletion`** borrow scratch via **`PooledIdFlagSets`**; the in-place delete path scopes that RAII block **before** **`removeAndSwap`** so **`idFlagSetPool.resize`** during shrink does not trip the pool’s “nothing checked out” invariant. **`resizeIndexCommon`** and both index constructors (including deserialize) grow or release the pool alongside **`visitedNodesHandlerPool`**.
> 
> On-disk serialization is unchanged; deserialize only initializes and sizes the new pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b7fd3d4c75d25b1d88ed13a636a97640678ac39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->