### PR TITLE
[MOD-17526] Make the SQ8 metadata describe the reconstruction

### DIFF
--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -293,13 +293,17 @@ class QuantPreprocessor : public PreprocessorInterface {
             return static_cast<OUTPUT_TYPE>(scaled + MetadataType{0.5});
         };
 
-        // Compute sum (and sum of squares for L2) while quantizing.
-        // Accumulators are FP32 to preserve metadata precision for FP16 inputs.
-        // 4 independent accumulators (sum)
-        float s0{}, s1{}, s2{}, s3{};
-
-        // 4 independent accumulators (sum of squares), only used for L2
-        float q0{}, q1{}, q2{}, q3{};
+        // Sum the quantized bytes, not the input values. Every kernel term is written in terms of
+        // the reconstruction x_r[i] = min + delta * a[i], so the stored sums have to describe x_r
+        // as well. Summing the input instead leaves a systematic mismatch of about 0.4% of ||x||^2,
+        // which is larger than a small true distance and made L2 come out negative: for two
+        // near-duplicate vectors at dim 128 the reconstruction distance is 2.93e-04 and the kernels
+        // returned -1.49e-01. The byte sums are exact integers, so the derivation below is the only
+        // place rounding enters.
+        //
+        // 4 independent accumulators each, so the unrolled loop keeps four dependency chains.
+        uint32_t s0{}, s1{}, s2{}, s3{};
+        uint32_t q0{}, q1{}, q2{}, q3{}; // only used for L2
 
         size_t i = 0;
         // round dim down to the nearest multiple of 4
@@ -315,38 +319,54 @@ class QuantPreprocessor : public PreprocessorInterface {
             // We know (input - min) => 0
             // If min == max, all values are the same and should be quantized to 0.
             // reconstruction will yield the same original value for all vectors.
-            quantized[i] = to_byte((x0 - min_val) * inv_delta);
-            quantized[i + 1] = to_byte((x1 - min_val) * inv_delta);
-            quantized[i + 2] = to_byte((x2 - min_val) * inv_delta);
-            quantized[i + 3] = to_byte((x3 - min_val) * inv_delta);
+            const OUTPUT_TYPE a0 = to_byte((x0 - min_val) * inv_delta);
+            const OUTPUT_TYPE a1 = to_byte((x1 - min_val) * inv_delta);
+            const OUTPUT_TYPE a2 = to_byte((x2 - min_val) * inv_delta);
+            const OUTPUT_TYPE a3 = to_byte((x3 - min_val) * inv_delta);
+            quantized[i] = a0;
+            quantized[i + 1] = a1;
+            quantized[i + 2] = a2;
+            quantized[i + 3] = a3;
 
-            // Accumulate sum for all metrics
-            s0 += x0;
-            s1 += x1;
-            s2 += x2;
-            s3 += x3;
+            s0 += a0;
+            s1 += a1;
+            s2 += a2;
+            s3 += a3;
 
-            // Accumulate sum of squares only for L2 metric
             if constexpr (Metric == VecSimMetric_L2) {
-                q0 += x0 * x0;
-                q1 += x1 * x1;
-                q2 += x2 * x2;
-                q3 += x3 * x3;
+                q0 += uint32_t{a0} * a0;
+                q1 += uint32_t{a1} * a1;
+                q2 += uint32_t{a2} * a2;
+                q3 += uint32_t{a3} * a3;
             }
         }
 
         // Tail: 0..3 remaining elements (still the same pass, just finishing work).
-        // Sum/sum_squares become metadata, so they are MetadataType.
-        MetadataType sum = (s0 + s1) + (s2 + s3);
-        MetadataType sum_squares = (q0 + q1) + (q2 + q3);
+        uint32_t q_sum = (s0 + s1) + (s2 + s3);
+        uint32_t q_sum_squares = (q0 + q1) + (q2 + q3);
 
         for (; i < this->dim; ++i) {
             const float x = transformed_value(input, i);
-            quantized[i] = to_byte((x - min_val) * inv_delta);
-            sum += x;
+            const OUTPUT_TYPE a = to_byte((x - min_val) * inv_delta);
+            quantized[i] = a;
+            q_sum += a;
             if constexpr (Metric == VecSimMetric_L2) {
-                sum_squares += x * x;
+                q_sum_squares += uint32_t{a} * a;
             }
+        }
+
+        // Derive the reconstruction sums from the exact byte sums, in double so the expansion does
+        // not lose the cross term, then store FP32 as before. The slot layout and types are
+        // unchanged; only what the numbers describe changes.
+        //   sum         = sum(x_r[i])   = dim*min + delta*q_sum
+        //   sum_squares = sum(x_r[i]^2) = dim*min^2 + 2*min*delta*q_sum + delta^2*q_sum_squares
+        const double d_min = min_val, d_delta = delta, d_dim = static_cast<double>(this->dim);
+        const MetadataType sum = static_cast<MetadataType>(d_dim * d_min + d_delta * q_sum);
+        MetadataType sum_squares{};
+        if constexpr (Metric == VecSimMetric_L2) {
+            sum_squares =
+                static_cast<MetadataType>(d_dim * d_min * d_min + 2.0 * d_min * d_delta * q_sum +
+                                          d_delta * d_delta * q_sum_squares);
         }
 
         // Metadata uses MetadataType. Use memcpy because the metadata offset

--- a/src/VecSim/spaces/computer/preprocessors.h
+++ b/src/VecSim/spaces/computer/preprocessors.h
@@ -152,9 +152,14 @@ private:
  *
  * Storage layout:
  * | quantized_values[dim] | min_val | delta | x_sum | (x_sum_squares for L2 only) |
- * where:
- * x_sum = Σx_i: sum of the original values,
- * x_sum_squares = Σx_i²: sum of squares of the original values.
+ * where, writing x_r[i] = min_val + delta * a[i] for the value a blob actually represents:
+ * x_sum        = Σx_r[i]:  sum of the reconstructed values,
+ * x_sum_squares = Σx_r[i]²: sum of their squares.
+ *
+ * These describe x_r, not the input x. Every formula below is written in terms of x_r, because
+ * that is what a quantized blob holds, so sums over the input would not satisfy them: the gap is
+ * the quantization error, about 0.4% of ||x||², which is larger than the distance between two
+ * similar vectors and made L2 come out negative.
  *
  * Storage metadata is always FP32 (independent of DataType) to match the asymmetric distance
  * kernels. The quantized blob size is:
@@ -194,10 +199,11 @@ private:
  *   where y_sum = Σy_i is precomputed and stored in the query blob.
  *
  * For L2:
- *   ||x - y||² = Σx_i² - 2*Σ(x_i * y_i) + Σy_i²
- *              = x_sum_squares - 2 * IP(x, y) + y_sum_squares
+ *   ||x_r - y||² = Σx_r[i]² - 2*Σ(x_r[i] * y_i) + Σy_i²
+ *                = x_sum_squares - 2 * IP(x_r, y) + y_sum_squares
  *   where:
- *     - x_sum_squares = Σx_i² is precomputed and stored in the storage blob
+ *     - x_sum_squares = Σx_r[i]² is precomputed and stored in the storage blob. A query is not
+ *       quantized, so y_sum_squares is Σy_i² over the query itself.
  *     - IP(x, y) is computed using the formula above
  *     - y_sum_squares = Σy_i² is precomputed and stored in the query blob
  *   For normalized L2, x and y in this formula are the centered values x' and y'; their distance
@@ -217,7 +223,7 @@ private:
  *              + delta_x * delta_y * Σ(qx_i * qy_i)
  *   where:
  *     - sum_x, sum_y are precomputed sums of the values represented by each blob
- *     - Σqx_i = (sum_x - dim * min_x) / delta_x  (sum of quantized values, derived from stored sum)
+ *     - Σqx_i = (sum_x - dim * min_x) / delta_x  (exact, since sum_x is derived from Σqx_i)
  *     - Σqy_i = (sum_y - dim * min_y) / delta_y
  *
  * For L2:
@@ -303,7 +309,9 @@ class QuantPreprocessor : public PreprocessorInterface {
         //
         // 4 independent accumulators each, so the unrolled loop keeps four dependency chains.
         uint32_t s0{}, s1{}, s2{}, s3{};
-        uint32_t q0{}, q1{}, q2{}, q3{}; // only used for L2
+        // 64-bit: 65025 * 65536 leaves under 1% of UINT32_MAX, and overflow here would corrupt
+        // the metadata rather than round it. This is the write path, once per vector.
+        uint64_t q0{}, q1{}, q2{}, q3{}; // only used for L2
 
         size_t i = 0;
         // round dim down to the nearest multiple of 4
@@ -334,16 +342,19 @@ class QuantPreprocessor : public PreprocessorInterface {
             s3 += a3;
 
             if constexpr (Metric == VecSimMetric_L2) {
-                q0 += uint32_t{a0} * a0;
-                q1 += uint32_t{a1} * a1;
-                q2 += uint32_t{a2} * a2;
-                q3 += uint32_t{a3} * a3;
+                q0 += uint64_t{a0} * a0;
+                q1 += uint64_t{a1} * a1;
+                q2 += uint64_t{a2} * a2;
+                q3 += uint64_t{a3} * a3;
             }
         }
 
         // Tail: 0..3 remaining elements (still the same pass, just finishing work).
         uint32_t q_sum = (s0 + s1) + (s2 + s3);
-        uint32_t q_sum_squares = (q0 + q1) + (q2 + q3);
+        uint64_t q_sum_squares{};
+        if constexpr (Metric == VecSimMetric_L2) {
+            q_sum_squares = (q0 + q1) + (q2 + q3);
+        }
 
         for (; i < this->dim; ++i) {
             const float x = transformed_value(input, i);
@@ -351,7 +362,7 @@ class QuantPreprocessor : public PreprocessorInterface {
             quantized[i] = a;
             q_sum += a;
             if constexpr (Metric == VecSimMetric_L2) {
-                q_sum_squares += uint32_t{a} * a;
+                q_sum_squares += uint64_t{a} * a;
             }
         }
 

--- a/tests/unit/test_components.cpp
+++ b/tests/unit/test_components.cpp
@@ -1650,6 +1650,14 @@ protected:
         ComputeSQ8Quantization(widened_blob, dim, baseline_storage);
         const float baseline_min = load_meta(baseline_storage, dim + sq8::MIN_VAL * sizeof(float));
         const float baseline_delta = load_meta(baseline_storage, dim + sq8::DELTA * sizeof(float));
+        // The storage baseline's sums describe the reconstruction min + delta * a[i]. The query is
+        // not quantized, so its sums describe the input itself. Those are different quantities and
+        // must be checked separately: they were only ever equal because both used to be the input.
+        float input_sum = 0.0f, input_sum_sq = 0.0f;
+        for (size_t i = 0; i < dim; i++) {
+            input_sum += widened_blob[i];
+            input_sum_sq += widened_blob[i] * widened_blob[i];
+        }
         const float baseline_sum = load_meta(baseline_storage, dim + sq8::SUM * sizeof(float));
         const float baseline_sum_sq =
             load_meta(baseline_storage, dim + sq8::SUM_SQUARES * sizeof(float));
@@ -1702,11 +1710,11 @@ protected:
             // Query FP32 metadata: y_sum (and y_sum_squares for L2) match the FP32 baseline.
             ASSERT_FLOAT_EQ(
                 load_meta(query_blob, query_meta_offset + sq8::SUM_QUERY * sizeof(float)),
-                baseline_sum);
+                input_sum);
             if constexpr (Metric == VecSimMetric_L2) {
                 ASSERT_FLOAT_EQ(load_meta(query_blob, query_meta_offset +
                                                           sq8::SUM_SQUARES_QUERY * sizeof(float)),
-                                baseline_sum_sq);
+                                input_sum_sq);
             }
 
             allocator->free_allocation(storage_blob);
@@ -1724,11 +1732,11 @@ protected:
             EXPECT_NO_FATAL_FAILURE(
                 CompareVectors<float16>(static_cast<const float16 *>(blob), original_blob, dim));
             ASSERT_FLOAT_EQ(load_meta(blob, query_meta_offset + sq8::SUM_QUERY * sizeof(float)),
-                            baseline_sum);
+                            input_sum);
             if constexpr (Metric == VecSimMetric_L2) {
                 ASSERT_FLOAT_EQ(
                     load_meta(blob, query_meta_offset + sq8::SUM_SQUARES_QUERY * sizeof(float)),
-                    baseline_sum_sq);
+                    input_sum_sq);
             }
             allocator->free_allocation(blob);
         }

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -4910,6 +4910,11 @@ TEST_F(SpacesTest, SQ8_SQ8_DispatcherAlignmentHints) {
 #endif // CPU_FEATURES_ARCH_X86_64
 
 namespace {
+// The stored sum_squares is ||x_r||^2 by construction, so read it rather than recomputing.
+float sq8_norm_sq(const std::vector<uint8_t> &blob, size_t dim) {
+    return load_unaligned<float>(blob.data() + dim + sq8::SUM_SQUARES * sizeof(float));
+}
+
 std::vector<uint8_t> sq8_quantize_l2(const std::vector<float> &v) {
     const size_t dim = v.size();
     std::vector<uint8_t> blob(dim * sizeof(uint8_t) + 4 * sizeof(float));
@@ -4957,14 +4962,73 @@ TEST_F(SpacesTest, SQ8_SQ8_L2_is_non_negative_and_matches_reconstruction) {
         const std::vector<uint8_t> qy = sq8_quantize_l2(y);
 
         const double expected = ReferenceL2SqrOverReconstruction(qx.data(), qy.data(), dim);
+
+        // The error floor is FP32 cancellation in sum_sq_x + sum_sq_y - 2*IP, so it scales with the
+        // norms, not with the distance. A flat bound is thousands of times the distance it guards
+        // at small dimensions, which would let a kernel returning zero pass.
+        const float tol = 8.0f * std::numeric_limits<float>::epsilon() *
+                          (sq8_norm_sq(qx, dim) + sq8_norm_sq(qy, dim));
         unsigned char alignment = 0;
         auto dispatched = L2_SQ8_SQ8_GetDistFunc(dim, &alignment, nullptr);
 
         for (const auto &probe :
              {std::make_pair("scalar", SQ8_SQ8_L2Sqr), std::make_pair("dispatched", dispatched)}) {
             const float got = probe.second(qx.data(), qy.data(), dim);
-            EXPECT_GE(got, 0.0f) << probe.first << " returned a negative distance, dim " << dim;
-            EXPECT_NEAR(got, expected, 1e-3 * std::max(1.0, expected))
+            // Bounded by the noise floor, not by zero: this change does not make the result
+            // provably non-negative. The two sides of the subtraction are computed by different
+            // routes, and a blob against itself lands just below zero at dim 512.
+            EXPECT_GE(got, -tol) << probe.first << " negative beyond the noise floor, dim " << dim;
+            EXPECT_NEAR(got, expected, tol)
+                << probe.first << " does not match the reconstruction, dim " << dim;
+        }
+    }
+}
+
+// The asymmetric path is how the defect reached production unnoticed: its tests run dimensions 1,
+// 5, 7 and 15 against an absolute tolerance of 0.01, and 0.4% of ||x||^2 at dim 5 is about 0.007,
+// which fits underneath. Storage is quantized and the query is not, so this checks
+// sum(x_r^2) + sum(y^2) - 2*sum(x_r*y) against a double reference over the same two sides.
+TEST_F(SpacesTest, SQ8_FP32_L2_matches_reconstruction_against_float_query) {
+    std::mt19937 gen(20260822);
+    std::uniform_real_distribution<float> value_gen(-1.0f, 1.0f);
+    std::uniform_real_distribution<float> nudge_gen(-1e-3f, 1e-3f);
+
+    for (const size_t dim : {5UL, 15UL, 64UL, 128UL, 512UL}) {
+        std::vector<float> x(dim), y(dim);
+        for (size_t i = 0; i < dim; i++) {
+            x[i] = value_gen(gen);
+            y[i] = x[i] + nudge_gen(gen); // near-duplicate: small true distance exposes the offset
+        }
+        const std::vector<uint8_t> qx = sq8_quantize_l2(x);
+
+        // The query carries its own sum of squares, over the query itself, since it is not
+        // quantized. Reference is the distance between the reconstruction and that query.
+        std::vector<float> query(dim + 2, 0.0f);
+        double ref = 0.0, y_sum_sq = 0.0;
+        const float min_x = load_unaligned<float>(qx.data() + dim + sq8::MIN_VAL * sizeof(float));
+        const float delta_x = load_unaligned<float>(qx.data() + dim + sq8::DELTA * sizeof(float));
+        for (size_t i = 0; i < dim; i++) {
+            query[i] = y[i];
+            y_sum_sq += static_cast<double>(y[i]) * y[i];
+            const double d = (static_cast<double>(min_x) + static_cast<double>(delta_x) * qx[i]) -
+                             static_cast<double>(y[i]);
+            ref += d * d;
+        }
+        // Both query slots matter: the asymmetric inner product is
+        // min*sum(y) + delta*sum(a[i]*y[i]), so zeroing SUM_QUERY silently drops the min*sum(y)
+        // term. Fill them the way the production query preprocessor does.
+        test_utils::preprocess_sq8_fp32_query(query.data(), dim);
+
+        const float tol = 8.0f * std::numeric_limits<float>::epsilon() *
+                          (sq8_norm_sq(qx, dim) + static_cast<float>(y_sum_sq));
+        unsigned char alignment = 0;
+        auto dispatched = L2_SQ8_FP32_GetDistFunc(dim, &alignment, nullptr);
+        for (const auto &probe :
+             {std::make_pair("scalar", SQ8_FP32_L2Sqr), std::make_pair("dispatched", dispatched)}) {
+            // storage first, query second, as the other asymmetric tests call it.
+            const float got = probe.second(qx.data(), query.data(), dim);
+            EXPECT_GE(got, -tol) << probe.first << " negative beyond the noise floor, dim " << dim;
+            EXPECT_NEAR(got, ref, tol)
                 << probe.first << " does not match the reconstruction, dim " << dim;
         }
     }

--- a/tests/unit/test_spaces.cpp
+++ b/tests/unit/test_spaces.cpp
@@ -4908,3 +4908,90 @@ TEST_F(SpacesTest, SQ8_SQ8_DispatcherAlignmentHints) {
     check("Cosine", &spaces::Cosine_SQ8_SQ8_GetDistFunc);
 }
 #endif // CPU_FEATURES_ARCH_X86_64
+
+namespace {
+std::vector<uint8_t> sq8_quantize_l2(const std::vector<float> &v) {
+    const size_t dim = v.size();
+    std::vector<uint8_t> blob(dim * sizeof(uint8_t) + 4 * sizeof(float));
+    test_utils::quantize_float_vec_to_sq8_with_metadata(v.data(), dim, blob.data());
+    return blob;
+}
+} // namespace
+
+namespace {
+// The reconstruction the kernels compute distances over: x_r[i] = min + delta * a[i]. Reference
+// values are accumulated in double so the comparison is against the algebra, not against another
+// FP32 implementation with the same rounding.
+double ReferenceL2SqrOverReconstruction(const uint8_t *a, const uint8_t *b, size_t dim) {
+    const float min_a = load_unaligned<float>(a + dim + sq8::MIN_VAL * sizeof(float));
+    const float delta_a = load_unaligned<float>(a + dim + sq8::DELTA * sizeof(float));
+    const float min_b = load_unaligned<float>(b + dim + sq8::MIN_VAL * sizeof(float));
+    const float delta_b = load_unaligned<float>(b + dim + sq8::DELTA * sizeof(float));
+    double acc = 0.0;
+    for (size_t i = 0; i < dim; i++) {
+        const double d = (static_cast<double>(min_a) + static_cast<double>(delta_a) * a[i]) -
+                         (static_cast<double>(min_b) + static_cast<double>(delta_b) * b[i]);
+        acc += d * d;
+    }
+    return acc;
+}
+} // namespace
+
+// The stored sums describe the reconstruction, not the input. Summing the input instead left a
+// systematic mismatch of about 0.4% of ||x||^2, which is larger than the distance between two
+// near-duplicate vectors, so L2 came back negative: at dim 128 the reconstruction distance is
+// 2.93e-04 and the kernels returned -1.49e-01. Near-duplicates are the case that exposes it,
+// because the true distance is small enough for the mismatch to dominate.
+TEST_F(SpacesTest, SQ8_SQ8_L2_is_non_negative_and_matches_reconstruction) {
+    std::mt19937 gen(20260820);
+    std::uniform_real_distribution<float> value_gen(-1.0f, 1.0f);
+    std::uniform_real_distribution<float> nudge_gen(-1e-3f, 1e-3f);
+
+    for (const size_t dim : {4UL, 15UL, 64UL, 128UL, 512UL}) {
+        std::vector<float> x(dim), y(dim);
+        for (size_t i = 0; i < dim; i++) {
+            x[i] = value_gen(gen);
+            y[i] = x[i] + nudge_gen(gen);
+        }
+        const std::vector<uint8_t> qx = sq8_quantize_l2(x);
+        const std::vector<uint8_t> qy = sq8_quantize_l2(y);
+
+        const double expected = ReferenceL2SqrOverReconstruction(qx.data(), qy.data(), dim);
+        unsigned char alignment = 0;
+        auto dispatched = L2_SQ8_SQ8_GetDistFunc(dim, &alignment, nullptr);
+
+        for (const auto &probe :
+             {std::make_pair("scalar", SQ8_SQ8_L2Sqr), std::make_pair("dispatched", dispatched)}) {
+            const float got = probe.second(qx.data(), qy.data(), dim);
+            EXPECT_GE(got, 0.0f) << probe.first << " returned a negative distance, dim " << dim;
+            EXPECT_NEAR(got, expected, 1e-3 * std::max(1.0, expected))
+                << probe.first << " does not match the reconstruction, dim " << dim;
+        }
+    }
+}
+
+// A blob against itself. Exact zero is not claimed here: the two sides of
+// sum_sq_x + sum_sq_y - 2*IP are computed by different routes and round differently, so this pins
+// the magnitude rather than the bit pattern.
+TEST_F(SpacesTest, SQ8_SQ8_L2_self_distance_is_near_zero) {
+    std::mt19937 gen(20260821);
+    std::uniform_real_distribution<float> value_gen(-3.0f, 5.0f);
+
+    for (const size_t dim : {3UL, 8UL, 64UL, 512UL}) {
+        std::vector<float> x(dim);
+        double norm_sq = 0.0;
+        for (size_t i = 0; i < dim; i++) {
+            x[i] = value_gen(gen);
+            norm_sq += static_cast<double>(x[i]) * x[i];
+        }
+        const std::vector<uint8_t> q = sq8_quantize_l2(x);
+        const float tol = static_cast<float>(1e-5 * norm_sq);
+
+        EXPECT_NEAR(SQ8_SQ8_L2Sqr(q.data(), q.data(), dim), 0.0f, tol)
+            << "scalar kernel, dim " << dim;
+        unsigned char alignment = 0;
+        auto dispatched = L2_SQ8_SQ8_GetDistFunc(dim, &alignment, nullptr);
+        EXPECT_NEAR(dispatched(q.data(), q.data(), dim), 0.0f, tol)
+            << "dispatched kernel, dim " << dim;
+    }
+}

--- a/tests/unit/unit_test_utils.h
+++ b/tests/unit/unit_test_utils.h
@@ -253,8 +253,11 @@ inline void ComputeSQ8Quantization(const float *original_blob, size_t dim, uint8
     // Quantize, accumulating the bytes as exact integers, then derive the sums over the
     // reconstruction min + delta * a[i], which is what the kernel algebra is written in terms of.
     // See QuantPreprocessor::quantize.
+    // 64-bit for the squares: 255^2 * dim passes UINT32_MAX just above dim 66051, and a
+    // wrapped counter would corrupt the stored norm rather than round it. Mirrors
+    // QuantPreprocessor::quantize.
     uint32_t q_sum = 0;
-    uint32_t q_sum_squares = 0;
+    uint64_t q_sum_squares = 0;
     for (size_t i = 0; i < dim; i++) {
         float normalized = (original_blob[i] - min_val) / delta;
         const uint32_t q = static_cast<uint8_t>(std::round(normalized));

--- a/tests/unit/unit_test_utils.h
+++ b/tests/unit/unit_test_utils.h
@@ -250,15 +250,23 @@ inline void ComputeSQ8Quantization(const float *original_blob, size_t dim, uint8
     float diff = max_val - min_val;
     float delta = (diff == 0.0f) ? 1.0f : diff / 255.0f;
 
-    // Calculate quantized values, sum and sum_squares
-    float sum = 0.0f;
-    float sum_squares = 0.0f;
+    // Quantize, accumulating the bytes as exact integers, then derive the sums over the
+    // reconstruction min + delta * a[i], which is what the kernel algebra is written in terms of.
+    // See QuantPreprocessor::quantize.
+    uint32_t q_sum = 0;
+    uint32_t q_sum_squares = 0;
     for (size_t i = 0; i < dim; i++) {
         float normalized = (original_blob[i] - min_val) / delta;
-        output[i] = static_cast<uint8_t>(std::round(normalized));
-        sum += original_blob[i];
-        sum_squares += original_blob[i] * original_blob[i];
+        const uint32_t q = static_cast<uint8_t>(std::round(normalized));
+        output[i] = static_cast<uint8_t>(q);
+        q_sum += q;
+        q_sum_squares += q * q;
     }
+
+    const double d_min = min_val, d_delta = delta, d_dim = static_cast<double>(dim);
+    const float sum = static_cast<float>(d_dim * d_min + d_delta * q_sum);
+    const float sum_squares = static_cast<float>(
+        d_dim * d_min * d_min + 2.0 * d_min * d_delta * q_sum + d_delta * d_delta * q_sum_squares);
 
     // Store metadata: min_val, delta, sum, sum_squares. Use memcpy because the metadata region
     // (output + dim) is not guaranteed to be 4-byte aligned for arbitrary dim values.

--- a/tests/utils/tests_utils.h
+++ b/tests/utils/tests_utils.h
@@ -188,8 +188,11 @@ static void quantize_float_vec_to_sq8_with_metadata(const float *v, size_t dim, 
         delta = 1.0f; // Avoid division by zero
 
     // Quantize, accumulating the bytes as exact integers.
+    // 64-bit for the squares: 255^2 * dim passes UINT32_MAX just above dim 66051, and a
+    // wrapped counter would corrupt the stored norm rather than round it. Mirrors
+    // QuantPreprocessor::quantize.
     uint32_t q_sum = 0;
-    uint32_t q_sum_squares = 0;
+    uint64_t q_sum_squares = 0;
     for (size_t i = 0; i < dim; i++) {
         float normalized = (v[i] - min_val) / delta;
         normalized = std::max(0.0f, std::min(255.0f, normalized));

--- a/tests/utils/tests_utils.h
+++ b/tests/utils/tests_utils.h
@@ -169,9 +169,11 @@ static float SQ8_SQ8_NotOptimized_L2Sqr(const void *pVect1v, const void *pVect2v
 }
 
 /**
- * Quantize float vector to SQ8 with precomputed sum and sum_squares.
- * Vector layout: [uint8_t values (dim)] [min (float)] [delta (float)] [sum (float)] [sum_squares
- * (float)] where sum = Σv[i] and norm = Σv[i]² (sum of squares of uint8 elements)
+ * Quantize a float vector to SQ8 with precomputed sums.
+ * Layout: [uint8_t values (dim)] [min (float)] [delta (float)] [sum (float)] [sum_squares (float)]
+ * where sum = sum(x_r[i]) and sum_squares = sum(x_r[i]^2) over the reconstruction
+ * x_r[i] = min + delta * qv[i]. The kernels are written in terms of x_r, so the metadata has to
+ * describe x_r and not the input. See QuantPreprocessor::quantize.
  */
 static void quantize_float_vec_to_sq8_with_metadata(const float *v, size_t dim, uint8_t *qv) {
     float min_val = v[0];
@@ -181,26 +183,28 @@ static void quantize_float_vec_to_sq8_with_metadata(const float *v, size_t dim, 
         max_val = std::max(max_val, v[i]);
     }
 
-    float sum = 0.0f;
-    float square_sum = 0.0f;
-    for (size_t i = 0; i < dim; i++) {
-        sum += v[i];
-        square_sum += v[i] * v[i];
-    }
-
-    // Calculate delta
     float delta = (max_val - min_val) / 255.0f;
     if (delta == 0)
         delta = 1.0f; // Avoid division by zero
 
-    // Quantize each value
+    // Quantize, accumulating the bytes as exact integers.
+    uint32_t q_sum = 0;
+    uint32_t q_sum_squares = 0;
     for (size_t i = 0; i < dim; i++) {
         float normalized = (v[i] - min_val) / delta;
         normalized = std::max(0.0f, std::min(255.0f, normalized));
-        qv[i] = static_cast<uint8_t>(std::round(normalized));
+        const uint32_t q = static_cast<uint8_t>(std::round(normalized));
+        qv[i] = static_cast<uint8_t>(q);
+        q_sum += q;
+        q_sum_squares += q * q;
     }
 
-    // Store parameters: [min, delta, sum, square_sum]
+    // Derive in double, store FP32.
+    const double d_min = min_val, d_delta = delta, d_dim = static_cast<double>(dim);
+    const float sum = static_cast<float>(d_dim * d_min + d_delta * q_sum);
+    const float square_sum = static_cast<float>(
+        d_dim * d_min * d_min + 2.0 * d_min * d_delta * q_sum + d_delta * d_delta * q_sum_squares);
+
     auto *params = qv + dim;
     std::memcpy(params + sq8::MIN_VAL * sizeof(float), &min_val, sizeof(float));
     std::memcpy(params + sq8::DELTA * sizeof(float), &delta, sizeof(float));


### PR DESCRIPTION
**Describe the changes in the pull request**

## The issue

SQ8 storage metadata held `sum = Σx[i]` and `sum_squares = Σx[i]²` over the **input** values. Every kernel is written over the **reconstruction** `x_r[i] = min + delta * a[i]`, which is what a quantized blob actually holds. The two differ by the quantization error, about 0.4% of `||x||²`. That is larger than the distance between two similar vectors, so L2 came back wrong and often negative.

Measured at dimension 128 on two near-duplicate vectors:

```
reference L2(x_r, y_r)    =  2.927985e-04
sums over x[i]   (before) = -1.486199e-01    negative, wrong by ~500x
sums over x_r[i] (after)  = +2.927985e-04    matches the reference
```

## The fix

Make the metadata describe `x_r`. Nothing else changes: no kernel is touched, and the blob keeps the same layout, slot count and FP32 slot types.

The existing algebra is already exact once the sums describe `x_r`:

```
IP = min1*sum2 + min2*sum1 - dim*min1*min2 + delta1*delta2*Σ(a[i]*b[i])
   = IP(x_r, y_r)     iff  sum    = Σx_r[i]  = dim*min + delta*q_sum

L2 = sum_sq_x + sum_sq_y - 2*IP
   = L2(x_r, y_r)     iff  sum_sq = Σx_r[i]²
```

So `quantize()` counts the quantized bytes as exact integers, then derives both sums from them in double and stores FP32 as before:

```cpp
sum         = dim*min + delta*q_sum;
sum_squares = dim*min*min + 2.0*min*delta*q_sum + delta*delta*q_sum_squares;
```

`q_sum` and `q_sum_squares` are local counters, not stored fields. `q_sum_squares` is `uint64_t`: each byte contributes up to `255²`, so a 32-bit counter passes `UINT32_MAX` just above dimension 66051, and a wrapped counter would corrupt the stored norm rather than round it.

`SUM` has exactly one reader, the inner product algebra above, which is what makes a metadata-only fix sufficient.

## What this does not fix

L2 is now correct, but not provably non-negative. Residual FP32 cancellation in `sum_sq_x + sum_sq_y - 2*IP` is about `1e-7 * ||x||²`, and two identical blobs have a true distance of zero, so self-distance lands just below it (measured `-4.9e-4` at dimension 512). The withdrawn revision below did guarantee non-negativity; this one does not. Tests bound the result by that noise floor rather than by zero, and the gap is recorded for follow-up.

## Storage and query describe different quantities

A query is never quantized, so its metadata keeps sums over the query itself: the asymmetric distance is `Σx_r² + Σy² - 2Σ(x_r * y)`. Three test assertions compared the query sum against the storage sum. They only ever agreed because both used to be the input sum, which is the same confusion this change fixes in the product code.

## Tests

`SQ8_SQ8_L2_is_non_negative_and_matches_reconstruction` and `SQ8_FP32_L2_matches_reconstruction_against_float_query`: near-duplicate vectors from dimension 4 to 512, scalar and dispatched kernels, against a double reference over `x_r`. Near-duplicates are the case that exposes this, because the true distance is small enough for the 0.4% mismatch to dominate.

The asymmetric test is new, and its absence is why the defect survived: the existing asymmetric L2 tests run dimensions 1, 5, 7 and 15 against an absolute tolerance of `0.01`, and 0.4% of `||x||²` at dimension 5 is about `0.007`, which fits underneath.

Tolerance is `8 * FLT_EPSILON * (norm_x + norm_y)`, scaled to the norms because the error floor is FP32 cancellation, which does not scale with the distance. A flat bound is thousands of times the distance it guards at small dimensions and would let a kernel returning zero pass.

`SQ8_SQ8_L2_self_distance_is_near_zero`: near zero, not exactly zero, for the reason above.

## Considered and rejected

An earlier revision made the L2 metadata integer (`uint32` `Q_SUM` / `Q_SUM_SQUARES`), added a `reconstructed_l2_sqr` helper regrouping the quadratic term so `S1 + S2 - 2Q` stays an exact integer, and rewrote 18 kernel files to combine in double. That buys exactly-zero self-distance and protection against FP32 cancellation when two vectors share a large offset, at 24 files, +630/-277, per-metric slot semantics, and 1 to 4.8 ns per distance call.

Those properties address the large-shared-offset case, not the defect above. This revision fixes the defect at zero per-call cost without touching a kernel. Carried forward: FP32 cancellation under a large shared offset, non-negative and exactly-zero self-distance, and the `MAX_EXACT_DIM` comment describing a bound the code does not have.

## Verification

CI green at `d5b467eb`: `basic tests`, `sanitizer / Test ubuntu-latest sanitizer` (ASan, both suites), `codeql-analysis / Analyze (cpp)`, `coverage / codecov job`, `codecov/patch`, `codecov/project`, `spellcheck`, Cursor Bugbot. Locally: `check-format`.

**Which issues this PR fixes**
1. MOD-17526

**Main objects this PR modified**
1. `src/VecSim/spaces/computer/preprocessors.h`: the derivation and the metadata documentation.
2. `tests/unit/unit_test_utils.h`, `tests/utils/tests_utils.h`: the two test mirrors of the quantizer.
3. `tests/unit/test_spaces.cpp`, `tests/unit/test_components.cpp`.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core SQ8 quantization metadata used on every indexed vector and L2 search path, but scope is limited to preprocessor/test quantizers with no kernel or layout change; incorrect sums would break distance ordering.
> 
> **Overview**
> **Fixes wrong and often negative SQ8 L2 distances** by making storage metadata match what the distance kernels assume: `sum` and `sum_squares` are over the **reconstructed** vector `x_r[i] = min + delta * a[i]`, not the pre-quantization input. The mismatch was on the order of ~0.4% of `||x||²`, which could dominate true distance between similar vectors.
> 
> `QuantPreprocessor::quantize()` now accumulates **quantized byte** sums (with `uint64_t` for squared-byte totals on L2), then derives `sum` and `sum_squares` in double and stores FP32 metadata as before. **Blob layout and distance kernels are unchanged.**
> 
> Tests and test quantizer helpers (`ComputeSQ8Quantization`, `quantize_float_vec_to_sq8_with_metadata`) follow the same rules. FP16 preprocessor tests assert query metadata against **input** sums, not storage reconstruction sums. New `test_spaces` cases check SQ8↔SQ8 and SQ8↔FP32 L2 against a double reference on near-duplicate vectors, with tolerances tied to FP32 cancellation noise rather than a loose absolute bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96910facda1b727c5728390ac9ccb8cb45a4a56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->