### PR TITLE
[MOD-18075] Allow custom HNSW neighbor debug implementations

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnsw.h
+++ b/src/VecSim/algorithms/hnsw/hnsw.h
@@ -285,7 +285,7 @@ public:
         return idToMetaData.data() + internal_id;
     }
     vecsim_stl::vector<graphNodeType> safeCollectAllNodeIncomingNeighbors(idType node_id) const;
-    VecSimDebugCommandCode getHNSWElementNeighbors(size_t label, int ***neighborsData);
+    VecSimDebugCommandCode getHNSWElementNeighbors(size_t label, int ***neighborsData) override;
     void insertElementToGraph(idType element_id, size_t element_max_level, idType entry_point,
                               size_t global_max_level, const void *vector_data);
     void removeVectorInPlace(idType id);

--- a/src/VecSim/algorithms/hnsw/hnsw_tiered.h
+++ b/src/VecSim/algorithms/hnsw/hnsw_tiered.h
@@ -245,7 +245,7 @@ public:
         this->getHNSWIndex()->unlockSharedIndexDataGuard();
     }
 
-    VecSimDebugCommandCode getHNSWElementNeighbors(size_t label, int ***neighborsData) {
+    VecSimDebugCommandCode getHNSWElementNeighbors(size_t label, int ***neighborsData) override {
         this->mainIndexGuard.lock_shared();
         auto res = this->getHNSWIndex()->getHNSWElementNeighbors(label, neighborsData);
         this->mainIndexGuard.unlock_shared();

--- a/src/VecSim/vec_sim_debug.cpp
+++ b/src/VecSim/vec_sim_debug.cpp
@@ -8,65 +8,10 @@
  */
 #include "vec_sim_debug.h"
 #include "VecSim/vec_sim_index.h"
-#include "VecSim/algorithms/hnsw/hnsw.h"
-#include "VecSim/algorithms/hnsw/hnsw_tiered.h"
-#include "VecSim/types/bfloat16.h"
 
 extern "C" int VecSimDebug_GetElementNeighborsInHNSWGraph(VecSimIndex *index, size_t label,
                                                           int ***neighborsData) {
-
-    // Set as if we return an error, and upon success we will set the pointers appropriately.
-    *neighborsData = nullptr;
-    VecSimIndexBasicInfo info = index->basicInfo();
-    if (info.algo != VecSimAlgo_HNSWLIB) {
-        return VecSimDebugCommandCode_BadIndex;
-    }
-    if (!info.isTiered) {
-        if (info.type == VecSimType_FLOAT32) {
-            return dynamic_cast<HNSWIndex<float, float> *>(index)->getHNSWElementNeighbors(
-                label, neighborsData);
-        } else if (info.type == VecSimType_FLOAT64) {
-            return dynamic_cast<HNSWIndex<double, double> *>(index)->getHNSWElementNeighbors(
-                label, neighborsData);
-        } else if (info.type == VecSimType_BFLOAT16) {
-            return dynamic_cast<HNSWIndex<vecsim_types::bfloat16, float> *>(index)
-                ->getHNSWElementNeighbors(label, neighborsData);
-        } else if (info.type == VecSimType_FLOAT16) {
-            return dynamic_cast<HNSWIndex<vecsim_types::float16, float> *>(index)
-                ->getHNSWElementNeighbors(label, neighborsData);
-        } else if (info.type == VecSimType_INT8) {
-            return dynamic_cast<HNSWIndex<int8_t, float> *>(index)->getHNSWElementNeighbors(
-                label, neighborsData);
-        } else if (info.type == VecSimType_UINT8) {
-            return dynamic_cast<HNSWIndex<uint8_t, float> *>(index)->getHNSWElementNeighbors(
-                label, neighborsData);
-        } else {
-            assert(false && "Invalid data type");
-        }
-    } else {
-        if (info.type == VecSimType_FLOAT32) {
-            return dynamic_cast<TieredHNSWIndex<float, float> *>(index)->getHNSWElementNeighbors(
-                label, neighborsData);
-        } else if (info.type == VecSimType_FLOAT64) {
-            return dynamic_cast<TieredHNSWIndex<double, double> *>(index)->getHNSWElementNeighbors(
-                label, neighborsData);
-        } else if (info.type == VecSimType_BFLOAT16) {
-            return dynamic_cast<TieredHNSWIndex<vecsim_types::bfloat16, float> *>(index)
-                ->getHNSWElementNeighbors(label, neighborsData);
-        } else if (info.type == VecSimType_FLOAT16) {
-            return dynamic_cast<TieredHNSWIndex<vecsim_types::float16, float> *>(index)
-                ->getHNSWElementNeighbors(label, neighborsData);
-        } else if (info.type == VecSimType_INT8) {
-            return dynamic_cast<TieredHNSWIndex<int8_t, float> *>(index)->getHNSWElementNeighbors(
-                label, neighborsData);
-        } else if (info.type == VecSimType_UINT8) {
-            return dynamic_cast<TieredHNSWIndex<uint8_t, float> *>(index)->getHNSWElementNeighbors(
-                label, neighborsData);
-        } else {
-            assert(false && "Invalid data type");
-        }
-    }
-    return VecSimDebugCommandCode_BadIndex;
+    return index->getHNSWElementNeighbors(label, neighborsData);
 }
 
 extern "C" void VecSimDebug_ReleaseElementNeighborsInHNSWGraph(int **neighborsData) {

--- a/src/VecSim/vec_sim_interface.h
+++ b/src/VecSim/vec_sim_interface.h
@@ -149,6 +149,17 @@ public:
     virtual VecSimDebugInfoIterator *debugInfoIterator() const = 0;
 
     /**
+     * @brief Return the HNSW graph neighbors for a label, grouped by level.
+     *
+     * Non-HNSW indexes return VecSimDebugCommandCode_BadIndex. The caller owns successful
+     * output and must release it with VecSimDebug_ReleaseElementNeighborsInHNSWGraph.
+     */
+    virtual VecSimDebugCommandCode getHNSWElementNeighbors(size_t label, int ***neighborsData) {
+        *neighborsData = nullptr;
+        return VecSimDebugCommandCode_BadIndex;
+    }
+
+    /**
      * @brief A function to be implemented by the inheriting index and called by rangeQuery.
      * @param queryBlob binary representation of the query vector. Blob size should match the index
      * data type and dimension. The index is responsible to process the query vector.


### PR DESCRIPTION
**Describe the changes in the pull request**

The HNSW neighbor debug API currently dispatches by casting indexes to the in-memory HNSW classes, so alternate HNSW backends cannot implement it safely. This adds a virtual debug hook with a fail-closed default and routes the public C API through it; the existing in-memory and tiered implementations preserve their behavior. The change is internal-only for current callers and enables disk HNSW graph inspection in RediSearchEnterprise.

**Which issues this PR fixes**
1. [MOD-18075](https://redislabs.atlassian.net/browse/MOD-18075)
2. N/A

**Main objects this PR modified**
1. `VecSimIndexAbstract` — extensible HNSW neighbor debug hook
2. In-memory and tiered HNSW indexes — existing implementations made polymorphic
3. VecSim debug C API — backend-independent dispatch

**Mark if applicable**

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes


[MOD-18075]: https://redislabs.atlassian.net/browse/MOD-18075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ