### PR TITLE
Deduplicate benchmark downloads and propagate failures

### DIFF
--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Download each URL once and avoid flooding the runner with processes and progress logs.
+# Download each URL once and suppress noisy progress logs.
 download_indices() {
     cat "$@" | sed '/^[[:space:]]*$/d' | sort -u | \
-        xargs -r -n 1 -P 4 wget --no-check-certificate --no-verbose \
+        xargs -r -n 1 -P 0 wget --no-check-certificate --no-verbose \
             --timeout=60 --tries=3 --waitretry=5 -P tests/benchmark/data
 }
 

--- a/tests/benchmark/bm_files.sh
+++ b/tests/benchmark/bm_files.sh
@@ -1,8 +1,18 @@
-BM_TYPE=$1
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download each URL once and avoid flooding the runner with processes and progress logs.
+download_indices() {
+    cat "$@" | sed '/^[[:space:]]*$/d' | sort -u | \
+        xargs -r -n 1 -P 4 wget --no-check-certificate --no-verbose \
+            --timeout=60 --tries=3 --waitretry=5 -P tests/benchmark/data
+}
+
+BM_TYPE=${1:-}
 alg="hnsw"
 
 if [ -z "$BM_TYPE"  ] || [ "$BM_TYPE" = "benchmarks-all" ]; then
-    cat tests/benchmark/data/hnsw_indices/*.txt tests/benchmark/data/svs_indices/*.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data
+    download_indices tests/benchmark/data/hnsw_indices/*.txt tests/benchmark/data/svs_indices/*.txt
     exit 0
 elif [ "$BM_TYPE" = "benchmarks-default" ] \
 || [ "$BM_TYPE" = "bm-basics-fp32-single" ] \
@@ -57,4 +67,4 @@ else
     exit 0
 fi
 
-cat tests/benchmark/data/${alg}_indices/${alg}_indices_$file_name.txt | xargs -n 1 -P 0 wget --no-check-certificate -P tests/benchmark/data
+download_indices "tests/benchmark/data/${alg}_indices/${alg}_indices_$file_name.txt"


### PR DESCRIPTION
The September 2 nightly timed out while downloading benchmark indices. The all-benchmarks path starts 73 downloads for 38 unique URLs with verbose progress output.

Deduplicate URLs and suppress progress output while retaining unlimited parallelism so larger runners can use their available bandwidth. Set a 60-second network timeout, three attempts, and a five-second retry wait. Enable strict shell error handling so failed downloads fail the step instead of being masked by `exit 0`.

Validation: shell syntax and whitespace checks; mocked downloads verified default/all and HNSW/SVS selections, one request per unique URL, download options, failure propagation in both paths, and no downloads for benchmarks without data. Rechecked deduplication and failure propagation after restoring unlimited parallelism. Full benchmark execution remains for CI.

Failure: https://github.com/RedisAI/VectorSimilarity/actions/runs/33677359784/job/100405740515

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/benchmark setup script only; no production or library behavior changes.
> 
> **Overview**
> Refactors benchmark index fetching in `bm_files.sh` behind a shared **`download_indices`** helper used for both the all-benchmarks and single-suite paths.
> 
> URLs are merged from the index list files, blank lines dropped, and **`sort -u`** so each URL is fetched once while keeping parallel **`wget`** (`-P 0`). Downloads use quieter logging (`--no-verbose`), a 60s timeout, three tries with a 5s retry wait, and **`set -euo pipefail`** so a failed download fails the step instead of being hidden behind success exits elsewhere in the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46646fcffbd422e0a3cf30b63fbe2226923c53b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->