### PR TITLE
[MOD-14957] Normalize FLAT overwrites (1/3)

### DIFF
--- a/src/VecSim/algorithms/brute_force/brute_force_single.h
+++ b/src/VecSim/algorithms/brute_force/brute_force_single.h
@@ -155,7 +155,8 @@ int BruteForceIndex_Single<DataType, DistType>::addVector(const void *vector_dat
     // Check if label already exists, so it is an update operation.
     if (optionalID != this->labelToIdLookup.end()) {
         idType id = optionalID->second;
-        this->vectors->updateElement(id, vector_data);
+        auto processed_blob = this->preprocessForStorage(vector_data);
+        this->vectors->updateElement(id, processed_blob.get());
         return 0;
     }
 

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -129,6 +129,33 @@ TYPED_TEST(BruteForceTest, brute_force_vector_update_test) {
     VecSimIndex_Free(index);
 }
 
+TYPED_TEST(BruteForceTest, brute_force_cosine_vector_overwrite_is_normalized) {
+    size_t dim = 4;
+    labelType label = 1;
+
+    BFParams params = {.dim = dim, .metric = VecSimMetric_Cosine};
+    VecSimIndex *index = this->CreateNewIndex(params);
+    auto *bf_single_index = this->CastToBF_Single(index);
+
+    TEST_DATA_T initial_vector[] = {1, 1, 1, 1};
+    TEST_DATA_T replacement_vector[] = {2, 2, 2, 2};
+    TEST_DATA_T normalized_replacement[dim];
+    memcpy(normalized_replacement, replacement_vector, sizeof(replacement_vector));
+    VecSim_Normalize(normalized_replacement, dim, TypeParam::get_index_type());
+
+    VecSimIndex_AddVector(index, initial_vector, label);
+    VecSimIndex_AddVector(index, replacement_vector, label);
+
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 1);
+
+    std::vector<std::vector<TEST_DATA_T>> stored_vectors;
+    bf_single_index->getDataByLabel(label, stored_vectors);
+    ASSERT_EQ(stored_vectors.size(), 1);
+    ASSERT_NO_FATAL_FAILURE(CompareVectors(stored_vectors[0].data(), normalized_replacement, dim));
+
+    VecSimIndex_Free(index);
+}
+
 /**** resizing cases ****/
 
 TYPED_TEST(BruteForceTest, resize_and_align_index) {


### PR DESCRIPTION
**Describe the changes in the pull request**

Single-value FLAT overwrites bypassed storage preprocessing. A cosine vector such as `[2, 2, 2, 2]` could replace an existing vector without being normalized. Run the replacement through `preprocessForStorage`, as insertion already does, while keeping the label's internal ID.

Stack **1/3**, based on `main`. #1035 adds tiered SQ8 with an immediate backend; #1029 adds accumulation and deferred backend creation on top. Merge #1034, then #1035, then #1029.

**Which issues this PR fixes**

- An existing cosine-overwrite bug exposed while implementing MOD-14957, extracted from #1029.

**Main objects this PR modified**

- `BruteForceIndex_Single::addVector` and its cosine overwrite regression test.

**Validation**

Built and tested on SSH `dorer-intel` at `c26aa251`: all 138 `test_bruteforce` tests passed, including the new regression. No local build was run.

GitHub validation checked on 2026-09-07: the sanitizer check passed. The [coverage job](https://github.com/RedisAI/VectorSimilarity/actions/runs/34095623197/job/101658802195) failed after its self-hosted runner lost contact with GitHub. The underlying cause is not yet diagnosed, and coverage validation remains incomplete.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to the overwrite branch in `BruteForceIndex_Single::addVector`; behavior aligns with existing insert preprocessing and is covered by a new regression test.
> 
> **Overview**
> **Single-label brute-force (FLAT) updates** now run replacement vectors through `preprocessForStorage` before `updateElement`, matching the insert path in `appendVector`. Previously, re-adding under an existing label wrote raw input, so **cosine** indexes could store unnormalized values and return wrong distances.
> 
> A unit test asserts that overwriting a cosine label with `[2,2,2,2]` leaves one normalized vector in storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22533ce0409438d116b1c826e148c1f8077e4810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->