### PR TITLE
Add an opaque userData slot to VecSimDiskContext

### DIFF
--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -257,10 +257,8 @@ typedef struct {
     void *storage; // Opaque pointer to disk storage
     const char *indexName;
     size_t indexNameLen;
-    bool rerank; // Whether to enable reranking for disk-based HNSW
-    // Opaque, embedder-defined value forwarded unchanged to the storage layer,
-    // which is what gives it meaning. Not interpreted here.
-    uint64_t userData;
+    uint32_t userData; // Embedder-defined; forwarded to the storage layer, never read by VecSim.
+    bool rerank;       // Whether to enable reranking for disk-based HNSW
 } VecSimDiskContext;
 
 typedef struct {

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -258,6 +258,9 @@ typedef struct {
     const char *indexName;
     size_t indexNameLen;
     bool rerank; // Whether to enable reranking for disk-based HNSW
+    // Opaque, embedder-defined value forwarded unchanged to the storage layer,
+    // which is what gives it meaning. Not interpreted here.
+    uint64_t userData;
 } VecSimDiskContext;
 
 typedef struct {


### PR DESCRIPTION
`VecSimDiskContext` is a pass-through: the embedder fills it, vecsim forwards it to the disk index, and the storage layer behind `storage` is what interprets the contents.

Storage implementations that keep several indexes in one physical store need to know which of them a handle belongs to. The index name is already available, but it is variable-width, which makes it a poor fit for a key prefix.

This adds `uint32_t userData` for that purpose — forwarded unchanged and never interpreted here.

Two deliberate choices:

- **A value, not a pointer.** `storage` is a `void *` because it is genuinely a handle to a live object; this is a small identifier, so a pointer would import lifetime and ownership questions across the boundary for no benefit.
- **32 bits, sorted into the struct by width.** Placed above `rerank` so fields run widest-first, which leaves `VecSimDiskContext` at 32 bytes — the same size as before this PR, so the slot costs nothing. The only value it carries today is a 16-bit field index; stopping at `u32` keeps headroom without pinning the embedder's current width into a public struct, and narrowing to `u16` would shrink nothing, since the trailing `bool` pads both widths out the same.

Reordering is safe: every caller builds this struct with designated initializers, and none sets `userData` yet. Checked with static asserts that `sizeof(VecSimDiskContext) == 32`, `offsetof(userData) == 24`, and that a C++20 designated initializer in the new order still compiles.

The meaning of the value is documented on the consumer side, where it is interpreted, rather than here.

Self-contained: no other change is required for this to be correct, and nothing in this repository reads the field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public struct field with no in-repo consumers or behavior changes; callers must zero-initialize new fields when constructing the struct.
> 
> **Overview**
> Extends the public **`VecSimDiskContext`** struct with a **`uint32_t userData`** field so embedders can pass a fixed-width index identifier into the disk storage layer (e.g. when several logical indexes share one physical store), without relying on variable-length **`indexName`** for keying.
> 
> VecSim does not interpret **`userData`**; it is only documented as forwarded unchanged with the rest of the disk context. **`rerank`** is unchanged aside from comment formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 567031e3e6978e08fda3e7f74bf30fec49c63521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
